### PR TITLE
Add encryption support for OSDs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
           sudo snap install --dangerous microceph_*.snap
           sudo snap connect microceph:block-devices
           sudo snap connect microceph:hardware-observe
+          sudo snap connect microceph:dm-crypt
 
           sudo microceph cluster bootstrap
 
@@ -62,7 +63,7 @@ jobs:
             # names (/dev/sdiY) that are not used inside GitHub Action runners
             minor="${loop_dev##/dev/loop}"
             sudo mknod -m 0660 "/dev/sdi${l}" b 7 "${minor}"
-            sudo microceph disk add --wipe "/dev/sdi${l}"
+            sudo microceph disk add --wipe "/dev/sdi${l}" --encrypt
           done
 
           # Wait for OSDs to become up

--- a/microceph/api/disks.go
+++ b/microceph/api/disks.go
@@ -37,7 +37,7 @@ func cmdDisksPost(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err = ceph.AddOSD(s, req.Path, req.Wipe)
+	err = ceph.AddOSD(s, req.Path, req.Wipe, req.Encrypt)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/microceph/api/types/disks.go
+++ b/microceph/api/types/disks.go
@@ -3,8 +3,9 @@ package types
 
 // DisksPost hold a path and a flag for enabling device wiping
 type DisksPost struct {
-	Path string `json:"path" yaml:"path"`
-	Wipe bool   `json:"wipe" yaml:"wipe"`
+	Path    string `json:"path" yaml:"path"`
+	Wipe    bool   `json:"wipe" yaml:"wipe"`
+	Encrypt bool   `json:"encrypt" yaml:"encrypt"`
 }
 
 // Disks is a slice of disks

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -2,9 +2,12 @@ package ceph
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -68,11 +71,147 @@ func nextOSD(s *state.State) (int64, error) {
 	}
 }
 
