### PR TITLE
Enable Format Flags for List

### DIFF
--- a/microceph/cmd/microceph/disable_rgw.go
+++ b/microceph/cmd/microceph/disable_rgw.go
@@ -11,7 +11,9 @@ import (
 )
 
 type cmdDisableRGW struct {
-	common     *CmdControl
+	common    *CmdControl
+	apiClient client.ApiWriter
+
 	flagTarget string
 }
 
@@ -22,28 +24,29 @@ func (c *cmdDisableRGW) Command() *cobra.Command {
 		RunE:  c.Run,
 	}
 	cmd.PersistentFlags().StringVar(&c.flagTarget, "target", "", "Server hostname (default: this server)")
+
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+		if err != nil {
+			return err
+		}
+		cli, err := m.LocalClient()
+		cli = cli.UseTarget(c.flagTarget)
+		c.apiClient = client.NewClient(cli)
+		return err
+	}
+
 	return cmd
 }
 
 // Run handles the disable rgw command.
 func (c *cmdDisableRGW) Run(cmd *cobra.Command, args []string) error {
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
-	if err != nil {
-		return err
-	}
-
-	cli, err := m.LocalClient()
-	if err != nil {
-		return err
-	}
-	cli = cli.UseTarget(c.flagTarget)
-
 	req := &types.RGWService{
 		Enabled: false,
 	}
 
-	err = client.EnableRGW(context.Background(), cli, req)
+	err := c.apiClient.EnableRGW(context.Background(), req)
 	if err != nil {
 		return err
 	}

--- a/microceph/cmd/microceph/disable_rgw_test.go
+++ b/microceph/cmd/microceph/disable_rgw_test.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"context"
-	"github.com/canonical/microceph/microceph/api/types"
-	tests2 "github.com/canonical/microceph/microceph/tests"
-	"github.com/stretchr/testify/mock"
 	"testing"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/mocks"
+	"github.com/stretchr/testify/mock"
 )
 
 // make sure it fails like before on empty config
