### PR TITLE
Fix OSD startup script liveness check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,12 @@ jobs:
           # Confirm ceph is healthy
           sudo microceph.ceph health | grep -xF "HEALTH_OK"
 
+          # Check health after restart
+          sudo snap stop microceph ; sleep 1 ; sudo snap start microceph ; sleep 7
+          sudo microceph.ceph status
+          sudo microceph.ceph health | grep -xF "HEALTH_OK"
+          pgrep ceph-osd || ( echo "No ceph-osd process found" ; exit 1 )
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -95,6 +95,7 @@ parts:
       - ceph-mgr
       - ceph-mon
       - ceph-osd
+      - lsof
     organize:
       usr/bin/: bin/
       usr/sbin/: bin/
@@ -133,6 +134,7 @@ parts:
       - lib/*/rados-classes
       - lib/python3
       - share/ceph
+      - bin/lsof
 
   deps:
     plugin: nil

--- a/snapcraft/commands/osd.start
+++ b/snapcraft/commands/osd.start
@@ -3,6 +3,18 @@ export SNAP_CURRENT="$(realpath "${SNAP_DATA}/..")/current"
 echo $$ > "${SNAP_CURRENT}/run/ceph-osd.pid"
 cd "${SNAP}"
 
+is_osd_running() {
+    local osdid="${1:?missing}"
+
+    skt="${SNAP_CURRENT}/run/ceph-osd.${nr}.asok"
+    pidfile="${SNAP_CURRENT}/run/ceph-osd.pid"
+
+    [ ! -e "$skt" ] && return 1
+    [ ! -f "$pidfile" ] && return 1
+    pgrep -F "${pidfile}" || return 1
+    lsof -t +E -aUf -- "${skt}" > /dev/null
+}
+
 spawn() {
     for i in "${SNAP_COMMON}/data/osd"/*; do
         filename="$(basename "${i}")"
@@ -12,7 +24,8 @@ spawn() {
         [ -z "$nr" ] && continue
 
         [ ! -e "${i}/ready" ] && continue
-        [ -e "${SNAP_CURRENT}/run/ceph-osd.${nr}.asok" ] && continue
+
+        is_osd_running "${nr}" && continue
 
         ceph-osd --cluster ceph --id "${nr}"
     done


### PR DESCRIPTION
In addition to checking for admin socket presence, also check there is a process listening at the other end in order to prevent false positives in checking ceph-osd startup due to a stale socket file

Signed-off-by: Peter Sabaini <peter.sabaini@canonical.com>