+// setupEncryptedOSD sets up an encrypted OSD on the given disk.
+//
+// Takes a path to the disk device as well as the osd data path and the osd id.
+// Returns the path to the encrypted device and an error if any.
+func setupEncryptedOSD(devicePath string, osdDataPath string, osdID int64) (string, error) {
+	if err := os.Symlink(devicePath, filepath.Join(osdDataPath, "unencrypted")); err != nil {
+		return "", fmt.Errorf("Failed to add unencrypted block symlink: %w", err)
+	}
+
+	// Create a key for the encrypted device
+	key, err := createKey()
+	if err != nil {
+		return "", fmt.Errorf("Key creation error: %w", err)
+	}
+
+	// Store key in ceph key value store
+	if err = storeKey(key, osdID); err != nil {
+		return "", fmt.Errorf("Key store error: %w", err)
+	}
+
+	// Encrypt the device
+	if err = encryptDevice(devicePath, key); err != nil {
+		return "", fmt.Errorf("Failed to encrypt: %w", err)
+	}
+
+	// Open the encrypted device
+	encryptedDevicePath, err := openEncryptedDevice(devicePath, osdID, key)
+	if err != nil {
+		return "", fmt.Errorf("Failed to open: %w", err)
+	}
+	return encryptedDevicePath, nil
+}
+
+// createKey creates a 128 bytes long key for use with LUKS.
+func createKey() ([]byte, error) {
+	// Generate a random data.
+	key := make([]byte, 96)
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to generate random key: %w", err)
+	}
+
+	// Encode as base64, this results in 128 bytes.
+	return []byte(base64.StdEncoding.EncodeToString(key)), nil
+}
+
+// encryptDevice encrypts the given device with the given key.
+func encryptDevice(path string, key []byte) error {
+	// Run the cryptsetup command.
+	cmd := exec.Command(
+		"cryptsetup",
+		"--batch-mode",
+		"--key-file", "-",
+		"luksFormat",
+		path)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("Error in cryptsetup pipe: %s", err)
+	}
+	if _, err = stdin.Write(key); err != nil {
+		return fmt.Errorf("Error writing key to cryptsetup pipe: %s", err)
+	}
+	stdin.Close()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to luksFormat device: %s, %s, %s", path, err, out)
+	}
+	return nil
+}
+
+// Store the key in the ceph key value store, under a name that derives from the osd id.
+func storeKey(key []byte, osdID int64) error {
+	// Run the ceph config-key set command
+	_, err := processExec.RunCommand("ceph", "config-key", "set", fmt.Sprintf("microceph:osd.%d/key", osdID), string(key))
+	if err != nil {
+		return fmt.Errorf("Failed to store key: %w", err)
+	}
+	return nil
+}
+
+// Open the encrypted device and return its path.
+func openEncryptedDevice(path string, osdID int64, key []byte) (string, error) {
+	// Run the cryptsetup open command, expect key on stdin
+	cmd := exec.Command(
+		"cryptsetup",
+		"--keyfile-size", "128",
+		"--key-file", "-",
+		"luksOpen",
+		path,
+		fmt.Sprintf("luksosd-%d", osdID),
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return "", fmt.Errorf("Error in cryptsetup pipe: %s", err)
+	}
+	if _, err = stdin.Write(key); err != nil {
+		return "", fmt.Errorf("Error writing key to cryptsetup pipe: %s", err)
+	}
+	stdin.Close()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to luksOpen device: %s, %s, %s", path, err, out)
+	}
+	return fmt.Sprintf("/dev/mapper/luksosd-%d", osdID), nil
+}
+
+// checkEncryptSupport checks if the kernel supports encryption.
+// Checks performed:
+// - Check if the kernel module is loaded.
+// - Check if we have a mapper control file.
+// - Check if we can access /run
+func checkEncryptSupport() error {
+	// Check if we have a mapper
+	if _, err := os.Stat("/dev/mapper/control"); err != nil {
+		return fmt.Errorf("Missing /dev/mapper/control: %w", err)
+	}
+
+	// Check if we have the dm_crypt module
+	inf, err := os.Stat("/sys/module/dm_crypt")
+	if err != nil || inf == nil || !inf.IsDir() {
+		return fmt.Errorf("Missing dm_crypt module: %w", err)
+	}
+
+	// Check if we can list the /run directory; older snapd had an issue with this, https://github.com/snapcore/snapd/pull/12445
+	if _, err = os.ReadDir("/run"); err != nil {
+		return fmt.Errorf("Can't access /run, might need to update snapd to >2.58: %w", err)
+	}
+	return nil
+}
+
 // AddOSD adds an OSD to the cluster, given a device path and a flag for wiping
