### PR TITLE
Update install docs with upgrade management section

### DIFF
--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -28,6 +28,7 @@ journey through the product.
    install
    initial_setup
    add_osds
+   update
 
 Follow the core tutorial steps in sequence; they take you on a learning journey through the product.
 

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -38,15 +38,3 @@ Install Microceph
     for i in $(seq 1 3); do
         lxc exec microceph-$i -- sh -c 'snap install microceph'
     done
-
-Update management
-~~~~~~~~~~~~~~~~~
-
-Updates are not managed from within microceph itself. As such, users are the ones who will manage them. Thus, automatic snap updates should be postponed indefinitely.
-This can be achieved with the following command (Supported with snapd from version 2.58 onwards):
-
-.. code-block:: shell
-
-    for i in $(seq 1 3); do
-        lxc exec microceph-$i -- sh -c 'snap refresh --hold microceph'
-    done

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -42,7 +42,7 @@ Install Microceph
 Update management
 ~~~~~~~~~~~~~~~~~
 
-For the time being, it's recommended that updates be postponed indefinitely.
+Updates are not managed from within microceph itself. As such, users are the ones who will manage them. Thus, automatic snap updates should be postponed indefinitely.
 This can be achieved with the following command (Supported with snapd from version 2.58 onwards):
 
 .. code-block:: shell

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -36,5 +36,5 @@ Install Microceph
 .. code-block:: shell
 
     for i in $(seq 1 3); do
-        lxc exec microceph-$i -- sh -c 'snap install microceph'
+        lxc exec microceph-$i -- sh -c 'snap install microceph && snap refresh --hold microceph'
     done

--- a/docs/tutorial/install.rst
+++ b/docs/tutorial/install.rst
@@ -38,3 +38,15 @@ Install Microceph
     for i in $(seq 1 3); do
         lxc exec microceph-$i -- sh -c 'snap install microceph'
     done
+
+Update management
+~~~~~~~~~~~~~~~~~
+
+For the time being, it's recommended that updates be postponed indefinitely.
+This can be achieved with the following command (Supported with snapd from version 2.58 onwards):
+
+.. code-block:: shell
+
+    for i in $(seq 1 3); do
+        lxc exec microceph-$i -- sh -c 'snap refresh --hold microceph'
+    done

--- a/docs/tutorial/update.rst
+++ b/docs/tutorial/update.rst
@@ -1,7 +1,8 @@
 Update management
 ~~~~~~~~~~~~~~~~~
 
-Microceph will not manages its own updates - users are required to do so. In order to set up microceph to manage updates correctly, the following steps need to be taken.
+Updates in Microceph are managed by the usual snap mechanisms. However, because snaps automatically deploy updates, this can be problematic in Microceph clusters that need an ordered rollout of updates.
+As such, we strongly advise that automatic updates be disabled for Microceph. Documentation about snaps updates can be consulted `here <https://snapcraft.io/docs/keeping-snaps-up-to-date>`_.
 
 Disable automatic updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -10,7 +11,7 @@ On each node of the cluster where microceph has been installed, we must run the 
 
 .. code-block:: shell
 
-    snap refresh --hold microceph
+    sudo snap refresh --hold microceph
 
 This will prevent automatic updates from happening.
 
@@ -48,8 +49,8 @@ With a healthy cluster, we need to run the following command on each node:
 
 .. code-block:: shell
 
-    snap refresh microceph
-    snap refresh --hold microceph
+    sudo snap refresh microceph
+    sudo snap refresh --hold microceph
 
 The order on which we run the commands is important. It should be as follows:
 
@@ -62,3 +63,11 @@ The output of the 'microceph.ceph status' command should provide us with the hos
 At present time, managers and monitors reside on the same nodes, but that may not always be the case.
 
 With that done, we should verify the cluster together to make it's settled and healthy once again.
+
+Additionally, we may consult that the new version has been refreshed correctly by running:
+
+.. code-block:: shell
+
+    snap list microceph
+
+And verifying that it matches our expectation.

