### PR TITLE
Add Cluster config management to microceph

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,36 @@ jobs:
           s3cmd --host localhost --host-bucket="localhost/%(bucket)" --access_key=fooAccessKey --secret_key=fooSecretKey --no-ssl put -P ~/test.txt s3://testbucket
           curl -s http://localhost/testbucket/test.txt | grep -F hello-radosgw
 
+      - name: Test Cluster Config
+        run: |
+          set -eux
+          cip=$(ip -4 -j route | jq -r '.[] | select(.dst | contains("default")) | .prefsrc' | tr -d '[:space:]')
+          
+          # pre config set timestamp for service age
+          ts=$(sudo systemctl show --property ActiveEnterTimestampMonotonic snap.microceph.osd.service | cut -d= -f2)
+
+          # set config
+          sudo microceph cluster config set cluster_network $cip/8 --wait
+
+          # post config set timestamp for service age
+          ts2=$(sudo systemctl show --property ActiveEnterTimestampMonotonic snap.microceph.osd.service | cut -d= -f2)
+
+          # Check config output
+          output=$(sudo microceph cluster config get cluster_network | grep -cim1 'cluster_network')
+          if [[ $output -lt 1 ]] ; then echo "config check failed: $output"; exit 1; fi
+
+          # Check service restarted
+          if [ $ts2 -lt $ts ]; then echo "config check failed: TS1: $ts2 TS2: $ts3"; exit 1; fi
+
+          # reset config
+          sudo microceph cluster config reset cluster_network --wait
+
+          # post config reset timestamp for service age
+          ts3=$(sudo systemctl show --property ActiveEnterTimestampMonotonic snap.microceph.osd.service | cut -d= -f2)
+
+          # Check service restarted
+          if [ $ts3 -lt $ts2 ]; then echo "config check failed: TS2: $ts2 TS3: $ts3"; exit 1; fi
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/microceph/api/configs.go
+++ b/microceph/api/configs.go
@@ -65,7 +65,7 @@ func cmdConfigsPut(s *state.State, r *http.Request) response.Response {
 	// Restart Daemons on host.
 	daemons := configTable[req.Key].Daemons
 	for i := range daemons {
-		err = ceph.RestartCephDaemon(daemons[i])
+		err = ceph.RestartCephService(daemons[i])
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -96,7 +96,7 @@ func cmdConfigsDelete(s *state.State, r *http.Request) response.Response {
 	// Restart Daemons on host.
 	daemons := configTable[req.Key].Daemons
 	for i := range daemons {
-		err = ceph.RestartCephDaemon(daemons[i])
+		err = ceph.RestartCephService(daemons[i])
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/microceph/api/configs.go
+++ b/microceph/api/configs.go
@@ -39,13 +39,16 @@ func cmdConfigsGet(s *state.State, r *http.Request) response.Response {
 		// Fetch all configs.
 		configs, err = ceph.ListConfigs()
 	}
+	if err != nil {
+		return response.SmartError(err)
+	}
 
 	return response.SyncResponse(true, configs)
 }
 
 func cmdConfigsPut(s *state.State, r *http.Request) response.Response {
 	var req types.Config
-	configTable := ceph.GetConfigTable()
+	configTable := ceph.GetConstConfigTable()
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -66,7 +69,7 @@ func cmdConfigsPut(s *state.State, r *http.Request) response.Response {
 
 func cmdConfigsDelete(s *state.State, r *http.Request) response.Response {
 	var req types.Config
-	configTable := ceph.GetConfigTable()
+	configTable := ceph.GetConstConfigTable()
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {

--- a/microceph/api/configs.go
+++ b/microceph/api/configs.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+	"github.com/lxc/lxd/lxd/response"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/ceph"
+	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microceph/microceph/common"
+)
+
+// Config table for ConfigExtras
+var configTable = ceph.GetConfigTable()
+
+// /1.0/configs endpoint.
+var configsCmd = rest.Endpoint{
+	Path: "configs",
+
+	Get:  rest.EndpointAction{Handler: cmdConfigsGet, ProxyTarget: true},
+	Put: rest.EndpointAction{Handler: cmdConfigsPut, ProxyTarget: true},
+	Delete: rest.EndpointAction{Handler: cmdConfigsDelete, ProxyTarget: true},
+}
+
+func cmdConfigsGet(s *state.State, r *http.Request) response.Response {
+	var req types.Config
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// Fetch configs.
+	configs, err := ceph.ListConfigs(common.CephState{State: s}, req.Key)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	return response.SyncResponse(true, configs)
+}
+
+func cmdConfigsPut(s *state.State, r *http.Request) response.Response {
+	var req types.Config
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	if !client.IsForwardedRequest(r) {
+		// Call set on the original Request but not on Forwarded Requests.
+		err = ceph.SetConfigItem(common.CephState{State: s}, req)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		// Forward request to cluster members
+		err = client.ForwardConfigRequestToClusterMembers(s, r, &req, client.SetConfig)
+	}
+
+	// Restart Daemons on host.
+	daemons := configTable[req.Key].Daemons
+	for i := range daemons {
+		err = ceph.RestartCephDaemon(daemons[i])
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	return response.EmptySyncResponse
+}
+
+func cmdConfigsDelete(s *state.State, r *http.Request) response.Response {
+	var req types.Config
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	if !client.IsForwardedRequest(r) {
+		// Call set on the original Request but not on Forwarded Requests.
+		err = ceph.RemoveConfigItem(common.CephState{State: s}, req)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		// Forward request to cluster members
+		err = client.ForwardConfigRequestToClusterMembers(s, r, &req, client.ClearConfig)
+	}
+
+	// Restart Daemons on host.
+	daemons := configTable[req.Key].Daemons
+	for i := range daemons {
+		err = ceph.RestartCephDaemon(daemons[i])
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	return response.EmptySyncResponse
+}

--- a/microceph/api/endpoints.go
+++ b/microceph/api/endpoints.go
@@ -11,4 +11,5 @@ var Endpoints = []rest.Endpoint{
 	resourcesCmd,
 	servicesCmd,
 	rgwServiceCmd,
+	configsCmd,
 }

--- a/microceph/api/endpoints.go
+++ b/microceph/api/endpoints.go
@@ -12,4 +12,5 @@ var Endpoints = []rest.Endpoint{
 	servicesCmd,
 	rgwServiceCmd,
 	configsCmd,
+	restartServiceCmd,
 }

--- a/microceph/api/services.go
+++ b/microceph/api/services.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/common"
-	"net/http"
 
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/shared/logger"
 
 	"github.com/canonical/microceph/microceph/ceph"
 )
@@ -27,6 +30,33 @@ func cmdServicesGet(s *state.State, r *http.Request) response.Response {
 	}
 
 	return response.SyncResponse(true, services)
+}
+
+// Service Reload Endpoint.
+var restartServiceCmd = rest.Endpoint{
+	Path: "services/restart",
+	Post: rest.EndpointAction{Handler: cmdRestartServicePost, ProxyTarget: true},
+}
+
+func cmdRestartServicePost(s *state.State, r *http.Request) response.Response {
+	var services types.Services
+
+	err := json.NewDecoder(r.Body).Decode(&services)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Failed decoding restart services: %v", err))
+		return response.InternalError(err)
+	}
+
+	for _, service := range services {
+		err = ceph.RestartCephService(service.Service)
+		if err != nil {
+			url := s.Address().String()
+			logger.Error(fmt.Sprintf("Failed restarting %s on host %s", service.Service, url))
+			return response.SyncResponse(false, err)
+		}
+	}
+
+	return response.EmptySyncResponse
 }
 
 var rgwServiceCmd = rest.Endpoint{

--- a/microceph/api/services.go
+++ b/microceph/api/services.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/canonical/microceph/microceph/api/types"
@@ -43,7 +42,7 @@ func cmdRestartServicePost(s *state.State, r *http.Request) response.Response {
 
 	err := json.NewDecoder(r.Body).Decode(&services)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Failed decoding restart services: %v", err))
+		logger.Errorf("Failed decoding restart services: %v", err)
 		return response.InternalError(err)
 	}
 
@@ -51,7 +50,7 @@ func cmdRestartServicePost(s *state.State, r *http.Request) response.Response {
 		err = ceph.RestartCephService(service.Service)
 		if err != nil {
 			url := s.Address().String()
-			logger.Error(fmt.Sprintf("Failed restarting %s on host %s", service.Service, url))
+			logger.Errorf("Failed restarting %s on host %s", service.Service, url)
 			return response.SyncResponse(false, err)
 		}
 	}

--- a/microceph/api/services.go
+++ b/microceph/api/services.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/canonical/microceph/microceph/api/types"
@@ -44,6 +45,16 @@ func cmdRestartServicePost(s *state.State, r *http.Request) response.Response {
 	if err != nil {
 		logger.Errorf("Failed decoding restart services: %v", err)
 		return response.InternalError(err)
+	}
+
+	// Check if provided services are valid and available in microceph
+	for _, service := range(services) {
+		valid_services := ceph.GetConfigTableServiceSet()
+		if _, ok := valid_services[service.Service]; !ok {
+			err := fmt.Errorf("%s is not a valid ceph service", service.Service)
+			logger.Errorf("%v", err)
+			return response.InternalError(err)
+		}
 	}
 
 	for _, service := range services {

--- a/microceph/api/types/configs.go
+++ b/microceph/api/types/configs.go
@@ -1,0 +1,11 @@
+// Package types provides shared types and structs.
+package types
+
+// Configs holds the key value pair
+type Config struct {
+	Key   string  `json:"key" yaml:"key"`
+	Value string  `json:"value" yaml:"value"`
+}
+
+// Configs is a slice of configs
+type Configs []Config

--- a/microceph/api/types/configs.go
+++ b/microceph/api/types/configs.go
@@ -5,6 +5,7 @@ package types
 type Config struct {
 	Key   string  `json:"key" yaml:"key"`
 	Value string  `json:"value" yaml:"value"`
+	Wait  bool    `json:"wait" yaml:"wait"`
 }
 
 // Configs is a slice of configs

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -38,10 +38,22 @@ func (c ConfigTable) Keys() (keys []string) {
 	return keys
 }
 
-func GetConfigTable() ConfigTable {
+// Since we can't have const maps, we encapsulate the map into a func
+// so that each request for the map gaurantees consistent definition.
+func GetConstConfigTable() ConfigTable {
 	return ConfigTable{
 		"public_network":  {"global", []string{"mon", "osd"}},
 		"cluster_network": {"global", []string{"osd"}},
+	}
+}
+
+func GetConfigTableServiceSet() Set {
+	return Set{
+		"mon": struct{}{},
+		"mgr": struct{}{},
+		"osd": struct{}{},
+		"mds": struct{}{},
+		"rgw": struct{}{},
 	}
 }
 
@@ -54,7 +66,7 @@ type ConfigDumpItem struct{
 type ConfigDump []ConfigDumpItem
 
 func SetConfigItem(c types.Config) error {
-	configTable := GetConfigTable()
+	configTable := GetConstConfigTable()
 
 	args := []string{
 		"config",
@@ -76,7 +88,7 @@ func SetConfigItem(c types.Config) error {
 
 func GetConfigItem(c types.Config) (types.Configs, error) {
 	var err error
-	configTable := GetConfigTable()
+	configTable := GetConstConfigTable()
 	ret := make(types.Configs, 1)
 	who := "mon"
 
@@ -102,7 +114,7 @@ func GetConfigItem(c types.Config) (types.Configs, error) {
 }
 
 func RemoveConfigItem(c types.Config) error {
-	configTable := GetConfigTable()
+	configTable := GetConstConfigTable()
 	args := []string{
 		"config",
 		"rm",
@@ -121,7 +133,7 @@ func RemoveConfigItem(c types.Config) error {
 func ListConfigs() (types.Configs, error) {
 	var dump ConfigDump
 	var configs types.Configs
-	configTable := GetConfigTable()
+	configTable := GetConstConfigTable()
 	args := []string{
 		"config",
 		"dump",

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -21,10 +21,10 @@ type ConfigExtras struct{
 	Cb      *func(s common.StateInterface, c types.Config)
 }
 
-type ConfigItem map[string]ConfigExtras
+type ConfigTable map[string]ConfigExtras
 
 // Check if certain key is present in the map.
-func (c ConfigItem) isKeyPresent(key string) bool {
+func (c ConfigTable) isKeyPresent(key string) bool {
 	if _, ok := c[key]; !ok {
         return false
     }
@@ -33,15 +33,15 @@ func (c ConfigItem) isKeyPresent(key string) bool {
 }
 
 // Return keys of the given set
-func (c ConfigItem) Keys() (keys []string) {
+func (c ConfigTable) Keys() (keys []string) {
     for k := range c {
         keys = append(keys, k)
     }
     return keys
 }
 
-func GetConfigTable() ConfigItem {
-	return ConfigItem{
+func GetConfigTable() ConfigTable {
+	return ConfigTable{
 		"public_network":  {"global", []string{"mon", "osd"}, "", nil},
 		"cluster_network": {"global", []string{"osd"}, "", nil},
 	}
@@ -54,10 +54,6 @@ type ConfigDump []struct{
 	Section string
 	Name    string
 	Value   string
-}
-
-func RestartCephDaemon(daemon string) error {
-	return snapReload(daemon)
 }
 
 func SetConfigItem(s common.StateInterface, c types.Config) error {

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -3,14 +3,143 @@ package ceph
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microceph/microceph/database"
 )
+
+type ConfigExtras struct{
+	Who     string // Ceph Config internal <who> against each key
+	Daemons []string // Daemons that need to be restarted post config change.
+	Regexp  string // Regular Expression to check value against key
+	Cb      *func(s common.StateInterface, c types.Config)
+}
+
+type ConfigItem map[string]ConfigExtras
+
+// Check if certain key is present in the map.
+func (c ConfigItem) isKeyPresent(key string) bool {
+	if _, ok := c[key]; !ok {
+        return false
+    }
+
+	return true
+}
+
+// Return keys of the given set
+func (c ConfigItem) Keys() (keys []string) {
+    for k := range c {
+        keys = append(keys, k)
+    }
+    return keys
+}
+
+func GetConfigTable() ConfigItem {
+	return ConfigItem{
+		"public_network":  {"global", []string{"mon", "osd"}, "", nil},
+		"cluster_network": {"global", []string{"osd"}, "", nil},
+	}
+}
+// Instantiation of config table.
+var configTable = GetConfigTable()
+
+// Struct to get Config Items from config dump json output.
+type ConfigDump []struct{
+	Section string
+	Name    string
+	Value   string
+}
+
+func RestartCephDaemon(daemon string) error {
+	return snapReload(daemon)
+}
+
+func SetConfigItem(s common.StateInterface, c types.Config) error {
+	args := []string{
+		"config",
+		"set",
+		configTable[c.Key].Who,
+		c.Key,
+		c.Value,
+	}
+
+	_, err := processExec.RunCommand("ceph", args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetConfigItem(s common.StateInterface, c types.Config) (types.Config, error) {
+	var err error
+	args := []string{
+		"config",
+		"get",
+		configTable[c.Key].Who,
+		c.Key,
+	}
+
+	c.Value, err = processExec.RunCommand("ceph", args...)
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func RemoveConfigItem(s common.StateInterface, c types.Config) error {
+	args := []string{
+		"config",
+		"rm",
+		configTable[c.Key].Who,
+		c.Key,
+		"-f",
+		"json-pretty",
+	}
+
+	_, err := processExec.RunCommand("ceph", args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ListConfigs(s common.StateInterface, key string) (types.Configs, error) {
+	var dump ConfigDump
+	var configs types.Configs
+	args := []string{
+		"config",
+		"dump",
+		"-f",
+		"json-pretty",
+	}
+
+	output, err := processExec.RunCommand("ceph", args...)
+	if err != nil {
+		return configs, err
+	}
+
+	json.Unmarshal([]byte(output), &dump)
+	// Only take configs permitted in config table.
+	for _, configItem := range dump {
+		if configTable.isKeyPresent(configItem.Name) {
+			configs = append(configs, types.Config{
+				Key: configItem.Name,
+				Value:  configItem.Value,
+			})
+		}
+	}
+
+	return configs, nil
+}
 
 func updateConfig(s common.StateInterface) error {
 	confPath := filepath.Join(os.Getenv("SNAP_DATA"), "conf")

--- a/microceph/ceph/config_test.go
+++ b/microceph/ceph/config_test.go
@@ -1,0 +1,91 @@
+package ceph
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type configSuite struct {
+	baseSuite
+}
+
+func TestConfig(t *testing.T) {
+	suite.Run(t, new(configSuite))
+}
+
+// Set up test suite
+func (s *configSuite) SetupTest() {
+	s.baseSuite.SetupTest()
+}
+
+func addConfigSetExpectations(r *mocks.Runner, key string, value string) {
+	r.On("RunCommand", []interface{}{
+		"ceph", "config", "set", "global", key, value, "-f", "json-pretty",
+	}...).Return(value, nil).Once()
+}
+
+func addConfigOpExpectations(r *mocks.Runner, op string, key string, value string) {
+	r.On("RunCommand", []interface{}{
+		"ceph", "config", op, "global", key,
+	}...).Return(value, nil).Once()
+}
+
+func addListConfigExpectations(r *mocks.Runner, key string, value string) {
+	var configs = ConfigDump{}
+	configs = append(configs, ConfigDumpItem{Section: "", Name: key, Value: value})
+	ret, _ := json.Marshal(configs)
+	r.On("RunCommand", []interface{}{
+		"ceph", "config", "dump", "-f", "json-pretty",
+	}...).Return(string(ret[:]), nil).Once()
+}
+
+func (s *configSuite) TestSetConfig() {
+	t := types.Config{Key: "cluster_network", Value: "0.0.0.0/16"}
+
+	r := mocks.NewRunner(s.T())
+	addConfigSetExpectations(r, t.Key, t.Value)
+	processExec = r
+
+	err := SetConfigItem(t)
+	assert.NoError(s.T(), err)
+}
+
+func (s *configSuite) TestGetConfig() {
+	t := types.Config{Key: "cluster_network", Value: "0.0.0.0/16"}
+
+	r := mocks.NewRunner(s.T())
+	addConfigOpExpectations(r, "get", t.Key, t.Value)
+	processExec = r
+
+	_, err := GetConfigItem(t)
+	assert.NoError(s.T(), err)
+}
+
+func (s *configSuite) TestResetConfig() {
+	t := types.Config{Key: "cluster_network", Value: "0.0.0.0/16"}
+
+	r := mocks.NewRunner(s.T())
+	addConfigOpExpectations(r, "rm", t.Key, t.Value)
+	processExec = r
+
+	err := RemoveConfigItem(t)
+	assert.NoError(s.T(), err)
+}
+
+func (s *configSuite) TestListConfig() {
+	t := types.Config{Key: "cluster_network", Value: "0.0.0.0/16"}
+
+	r := mocks.NewRunner(s.T())
+	addListConfigExpectations(r, t.Key, t.Value)
+	processExec = r
+
+	configs, err := ListConfigs()
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), configs[0].Key, t.Key)
+	assert.Equal(s.T(), configs[0].Value, t.Value)
+}

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -366,7 +366,7 @@ func AddOSD(s *state.State, path string, wipe bool, encrypt bool) error {
 	}
 
 	// Spawn the OSD.
-	err = snapReload("osd")
+	err = snapRestart("osd", true)
 	if err != nil {
 		return err
 	}

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -5,11 +5,104 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/Rican7/retry"
+	"github.com/Rican7/retry/backoff"
+	"github.com/Rican7/retry/strategy"
 	"github.com/canonical/microcluster/state"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/database"
+	"github.com/tidwall/gjson"
 )
+
+type Set map[string]int
+
+func (sub Set) isIn(super Set) bool {
+	flag := true
+
+	// mark flag false if any key from subset is not present in superset.
+	for key := range sub {
+		_, ok := super[key]
+		if !ok {
+			flag = false
+			break // Break the loop.
+		}
+	}
+
+	return flag
+}
+
+// Table to map fetchFunc for workers (daemons) to a service.
+var serviceWorkerTable = map[string](func () (Set, error)) {
+	"osd": getUpOsds,
+	"mon": getMons,
+}
+
+func RestartCephService(service string) error {
+
+	if _, ok := serviceWorkerTable[service]; !ok {
+		return fmt.Errorf("No handler defined for service %s", service)
+	}
+
+	workers, err := serviceWorkerTable[service]()
+	if err != nil {
+		return err
+	}
+
+	// Reload the service.
+	snapReload(service)
+
+	err = retry.Retry(func(i uint) error {
+		iWorkers, err := serviceWorkerTable[service]()
+		if err != nil {
+			return err
+		}
+
+		// All still not up
+		if !workers.isIn(iWorkers) {
+			return fmt.Errorf(
+				"Attempt %d: Workers: %v not all present in %v", i, workers, iWorkers,
+			)
+		}
+		return nil
+	}, strategy.Delay(5), strategy.Limit(10), strategy.Backoff(backoff.Linear(5)))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getMons() (Set, error) {
+	var retval Set
+	output, err := processExec.RunCommand("ceph", "mon", "dump", "-f", "json-pretty")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get a list of mons.
+	mons := gjson.Get(output, "mons.#.name")
+	for _, key := range mons.Array() {
+		retval[key.String()] = 1
+	}
+
+	return retval, nil
+}
+
+func getUpOsds() (Set, error) {
+	var retval Set
+	output, err := processExec.RunCommand("ceph", "osd", "dump", "-f", "json-pretty")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get a list of uuid of osds in up state.
+	upOsds := gjson.Get(output, "osds.#(up==1)#.uuid")
+	for _, element := range upOsds.Array() {
+		retval[element.String()] = 1
+	}
+	return retval, nil
+}
 
 // ListServices retrieves a list of services from the database
 func ListServices(s *state.State) (types.Services, error) {

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -1,0 +1,73 @@
+package ceph
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/canonical/microceph/microceph/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type servicesSuite struct {
+	baseSuite
+	// TestStateInterface *mocks.StateInterface
+}
+
+func TestServices(t *testing.T) {
+	suite.Run(t, new(servicesSuite))
+}
+
+// Set up test suite
+func (s *servicesSuite) SetupTest() {
+	s.baseSuite.SetupTest()
+}
+
+func addOsdDumpExpectations(r *mocks.Runner) {
+	osdDumpObj := "{\"osds\":[{\"up\":1,\"uuid\":\"bfbbd27a-472f-4771-a6f7-7c5db9803d41\"}]}"
+	osdDump, _ := json.Marshal(osdDumpObj)
+
+	// Expect osd service worker query
+	r.On("RunCommand", []interface{}{
+		"ceph", "osd", "dump", "-f", "json-pretty",
+	}...).Return(string(osdDump[:]), nil).Twice()
+}
+
+func addMonDumpExpectations(r *mocks.Runner) {
+	monDumpObj := "{\"mons\":[{\"name\":\"bfbbd27a\"}]}"
+	monDump, _ := json.Marshal(monDumpObj)
+
+	// Expect mon service worker query
+	r.On("RunCommand", []interface{}{
+		"ceph", "mon", "dump", "-f", "json-pretty",
+	}...).Return(string(monDump[:]), nil).Twice()
+}
+
+func addServiceRestartExpectations(r *mocks.Runner, services []string) {
+	for _, service := range services {
+		r.On("RunCommand", []interface{}{
+			"snapctl", "restart", fmt.Sprintf("microceph.%s", service),
+		}...).Return("ok", nil).Once()
+	}
+}
+
+func (s *servicesSuite) TestRestartInvalidService() {
+	err := RestartCephService("InvalidService")
+	assert.ErrorContains(s.T(), err, "No handler defined")
+}
+
+func (s *servicesSuite) TestRestartServiceWorkerSuccess() {
+	ts := []string{"mon", "osd"} // test services
+
+	r := mocks.NewRunner(s.T())
+	addMonDumpExpectations(r)
+	addOsdDumpExpectations(r)
+	addServiceRestartExpectations(r, ts)
+	processExec = r
+
+	// Handler is defined for both mon and osd services.
+	err := RestartCephServices(ts)
+	assert.Equal(s.T(), err, nil)
+}
+

--- a/microceph/ceph/snap.go
+++ b/microceph/ceph/snap.go
@@ -42,13 +42,17 @@ func snapStop(service string, disable bool) error {
 	return nil
 }
 
-// snapReload restarts a service via snapctl.
-func snapReload(service string) error {
+// Restarts (optionally reloads) a service via snapctl.
+func snapRestart(service string, isReload bool) error {
 	args := []string{
 		"restart",
-		"--reload",
-		fmt.Sprintf("microceph.%s", service),
 	}
+
+	if isReload {
+		args = append(args, "--reload")
+	}
+
+	args = append(args, fmt.Sprintf("microceph.%s", service))
 
 	_, err := processExec.RunCommand("snapctl", args...)
 	if err != nil {

--- a/microceph/client/client.go
+++ b/microceph/client/client.go
@@ -4,13 +4,89 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/canonical/microcluster/client"
+	restTypes "github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
+	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/shared/api"
 
 	"github.com/canonical/microceph/microceph/api/types"
 )
+
+func SetConfig(ctx context.Context, c *client.Client, data *types.Config) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	err := c.Query(queryCtx, "PUT", api.NewURL().Path("configs"), data, nil)
+	if err != nil {
+		return fmt.Errorf("Failed setting cluster config: %w, Key: %s, Value: %s", err, data.Key, data.Value)
+	}
+
+	return nil
+}
+
+func ClearConfig(ctx context.Context, c *client.Client, data *types.Config) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	err := c.Query(queryCtx, "DELETE", api.NewURL().Path("configs"), data, nil)
+	if err != nil {
+		return fmt.Errorf("Failed clearing cluster config: %w, Key: %s", err, data.Key)
+	}
+
+	return nil
+}
+
+func GetConfig(ctx context.Context, c *client.Client, data *types.Config) (types.Configs, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	configs := types.Configs{}
+
+	err := c.Query(queryCtx, "GET", api.NewURL().Path("configs"), data, &configs)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch cluster config: %w, Key: %s", err, data.Key)
+	}
+
+	return configs, nil
+}
+
+// IsForwardedRequest determines if this request has been forwarded from another cluster member.
+func IsForwardedRequest(r *http.Request) bool {
+	return r.Header.Get("User-Agent") == request.UserAgentNotifier
+}
+
+func ForwardConfigRequestToClusterMembers(s *state.State, r *http.Request, data *types.Config, handle func(ctx context.Context, c *client.Client, data *types.Config) error) (error) {
+	// Get a collection of clients every other cluster member, with the notification user-agent set.
+	cluster, err := s.Cluster(r)
+	if err != nil {
+		return fmt.Errorf("Failed to get a client for every cluster member: %w", err)
+	}
+
+	err = cluster.Query(s.Context, true, func(ctx context.Context, c *client.Client) error {
+		addrPort, err := restTypes.ParseAddrPort(s.Address().URL.Host)
+		if err != nil {
+			return fmt.Errorf("Failed to parse addr:port of listen address %q: %w", s.Address().URL.Host, err)
+		}
+
+		// Asynchronously send a POST to each other cluster member.
+		err = handle(ctx, c, data)
+		if err != nil {
+			clientURL := c.URL()
+			return fmt.Errorf("Failed Forwarding To: %q, From: %s: %w", clientURL.String(), addrPort, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
 
 // AddDisk requests Ceph sets up a new OSD.
 func AddDisk(ctx context.Context, c *client.Client, data *types.DisksPost) error {

--- a/microceph/cmd/microceph/cluster.go
+++ b/microceph/cmd/microceph/cluster.go
@@ -38,6 +38,10 @@ func (c *cmdCluster) Command() *cobra.Command {
 	clusterSQLCmd := cmdClusterSQL{common: c.common, cluster: c}
 	cmd.AddCommand(clusterSQLCmd.Command())
 
+	// Config Subcommand
+	clusterConfigCmd := cmdClusterConfig{common: c.common, cluster: c}
+	cmd.AddCommand(clusterConfigCmd.Command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }

--- a/microceph/cmd/microceph/cluster_config.go
+++ b/microceph/cmd/microceph/cluster_config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +9,6 @@ type cmdClusterConfig struct {
 	cluster *cmdCluster
 }
 
-var allowList = ceph.GetConfigTable()
 func (c *cmdClusterConfig) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",

--- a/microceph/cmd/microceph/cluster_config.go
+++ b/microceph/cmd/microceph/cluster_config.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"github.com/canonical/microceph/microceph/ceph"
+	"github.com/spf13/cobra"
+)
+
+type cmdClusterConfig struct {
+	common  *CmdControl
+	cluster *cmdCluster
+}
+
+var allowList = ceph.GetConfigTable()
+func (c *cmdClusterConfig) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Ceph Cluster configs",
+	}
+
+	// Get
+	clusterConfigGetCmd := cmdClusterConfigGet{common: c.common, cluster: c.cluster, clusterConfig: c}
+	cmd.AddCommand(clusterConfigGetCmd.Command())
+
+	// Set
+	clusterConfigSetCmd := cmdClusterConfigSet{common: c.common, cluster: c.cluster, clusterConfig: c}
+	cmd.AddCommand(clusterConfigSetCmd.Command())
+
+	// Reset
+	clusterConfigResetCmd := cmdClusterConfigReset{common: c.common, cluster: c.cluster, clusterConfig: c}
+	cmd.AddCommand(clusterConfigResetCmd.Command())
+
+	// List
+	clusterConfigListCmd := cmdClusterConfigList{common: c.common, cluster: c.cluster, clusterConfig: c}
+	cmd.AddCommand(clusterConfigListCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+
+	return cmd
+}

--- a/microceph/cmd/microceph/cluster_config_get.go
+++ b/microceph/cmd/microceph/cluster_config_get.go
@@ -29,7 +29,7 @@ func (c *cmdClusterConfigGet) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigGet) Run(cmd *cobra.Command, args []string) error {
-	allowList := ceph.GetConfigTable()
+	allowList := ceph.GetConstConfigTable()
 
 	// Get can be called with a single key.
 	if len(args) != 1 {

--- a/microceph/cmd/microceph/cluster_config_get.go
+++ b/microceph/cmd/microceph/cluster_config_get.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/lxc/lxd/lxc/utils"
@@ -28,7 +29,9 @@ func (c *cmdClusterConfigGet) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigGet) Run(cmd *cobra.Command, args []string) error {
-	// Get can be called with a single key or without any key for all configs.
+	allowList := ceph.GetConfigTable()
+
+	// Get can be called with a single key.
 	if len(args) != 1 {
 		return cmd.Help()
 	}

--- a/microceph/cmd/microceph/cluster_config_get.go
+++ b/microceph/cmd/microceph/cluster_config_get.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/lxc/lxd/lxc/utils"
+	"github.com/spf13/cobra"
+)
+
+type cmdClusterConfigGet struct {
+	common  *CmdControl
+	cluster *cmdCluster
+	clusterConfig *cmdClusterConfig
+}
+
+func (c *cmdClusterConfigGet) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get specified Ceph Cluster config",
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdClusterConfigGet) Run(cmd *cobra.Command, args []string) error {
+	// Get can be called with a single key or without any key for all configs.
+	if len(args) != 1 {
+		return cmd.Help()
+	}
+
+	if _, ok := allowList[args[0]]; !ok {
+		return fmt.Errorf("Key %s is invalid. \nPermitted Keys: %v", args[0], allowList.Keys())
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return fmt.Errorf("Unable to configure MicroCeph: %w", err)
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	req := &types.Config{
+		Key: args[0],
+	}
+
+	configs, err := client.GetConfig(context.Background(), cli, req)
+	if err != nil {
+		return err
+	}
+
+	data := make([][]string, len(configs))
+	for i, config := range configs {
+		data[i] = []string{fmt.Sprintf("%d", i), config.Key, config.Value}
+	}
+
+	header := []string{"#", "Key", "Value"}
+	err = utils.RenderTable(utils.TableFormatTable, header, data, configs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/microceph/cmd/microceph/cluster_config_list.go
+++ b/microceph/cmd/microceph/cluster_config_list.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/lxc/lxd/lxc/utils"
+	"github.com/spf13/cobra"
+)
+
+type cmdClusterConfigList struct {
+	common  *CmdControl
+	cluster *cmdCluster
+	clusterConfig *cmdClusterConfig
+}
+
+func (c *cmdClusterConfigList) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all set Ceph level configs",
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdClusterConfigList) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return fmt.Errorf("Unable to configure MicroCeph: %w", err)
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	// Create an empty Key request.
+	req := &types.Config{
+		Key: "",
+	}
+
+	configs, err := client.GetConfig(context.Background(), cli, req)
+	if err != nil {
+		return err
+	}
+
+	data := make([][]string, len(configs))
+	for i, config := range configs {
+		data[i] = []string{fmt.Sprintf("%d", i), config.Key, config.Value}
+	}
+
+	header := []string{"#", "Key", "Value"}
+	err = utils.RenderTable(utils.TableFormatTable, header, data, configs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/microceph/cmd/microceph/cluster_config_reset.go
+++ b/microceph/cmd/microceph/cluster_config_reset.go
@@ -31,7 +31,7 @@ func (c *cmdClusterConfigReset) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigReset) Run(cmd *cobra.Command, args []string) error {
-	allowList := ceph.GetConfigTable()
+	allowList := ceph.GetConstConfigTable()
 	if len(args) != 1 {
 		return cmd.Help()
 	}

--- a/microceph/cmd/microceph/cluster_config_reset.go
+++ b/microceph/cmd/microceph/cluster_config_reset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
@@ -27,6 +28,7 @@ func (c *cmdClusterConfigReset) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigReset) Run(cmd *cobra.Command, args []string) error {
+	allowList := ceph.GetConfigTable()
 	if len(args) != 1 {
 		return cmd.Help()
 	}

--- a/microceph/cmd/microceph/cluster_config_reset.go
+++ b/microceph/cmd/microceph/cluster_config_reset.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+)
+
+type cmdClusterConfigReset struct {
+	common  *CmdControl
+	cluster *cmdCluster
+	clusterConfig *cmdClusterConfig
+}
+
+func (c *cmdClusterConfigReset) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset <key>",
+		Short: "Clear specified Ceph Cluster config",
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdClusterConfigReset) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmd.Help()
+	}
+
+	if _, ok := allowList[args[0]]; !ok {
+		return fmt.Errorf("Resetting key %s is not allowed", args[0])
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return fmt.Errorf("Unable to configure MicroCeph: %w", err)
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	req := &types.Config{
+		Key: args[0],
+	}
+
+	err = client.ClearConfig(context.Background(), cli, req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/microceph/cmd/microceph/cluster_config_reset.go
+++ b/microceph/cmd/microceph/cluster_config_reset.go
@@ -15,6 +15,8 @@ type cmdClusterConfigReset struct {
 	common  *CmdControl
 	cluster *cmdCluster
 	clusterConfig *cmdClusterConfig
+
+	flagWait bool
 }
 
 func (c *cmdClusterConfigReset) Command() *cobra.Command {
@@ -24,6 +26,7 @@ func (c *cmdClusterConfigReset) Command() *cobra.Command {
 		RunE: c.Run,
 	}
 
+	cmd.Flags().BoolVar(&c.flagWait, "wait", false, "Wait for required ceph services to restart post config reset.")
 	return cmd
 }
 
@@ -49,6 +52,7 @@ func (c *cmdClusterConfigReset) Run(cmd *cobra.Command, args []string) error {
 
 	req := &types.Config{
 		Key: args[0],
+		Wait: c.flagWait,
 	}
 
 	err = client.ClearConfig(context.Background(), cli, req)

--- a/microceph/cmd/microceph/cluster_config_set.go
+++ b/microceph/cmd/microceph/cluster_config_set.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+)
+
+type cmdClusterConfigSet struct {
+	common  *CmdControl
+	cluster *cmdCluster
+	clusterConfig *cmdClusterConfig
+}
+
+func (c *cmdClusterConfigSet) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <Key> <Value>",
+		Short: "Set specified Ceph Cluster config",
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return cmd.Help()
+	}
+
+	if _, ok := allowList[args[0]]; !ok {
+		return fmt.Errorf("Configuring key %s is not allowed. \nPermitted Keys: %v", args[0], allowList.Keys())
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return fmt.Errorf("Unable to configure MicroCeph: %w", err)
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	req := &types.Config{
+		Key: args[0],
+		Value: args[1],
+	}
+
+	err = client.SetConfig(context.Background(), cli, req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/microceph/cmd/microceph/cluster_config_set.go
+++ b/microceph/cmd/microceph/cluster_config_set.go
@@ -15,6 +15,8 @@ type cmdClusterConfigSet struct {
 	common  *CmdControl
 	cluster *cmdCluster
 	clusterConfig *cmdClusterConfig
+
+	flagWait bool
 }
 
 func (c *cmdClusterConfigSet) Command() *cobra.Command {
@@ -24,6 +26,7 @@ func (c *cmdClusterConfigSet) Command() *cobra.Command {
 		RunE: c.Run,
 	}
 
+	cmd.Flags().BoolVar(&c.flagWait, "wait", false, "Wait for required ceph services to restart post config set.")
 	return cmd
 }
 
@@ -50,6 +53,7 @@ func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
 	req := &types.Config{
 		Key: args[0],
 		Value: args[1],
+		Wait: c.flagWait,
 	}
 
 	err = client.SetConfig(context.Background(), cli, req)

--- a/microceph/cmd/microceph/cluster_config_set.go
+++ b/microceph/cmd/microceph/cluster_config_set.go
@@ -31,7 +31,7 @@ func (c *cmdClusterConfigSet) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
-	allowList := ceph.GetConfigTable()
+	allowList := ceph.GetConstConfigTable()
 	if len(args) != 2 {
 		return cmd.Help()
 	}

--- a/microceph/cmd/microceph/cluster_config_set.go
+++ b/microceph/cmd/microceph/cluster_config_set.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
@@ -27,6 +28,7 @@ func (c *cmdClusterConfigSet) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
+	allowList := ceph.GetConfigTable()
 	if len(args) != 2 {
 		return cmd.Help()
 	}

--- a/microceph/go.mod
+++ b/microceph/go.mod
@@ -5,14 +5,15 @@ go 1.18
 require (
 	github.com/canonical/microcluster v0.0.0-20230501200316-dd78e864d2f1
 	github.com/lxc/lxd v0.0.0-20230501200206-976cd2bfee6a
+	github.com/Rican7/retry v0.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pborman/uuid v1.2.1
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
+	github.com/tidwall/gjson v1.14.4
 )
 
 require (
-	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a // indirect
 	github.com/canonical/go-dqlite v1.11.9 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -51,6 +52,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/zitadel/oidc/v2 v2.5.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/microceph/go.sum
+++ b/microceph/go.sum
@@ -325,6 +325,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Added command
```microceph cluster config set/get/reset/list```
for managing configs (currently limited to cluster_network and public_network)