### PR TITLE
Add checks for dmcrypt intf connection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           sudo snap install --dangerous microceph_*.snap
           sudo snap connect microceph:block-devices
           sudo snap connect microceph:hardware-observe
-          sudo snap connect microceph:dm-crypt
+          # defer dm-crypt enablement for later.
 
           # Daemon needs restart for the added dm-crypt connection
           sudo snap restart microceph.daemon
@@ -57,9 +57,26 @@ jobs:
           sudo microceph.ceph osd crush rule rm replicated_rule
           sudo microceph.ceph osd crush rule create-replicated single default osd
 
+      - name: Add OSD with failure
+        run: |
+          set -eux
+          loop_file="$(sudo mktemp -p /mnt XXXX.img)"
+          sudo truncate -s 1G "${loop_file}"
+          loop_dev="$(sudo losetup --show -f "${loop_file}")"
+
+          minor="${loop_dev##/dev/loop}"
+          sudo mknod -m 0660 "/dev/sdi21" b 7 "${minor}"
+
+          set +e
+          sudo microceph disk add --wipe "/dev/sdi21" --encrypt || rc="$?"
+          if [[ $rc -eq 0 ]] ; then echo "FDE should fail without dmcrypt: $rc"; exit 1; fi
+
       - name: Add OSDs
         run: |
           set -eux
+          # Enable dm-crypt connection and restart microceph daemon
+          sudo snap connect microceph:dm-crypt
+          sudo snap restart microceph.daemon
           # Add OSDs backed by loop devices on /mnt (ephemeral "large" disk attached to GitHub action runners)
           i=0
           for l in a b c; do

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -193,6 +193,12 @@ func checkEncryptSupport() error {
 		return fmt.Errorf("Missing /dev/mapper/control: %w", err)
 	}
 
+	// Check if the dm-crypt interface is not connected.
+	if !isIntfConnected("dm-crypt") {
+		helper := fmt.Sprint("Use \"sudo snap connect microceph:dm-crypt\" to enable encryption.")
+		return fmt.Errorf("dm-crypt interface connection missing: \n%s", helper)
+	}
+
 	// Check if we have the dm_crypt module
 	inf, err := os.Stat("/sys/module/dm_crypt")
 	if err != nil || inf == nil || !inf.IsDir() {

--- a/microceph/ceph/snap.go
+++ b/microceph/ceph/snap.go
@@ -2,7 +2,26 @@ package ceph
 
 import (
 	"fmt"
+
+	"github.com/lxc/lxd/shared/logger"
 )
+
+// Check if a snapd interface is connected to microceph
+func isIntfConnected(name string) bool {
+	args := []string{
+		"is-connected",
+		name,
+	}
+
+	_, err := processExec.RunCommand("snapctl", args...)
+	if err != nil { // Non-zero return code when connection not present.
+		logger.Errorf("Failure: check is-connected %s: %v", name, err)
+		return false
+	}
+
+	// 0 return code when connection is present
+	return true
+}
 
 // snapStart starts a service via snapctl, optionally enabling it.
 func snapStart(service string, enable bool) error {


### PR DESCRIPTION
```
ubuntu@bastion:~$ sudo microceph disk add  /dev/disk/by-id/virtio-d15384b1-7159-4a91-a --wipe --encrypt
Error: Failed adding new disk: Encryption unsupported on this machine: Missing dm_crypt module: stat /sys/module/dm_crypt: no such file or directory
Use "sudo snap connect microceph:dm-crypt" to enable disk encryption.
```