### PR TITLE
Rebase on new snap interface name

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
           git fetch origin pull/9547/head:pr-9547
           git fetch origin pull/9585/head:pr-9585
           git checkout pr-9547
-          git cherry-pick pr-9585
+          git cherry-pick a8c7130e2a8999e0665a6829c21227dc5fcb27e0
           snapcraft snap --use-lxd
           sudo snap install *.snap --dangerous
           snapcraft clean --use-lxd
@@ -66,7 +66,7 @@ jobs:
           if [ -z "$devmode" ]; then
               for interface in \
                       block-devices \
-                      device-mapper-support \
+                      device-mapper-devices \
                       device-mapper-control \
                       hardware-observe \
                       lvm-control \

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ apps:
     plugs:
       - block-devices
       - device-mapper-control
-      - device-mapper-support
+      - device-mapper-devices
       - hardware-observe
       - lvm-control
       - mount-observe
@@ -66,7 +66,7 @@ apps:
     plugs:
       - block-devices
       - device-mapper-control
-      - device-mapper-support
+      - device-mapper-devices
       - hardware-observe
       - lvm-control
       - mount-observe
@@ -79,7 +79,7 @@ apps:
     plugs:
       - block-devices
       - device-mapper-control
-      - device-mapper-support
+      - device-mapper-devices
       - hardware-observe
       - lvm-control
       - mount-observe


### PR DESCRIPTION
The current confined support is based on in-review patches which
have now changed based on review feedback.