### PR TITLE
Add an interface to access the microcluster state

### DIFF
--- a/microceph/common/state.go
+++ b/microceph/common/state.go
@@ -1,0 +1,21 @@
+// Package common interfaces the microcluster cluster state
+package common
+
+import (
+	"github.com/canonical/microcluster/state"
+)
+
+// StateInterface for retrieving cluster state
+type StateInterface interface {
+	ClusterState() *state.State
+}
+
+// CephState holds cluster state
+type CephState struct {
+	State *state.State
+}
+
+// ClusterState gets the cluster state
+func (c CephState) ClusterState() *state.State {
+	return c.State
+}


### PR DESCRIPTION
Create interface for easier mocking; split out of PR #54

Signed-off-by: Peter Sabaini <peter.sabaini@canonical.com>