-func Test_cmdDisableRGW_Execute(t *testing.T) {
+func TestCmdDisableRGWExecute(t *testing.T) {
 	tests := []struct {
 		name    string
 		common  *CmdControl
@@ -35,7 +36,7 @@ func Test_cmdDisableRGW_Execute(t *testing.T) {
 	}
 }
 
-func Test_cmdDisableRGW_Run(t *testing.T) {
+func TestCmdDisableRGWRun(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr bool
@@ -52,7 +53,7 @@ func Test_cmdDisableRGW_Run(t *testing.T) {
 		}
 		apiMock.On("EnableRGW", mock.Anything, req).Return(nil)
 		c := &cmdDisableRGW{
-			apiClient: apiMock,
+			apiClient: &apiMock,
 		}
 
 		if err := c.Run(c.Command(), []string{}); (err != nil) != tt.wantErr {

--- a/microceph/cmd/microceph/disable_rgw_test.go
+++ b/microceph/cmd/microceph/disable_rgw_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/tests"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+// make sure it fails like before on empty config
+func Test_cmdDisableRGW_Execute(t *testing.T) {
+	tests := []struct {
+		name    string
+		common  *CmdControl
+		wantErr string
+	}{
+		{
+			"failure constructing app without state dir",
+			&CmdControl{
+				FlagStateDir: "",
+			},
+			"Missing state directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cmdDisableRGW{
+				common: tt.common,
+			}
+			if err := c.Command().ExecuteContext(context.Background()); (err != nil) && err.Error() != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_cmdDisableRGW_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "ok",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		apiMock := tests2.ApiMock{}
+		req := &types.RGWService{
+			Enabled: false,
+		}
+		apiMock.On("EnableRGW", mock.Anything, req).Return(nil)
+		c := &cmdDisableRGW{
+			apiClient: apiMock,
+		}
+
+		if err := c.Run(c.Command(), []string{}); (err != nil) != tt.wantErr {
+			t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+		}
+	}
+}

--- a/microceph/cmd/microceph/disk_add_test.go
+++ b/microceph/cmd/microceph/disk_add_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/tests"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+// make sure it fails like before on empty config
+func Test_cmdDiskAdd_Execute(t *testing.T) {
+	tests := []struct {
+		name    string
+		common  *CmdControl
+		wantErr string
+	}{
+		{
+			"failure constructing app without state dir",
+			&CmdControl{
+				FlagStateDir: "",
+			},
+			"Missing state directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cmdDiskAdd{
+				common: tt.common,
+			}
+			if err := c.Command().ExecuteContext(context.Background()); (err != nil) && err.Error() != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_cmdDiskAdd_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		wipe    bool
+		wantErr bool
+	}{
+		{
+			name:    "Success Add with wipe",
+			wipe:    true,
+			wantErr: false,
+		},
+		{
+			name:    "Success Add without wipe",
+			wipe:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		apiMock := tests2.ApiMock{}
+		path := "/tmp/disk"
+		req := &types.DisksPost{
+			Path: path,
+			Wipe: tt.wipe,
+		}
+		apiMock.On("AddDisk", mock.Anything, req).Return(nil)
+
+		c := &cmdDiskAdd{
+			apiClient: apiMock,
+		}
+		cmd := c.Command()
+		c.flagWipe = tt.wipe
+
+		if err := c.Run(cmd, []string{path}); (err != nil) != tt.wantErr {
+			t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+		}
+	}
+}

--- a/microceph/cmd/microceph/disk_add_test.go
+++ b/microceph/cmd/microceph/disk_add_test.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"context"
-	"github.com/canonical/microceph/microceph/api/types"
-	tests2 "github.com/canonical/microceph/microceph/tests"
-	"github.com/stretchr/testify/mock"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/mocks"
 )
 
 // make sure it fails like before on empty config
-func Test_cmdDiskAdd_Execute(t *testing.T) {
+func TestCmdDiskAddExecute(t *testing.T) {
 	tests := []struct {
 		name    string
 		common  *CmdControl
@@ -35,7 +37,7 @@ func Test_cmdDiskAdd_Execute(t *testing.T) {
 	}
 }
 
-func Test_cmdDiskAdd_Run(t *testing.T) {
+func TestCmdDiskAddRun(t *testing.T) {
 	tests := []struct {
 		name    string
 		wipe    bool
@@ -62,7 +64,7 @@ func Test_cmdDiskAdd_Run(t *testing.T) {
 		apiMock.On("AddDisk", mock.Anything, req).Return(nil)
 
 		c := &cmdDiskAdd{
-			apiClient: apiMock,
+			apiClient: &apiMock,
 		}
 		cmd := c.Command()
 		c.flagWipe = tt.wipe

--- a/microceph/cmd/microceph/disk_list.go
+++ b/microceph/cmd/microceph/disk_list.go
@@ -19,6 +19,7 @@ type cmdDiskList struct {
 	common                *CmdControl
 	disk                  *cmdDisk
 	flgShowAvailableDisks bool
+	flagFormat            string
 
 	apiClient client.ApiReader
 }
@@ -31,6 +32,7 @@ func (c *cmdDiskList) Command() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&c.flgShowAvailableDisks, "available", "a", false, i18n.G("Show only available local disks"))
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
@@ -48,14 +50,14 @@ func (c *cmdDiskList) Command() *cobra.Command {
 func (c *cmdDiskList) Run(cmd *cobra.Command, args []string) error {
 
 	if !c.flgShowAvailableDisks {
-		err := listConfiguredDisks(c.apiClient, utils.TableFormatTable)
+		err := listConfiguredDisks(c.apiClient, c.flagFormat)
 		if err != nil {
 			return err
 		}
 	}
 
 	if c.flgShowAvailableDisks {
-		err := listLocalDisks(c.apiClient, utils.TableFormatTable)
+		err := listLocalDisks(c.apiClient, c.flagFormat)
 		if err != nil {
 			return err
 		}

--- a/microceph/cmd/microceph/disk_list.go
+++ b/microceph/cmd/microceph/disk_list.go
@@ -3,16 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/lxc/lxd/shared/i18n"
 	"os"
 	"sort"
 
-	"github.com/canonical/microcluster/microcluster"
-	"github.com/lxc/lxd/lxc/utils"
-	"github.com/lxc/lxd/shared/units"
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/lxc/lxd/lxc/utils"
+	"github.com/lxc/lxd/shared/i18n"
+	"github.com/lxc/lxd/shared/units"
 )
 
 type cmdDiskList struct {

--- a/microceph/cmd/microceph/disk_list_test.go
+++ b/microceph/cmd/microceph/disk_list_test.go
@@ -4,22 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/canonical/microceph/microceph/api/types"
-	tests2 "github.com/canonical/microceph/microceph/tests"
-	"github.com/lxc/lxd/lxc/utils"
-	"github.com/lxc/lxd/shared/api"
-	"github.com/pborman/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/mocks"
+	"github.com/lxc/lxd/lxc/utils"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // make sure it fails like before on empty config
-func Test_cmdDiskList_Execute(t *testing.T) {
+func TestCmdDiskListExecute(t *testing.T) {
 	tests := []struct {
 		name    string
 		common  *CmdControl
@@ -46,7 +48,7 @@ func Test_cmdDiskList_Execute(t *testing.T) {
 	}
 }
 
-func Test_cmdDiskList_Run(t *testing.T) {
+func TestCmdDiskListRun(t *testing.T) {
 
 	type disks struct {
 		mustBeRendered bool
@@ -285,7 +287,7 @@ func Test_cmdDiskList_Run(t *testing.T) {
 			apiMock.On("GetDisks", mock.Anything).Return(tt.mockDisks.data, tt.mockDisks.error)
 			apiMock.On("GetResources", mock.Anything).Return(tt.mockResources.data, tt.mockResources.error)
 			c := &cmdDiskList{
-				apiClient: apiMock,
+				apiClient: &apiMock,
 			}
 
 			cmd := c.Command()

--- a/microceph/cmd/microceph/disk_list_test.go
+++ b/microceph/cmd/microceph/disk_list_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/tests"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"io"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// make sure it fails like before on empty config
+func Test_cmdDiskList_Execute(t *testing.T) {
+	tests := []struct {
+		name    string
+		common  *CmdControl
+		wantErr string
+	}{
+		{
+			"failure constructing app without state dir",
+			&CmdControl{
+				FlagStateDir: "",
+			},
+			"Missing state directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cmdDiskList{
+				common: tt.common,
+				disk:   nil,
+			}
+			if err := c.Command().ExecuteContext(context.Background()); (err != nil) && err.Error() != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_cmdDiskList_Run(t *testing.T) {
+
+	type disks struct {
+		data  types.Disks
+		error error
+	}
+
+	type resources struct {
+		data  *api.ResourcesStorage
+		error error
+	}
+
+	tests := []struct {
+		name          string
+		mockDisks     disks
+		mockResources resources
+		wantErr       bool
+	}{
+		{
+			name: "Success Empty List",
+			mockDisks: disks{
+				data:  types.Disks{},
+				error: nil,
+			},
+			mockResources: resources{
+				data:  &api.ResourcesStorage{},
+				error: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success 2 Disks",
+			mockDisks: disks{
+				data: []types.Disk{
+					{
+						OSD:      0,
+						Path:     "/tmp/folder-1",
+						Location: "node-1",
+					},
+					{
+						OSD:      1,
+						Path:     "/tmp/folder-2",
+						Location: "node-2",
+					},
+				},
+				error: nil,
+			},
+			mockResources: resources{
+				data:  &api.ResourcesStorage{},
+				error: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success 2 Resources",
+			mockDisks: disks{
+				data:  types.Disks{},
+				error: nil,
+			},
+			mockResources: resources{
+				data: &api.ResourcesStorage{
+					Disks: []api.ResourcesStorageDisk{
+						{
+							Model:  "Virtual Warp Drive",
+							Size:   1000,
+							ID:     uuid.NewUUID().String(),
+							Device: "/dev/sda1",
+						},
+						{
+							Model:  "Virtual Flux Drive",
+							Size:   1000,
+							ID:     uuid.NewUUID().String(),
+							Device: "/dev/sdb1",
+						},
+					},
+					Total: 0,
+				},
+				error: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success 2 Resources / 3 Disks",
+			mockDisks: disks{
+				data: []types.Disk{
+					{
+						OSD:      0,
+						Path:     "/tmp/folder-1",
+						Location: "node-1",
+					},
+					{
+						OSD:      1,
+						Path:     "/tmp/folder-2",
+						Location: "node-2",
+					},
+					{
+						OSD:      2,
+						Path:     "/tmp/folder-3",
+						Location: "node-3",
+					},
+				},
+				error: nil,
+			},
+			mockResources: resources{
+				data: &api.ResourcesStorage{
+					Disks: []api.ResourcesStorageDisk{
+						{
+							Model:  "Virtual Warp Drive",
+							Size:   1000,
+							ID:     uuid.NewUUID().String(),
+							Device: "/dev/sda1",
+							Type:   "warp",
+						},
+						{
+							Model:  "Virtual Flux Drive",
+							Size:   1000,
+							ID:     uuid.NewUUID().String(),
+							Device: "/dev/sdb1",
+							Type:   "flux",
+						},
+					},
+					Total: 0,
+				},
+				error: nil,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiMock := tests2.ApiMock{}
+			apiMock.On("GetDisks", mock.Anything).Return(tt.mockDisks.data, tt.mockDisks.error)
+			apiMock.On("GetResources", mock.Anything).Return(tt.mockResources.data, tt.mockResources.error)
+			c := &cmdDiskList{
+				apiClient: apiMock,
+			}
+
+			saveStdout := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			if err := c.Run(c.Command(), []string{}); (err != nil) != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			w.Close()
+			out, _ := io.ReadAll(r)
+			os.Stdout = saveStdout
+
+			outputString := string(out)
+
+			for _, disk := range tt.mockDisks.data {
+				assert.Contains(t, outputString, strconv.FormatInt(disk.OSD, 10))
+				assert.Contains(t, outputString, disk.Location)
+				assert.Contains(t, outputString, disk.Path)
+			}
+
+			for _, disk := range tt.mockResources.data.Disks {
+				assert.Contains(t, outputString, disk.Model)
+				assert.Contains(t, outputString, fmt.Sprintf("%dB", disk.Size))
+				assert.Contains(t, outputString, disk.Type)
+				assert.Contains(t, outputString, disk.DevicePath)
+			}
+
+			println(outputString)
+
+		})
+	}
+}

--- a/microceph/cmd/microceph/enable_rgw_test.go
+++ b/microceph/cmd/microceph/enable_rgw_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/tests"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+// make sure it fails like before on empty config
+func Test_cmdEnableRGW_Execute(t *testing.T) {
+	tests := []struct {
+		name    string
+		common  *CmdControl
+		wantErr string
+	}{
+		{
+			"failure constructing app without state dir",
+			&CmdControl{
+				FlagStateDir: "",
+			},
+			"Missing state directory",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cmdEnableRGW{
+				common: tt.common,
+			}
+			if err := c.Command().ExecuteContext(context.Background()); (err != nil) && err.Error() != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_cmdEnableRGW_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			name:    "ok",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		apiMock := tests2.ApiMock{}
+		req := &types.RGWService{
+			Port:    80,
+			Enabled: true,
+		}
+		apiMock.On("EnableRGW", mock.Anything, req).Return(nil)
+		c := &cmdEnableRGW{
+			apiClient: apiMock,
+		}
+
+		if err := c.Run(c.Command(), []string{}); (err != nil) != tt.wantErr {
+			t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+		}
+	}
+}

--- a/microceph/cmd/microceph/enable_rgw_test.go
+++ b/microceph/cmd/microceph/enable_rgw_test.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"context"
-	"github.com/canonical/microceph/microceph/api/types"
-	tests2 "github.com/canonical/microceph/microceph/tests"
-	"github.com/stretchr/testify/mock"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	tests2 "github.com/canonical/microceph/microceph/mocks"
 )
 
 // make sure it fails like before on empty config
-func Test_cmdEnableRGW_Execute(t *testing.T) {
+func TestCmdEnableRGWExecute(t *testing.T) {
 	tests := []struct {
 		name    string
 		common  *CmdControl
@@ -35,7 +37,7 @@ func Test_cmdEnableRGW_Execute(t *testing.T) {
 	}
 }
 
-func Test_cmdEnableRGW_Run(t *testing.T) {
+func TestCmdEnableRGWRun(t *testing.T) {
 	tests := []struct {
 		name    string
 		wantErr bool
@@ -53,7 +55,7 @@ func Test_cmdEnableRGW_Run(t *testing.T) {
 		}
 		apiMock.On("EnableRGW", mock.Anything, req).Return(nil)
 		c := &cmdEnableRGW{
-			apiClient: apiMock,
+			apiClient: &apiMock,
 		}
 
 		if err := c.Run(c.Command(), []string{}); (err != nil) != tt.wantErr {

--- a/microceph/cmd/microceph/init.go
+++ b/microceph/cmd/microceph/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/lxc/lxd/lxc/utils"
 	"os"
 	"time"
 
@@ -139,7 +140,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 
 	apiClient := client.NewClient(lc)
 	if wantsDisks {
-		err = listLocalDisks(apiClient)
+		err = listLocalDisks(apiClient, utils.TableFormatTable)
 		if err != nil {
 			return err
 		}

--- a/microceph/cmd/microceph/init.go
+++ b/microceph/cmd/microceph/init.go
@@ -137,8 +137,9 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	apiClient := client.NewClient(lc)
 	if wantsDisks {
-		err = listLocalDisks(lc)
+		err = listLocalDisks(apiClient)
 		if err != nil {
 			return err
 		}
@@ -164,7 +165,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 				Wipe: diskWipe,
 			}
 
-			err = client.AddDisk(context.Background(), lc, req)
+			err = apiClient.AddDisk(context.Background(), req)
 			if err != nil {
 				return err
 			}

--- a/microceph/cmd/microceph/init.go
+++ b/microceph/cmd/microceph/init.go
@@ -3,17 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/lxc/lxd/lxc/utils"
 	"os"
 	"time"
 
-	"github.com/canonical/microcluster/microcluster"
-	"github.com/lxc/lxd/lxd/util"
-	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/lxc/lxd/lxc/utils"
+	"github.com/lxc/lxd/lxd/util"
+	cli "github.com/lxc/lxd/shared/cmd"
 )
 
 type cmdInit struct {

--- a/microceph/cmd/microceph/status.go
+++ b/microceph/cmd/microceph/status.go
@@ -37,14 +37,16 @@ func (c *cmdStatus) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	apiClient := client.NewClient(cli)
+
 	// Get configured disks.
-	disks, err := client.GetDisks(context.Background(), cli)
+	disks, err := apiClient.GetDisks(context.Background())
 	if err != nil {
 		return err
 	}
 
 	// Get services.
-	services, err := client.GetServices(context.Background(), cli)
+	services, err := apiClient.GetServices(context.Background())
 	if err != nil {
 		return err
 	}

--- a/microceph/go.mod
+++ b/microceph/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -60,5 +61,4 @@ require (
 	gopkg.in/httprequest.v1 v1.2.1 // indirect
 	gopkg.in/macaroon.v2 v2.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/microceph/mocks/client_mock.go
+++ b/microceph/mocks/client_mock.go
@@ -1,22 +1,24 @@
-package tests
+package mocks
 
 import (
 	"context"
+
+	"github.com/stretchr/testify/mock"
+
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/lxc/lxd/shared/api"
-	"github.com/stretchr/testify/mock"
 )
 
 type ApiMock struct {
 	mock.Mock
 }
 
-func (m ApiMock) GetDisks(ctx context.Context) (types.Disks, error) {
+func (m *ApiMock) GetDisks(ctx context.Context) (types.Disks, error) {
 	mockArgs := m.Called(ctx)
 	return mockArgs.Get(0).(types.Disks), mockArgs.Error(1)
 }
 
-func (m ApiMock) GetResources(ctx context.Context) (*api.ResourcesStorage, error) {
+func (m *ApiMock) GetResources(ctx context.Context) (*api.ResourcesStorage, error) {
 	mockArgs := m.Called(ctx)
 	if mockArgs.Get(0) != nil {
 		return mockArgs.Get(0).(*api.ResourcesStorage), mockArgs.Error(1)
@@ -24,17 +26,17 @@ func (m ApiMock) GetResources(ctx context.Context) (*api.ResourcesStorage, error
 	return nil, mockArgs.Error(1)
 }
 
-func (m ApiMock) GetServices(ctx context.Context) (types.Services, error) {
+func (m *ApiMock) GetServices(ctx context.Context) (types.Services, error) {
 	mockArgs := m.Called(ctx)
 	return mockArgs.Get(0).(types.Services), mockArgs.Error(1)
 }
 
-func (m ApiMock) AddDisk(ctx context.Context, data *types.DisksPost) error {
+func (m *ApiMock) AddDisk(ctx context.Context, data *types.DisksPost) error {
 	mockArgs := m.Called(ctx, data)
 	return mockArgs.Error(0)
 }
 
-func (m ApiMock) EnableRGW(ctx context.Context, data *types.RGWService) error {
+func (m *ApiMock) EnableRGW(ctx context.Context, data *types.RGWService) error {
 	mockArgs := m.Called(ctx, data)
 	return mockArgs.Error(0)
 }

--- a/microceph/tests/client_mock.go
+++ b/microceph/tests/client_mock.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"context"
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/stretchr/testify/mock"
+)
+
+type ApiMock struct {
+	mock.Mock
+}
+
+func (m ApiMock) GetDisks(ctx context.Context) (types.Disks, error) {
+	mockArgs := m.Called(ctx)
+	return mockArgs.Get(0).(types.Disks), mockArgs.Error(1)
+}
+
+func (m ApiMock) GetResources(ctx context.Context) (*api.ResourcesStorage, error) {
+	mockArgs := m.Called(ctx)
+	if mockArgs.Get(0) != nil {
+		return mockArgs.Get(0).(*api.ResourcesStorage), mockArgs.Error(1)
+	}
+	return nil, mockArgs.Error(1)
+}
+
+func (m ApiMock) GetServices(ctx context.Context) (types.Services, error) {
+	mockArgs := m.Called(ctx)
+	return mockArgs.Get(0).(types.Services), mockArgs.Error(1)
+}
+
+func (m ApiMock) AddDisk(ctx context.Context, data *types.DisksPost) error {
+	mockArgs := m.Called(ctx, data)
+	return mockArgs.Error(0)
+}
+
+func (m ApiMock) EnableRGW(ctx context.Context, data *types.RGWService) error {
+	mockArgs := m.Called(ctx, data)
+	return mockArgs.Error(0)
+}


### PR DESCRIPTION
Sorry for the confusion - had to resolve some conflicts and did something weird, so #102 got closed :D
Changes as described in https://github.com/canonical/microceph/pull/102

So I went ahead and did as mentioned before.
I am not very much in love with how the asserts work on the table tbh but that's due to the fact that I would like to propose some changes to utils.RenderTable first. This should really set up differently tbh only returning the model. You can run some decent assertions on that one, without digging into os.stdout and parsing strings...
So pending that discussion I went for a "works for now" (hopefully) approach.

Let me know how that works for you - I added tests for all commands I can stick the newly proposed ApiClient in.
