### PR TITLE
add rados command to microceph

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -100,6 +100,10 @@ apps:
     command: commands/rbd
     plugs:
       - network
+  rados:
+    command: commands/rados
+    plugs:
+      - network
 
 parts:
   ceph:
@@ -127,6 +131,7 @@ parts:
       - bin/ceph-osd
       - bin/monmaptool
       - bin/rbd
+      - bin/rados
       - bin/radosgw
       - bin/radosgw-admin
       - lib/*/ceph
@@ -160,6 +165,7 @@ parts:
       - lib/*/librabbitmq.so*
       - lib/*/librados.so*
       - lib/*/libradosgw.so*
+      - lib/*/libradosstriper.so.*
       - lib/*/librbd.so*
       - lib/*/librdmacm.so*
       - lib/*/libroken.so*

--- a/snapcraft/commands/rados
+++ b/snapcraft/commands/rados
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "${SNAP}/bin/rados" "$@"


### PR DESCRIPTION
Add microceph.rados command as part of snapcraft.

rados utility is used in some of the ceph libraries like [1] and so expose the utility as part of microceph.

[1] https://github.com/juju/charm-helpers