-func AddOSD(s *state.State, path string, wipe bool) error {
+func AddOSD(s *state.State, path string, wipe bool, encrypt bool) error {
 	// Validate the path.
 	if !shared.IsBlockdevPath(path) {
 		return fmt.Errorf("Invalid disk path: %s", path)
+	}
+	// Check if we need to support encryption
+	if encrypt {
+		if err := checkEncryptSupport(); err != nil {
+			return fmt.Errorf("Encryption unsupported on this machine: %w", err)
+		}
 	}
 
 	_, _, major, minor, _, _, err := shared.GetFileStat(path)
@@ -139,9 +278,18 @@ func AddOSD(s *state.State, path string, wipe bool) error {
 		return fmt.Errorf("Failed to generate OSD keyring: %w", err)
 	}
 
+	var blockPath string
+	if encrypt {
+		blockPath, err = setupEncryptedOSD(path, osdDataPath, nr)
+		if err != nil {
+			return err
+		}
+	} else {
+		blockPath = path
+	}
+
 	// Setup device symlink.
-	err = os.Symlink(path, filepath.Join(osdDataPath, "block"))
-	if err != nil {
+	if err = os.Symlink(blockPath, filepath.Join(osdDataPath, "block")); err != nil {
 		return fmt.Errorf("Failed to add block symlink: %w", err)
 	}
 

--- a/microceph/cmd/microceph/disk_add.go
+++ b/microceph/cmd/microceph/disk_add.go
@@ -14,7 +14,8 @@ type cmdDiskAdd struct {
 	common *CmdControl
 	disk   *cmdDisk
 
-	flagWipe bool
+	flagWipe    bool
+	flagEncrypt bool
 }
 
 func (c *cmdDiskAdd) Command() *cobra.Command {
@@ -25,6 +26,7 @@ func (c *cmdDiskAdd) Command() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&c.flagWipe, "wipe", false, "Wipe the disk prior to use")
+	cmd.PersistentFlags().BoolVar(&c.flagEncrypt, "encrypt", false, "Encrypt the disk prior to use")
 
 	return cmd
 }
@@ -45,8 +47,9 @@ func (c *cmdDiskAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	req := &types.DisksPost{
-		Path: args[0],
-		Wipe: c.flagWipe,
+		Path:    args[0],
+		Wipe:    c.flagWipe,
+		Encrypt: c.flagEncrypt,
 	}
 
 	err = client.AddDisk(context.Background(), cli, req)

--- a/microceph/cmd/microceph/init.go
+++ b/microceph/cmd/microceph/init.go
@@ -158,10 +158,16 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
+			diskEncrypt, err := cli.AskBool("Would you like the disk to be encrypted? [default=no]: ", "no")
+			if err != nil {
+				return err
+			}
+
 			// Add the disk.
 			req := &types.DisksPost{
-				Path: diskPath,
-				Wipe: diskWipe,
+				Path:    diskPath,
+				Wipe:    diskWipe,
+				Encrypt: diskEncrypt,
 			}
 
 			err = client.AddDisk(context.Background(), lc, req)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,6 +34,7 @@ apps:
     daemon: simple
     plugs:
       - block-devices
+      - dm-crypt
       - hardware-observe
       - network
       - network-bind
@@ -70,6 +71,7 @@ apps:
     stop-timeout: 5m
     plugs:
       - block-devices
+      - dm-crypt
       - hardware-observe
       - network
       - network-bind
@@ -83,6 +85,8 @@ apps:
     command: commands/microceph
     plugs:
       - network
+      - block-devices
+      - dm-crypt
   rbd:
     command: commands/rbd
     plugs:

--- a/snapcraft/commands/osd.start
+++ b/snapcraft/commands/osd.start
@@ -3,6 +3,26 @@ export SNAP_CURRENT="$(realpath "${SNAP_DATA}/..")/current"
 echo $$ > "${SNAP_CURRENT}/run/ceph-osd.pid"
 cd "${SNAP}"
 
+
+maybe_unlock() {
+    local dev="${1:?missing}"
+    local osdid="${2:?missing}"
+    local key="${3:?missing}"
+
+    luksname="luksosd-${osdid}"
+
+    [ -b "/dev/mapper/$luksname" ] && return
+
+    if cryptsetup isLuks "$dev" ; then
+        echo "${key}" | cryptsetup luksOpen "$dev" "$luksname" --key-file - --keyfile-size 128
+    fi
+}
+
+get_key() {
+    local osdid="${1:?missing}"
+    ceph config-key get "microceph:osd.${osdid}/key"
+}
+
 is_osd_running() {
     local osdid="${1:?missing}"
 
@@ -25,6 +45,10 @@ spawn() {
         [ ! -e "${i}/ready" ] && continue
 
         is_osd_running "${nr}" && continue
+
+        if [ -b "${i}/unencrypted" ] ; then
+            maybe_unlock "${i}/unencrypted" "${nr}" "$( get_key "${nr}" )"
+        fi
 
         ceph-osd --cluster ceph --id "${nr}"
     done


### PR DESCRIPTION
OSDs can optionally be encrypted via LUKS and dm-crypt on initialization

Closes #34