--- a/docs/tutorial/update.rst
+++ b/docs/tutorial/update.rst
@@ -2,7 +2,7 @@ Update management
 ~~~~~~~~~~~~~~~~~
 
 Updates in Microceph are managed by the usual snap mechanisms. However, because snaps automatically deploy updates, this can be problematic in Microceph clusters that need an ordered rollout of updates.
-As such, we strongly advise that automatic updates be disabled for Microceph. Documentation about snaps updates can be consulted `here <https://snapcraft.io/docs/keeping-snaps-up-to-date>`_.
+As such, we strongly advise that automatic updates be disabled for Microceph. Documentation about snap updates can be consulted `here <https://snapcraft.io/docs/keeping-snaps-up-to-date>`_.
 
 Disable automatic updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -52,11 +52,11 @@ With a healthy cluster, we need to run the following command on each node:
     sudo snap refresh microceph
     sudo snap refresh --hold microceph
 
-The order on which we run the commands is important. It should be as follows:
+The order in which we run the commands is important. It should be as follows:
 
-1. Managers
-2. Monitors
-3. All other entities (i.e: OSDs)
+1. Managers (mgr)
+2. Monitors (mon)
+3. All other entities (osd, rgw, etc.)
 
 The output of the 'microceph.ceph status' command should provide us with the hostnames of the mons and managers ('microceph-1' et al in this example).
 

--- a/docs/tutorial/update.rst
+++ b/docs/tutorial/update.rst
@@ -44,11 +44,21 @@ The output should be something like the following:
         usage:   65 MiB used, 45 GiB / 45 GiB avail
         pgs:     1 active+clean
 
-Within a cluster healthy, we need to run the following command on each node:
+With a healthy cluster, we need to run the following command on each node:
 
 .. code-block:: shell
 
-    snap install microceph
+    snap refresh microceph
     snap refresh --hold microceph
+
+The order on which we run the commands is important. It should be as follows:
+
+1. Managers
+2. Monitors
+3. All other entities (i.e: OSDs)
+
+The output of the 'microceph.ceph status' command should provide us with the hostnames of the mons and managers ('microceph-1' et al in this example).
+
+At present time, managers and monitors reside on the same nodes, but that may not always be the case.
 
 With that done, we should verify the cluster together to make it's settled and healthy once again.

--- a/docs/tutorial/update.rst
+++ b/docs/tutorial/update.rst
@@ -1,0 +1,54 @@
+Update management
+~~~~~~~~~~~~~~~~~
+
+Microceph will not manages its own updates - users are required to do so. In order to set up microceph to manage updates correctly, the following steps need to be taken.
+
+Disable automatic updates
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On each node of the cluster where microceph has been installed, we must run the following:
+
+.. code-block:: shell
+
+    snap refresh --hold microceph
+
+This will prevent automatic updates from happening.
+
+Updating microceph
+~~~~~~~~~~~~~~~~~~
+
+When we want to update microceph, we need to be sure that all nodes are reachable and the cluster is healthy.
+
+In order to do so, we run the following command on one of the nodes:
+
+.. code-block:: shell
+
+    microceph.ceph status
+
+The output should be something like the following:
+
+.. code-block:: shell
+
+    cluster:
+        id:     q84fdf22-d12e-577n-9212-p10186effdzy
+        health: HEALTH_OK
+    
+    services:
+        mon: 3 daemons, quorum microceph-1,microceph-2,microceph-3 (age 25m)
+        mgr: microceph-1(active, since 35m), standbys: microceph-2, microceph-3
+        osd: 3 osds: 3 up (since 2m), 3 in (since 4m)
+    
+    data:
+        pools:   1 pools, 1 pgs
+        objects: 2 objects, 577 KiB
+        usage:   65 MiB used, 45 GiB / 45 GiB avail
+        pgs:     1 active+clean
+
+Within a cluster healthy, we need to run the following command on each node:
+
+.. code-block:: shell
+
+    snap install microceph
+    snap refresh --hold microceph
+
+With that done, we should verify the cluster together to make it's settled and healthy once again.


### PR DESCRIPTION
This PR adds a section in the installation docs that specifies the recommended way to manage upgrades.