### PR TITLE
snapcraft: Add network-observe to osd

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -71,6 +71,7 @@ apps:
       - hardware-observe
       - network
       - network-bind
+      - network-observe
 
   # Commands
   ceph:


### PR DESCRIPTION
This is needed to access /usr/bin/ss.

Signed-off-by: Stéphane Graber <stephane.graber@canonical.com>