### PR TITLE
Add content-interface for ceph config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,11 @@ jobs:
           sudo microceph.ceph version
           sudo microceph.ceph status
 
+          # Verify metadata.yaml
+          meta=/var/snap/microceph/current/conf/metadata.yaml
+          cat $meta
+          grep -q ceph-version $meta
+
           # Allow ceph to notice no OSD are present
           sleep 30
           sudo microceph.ceph status

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -uex
+conf="${SNAP_DATA}/conf"
+mkdir -p -m 0755 "${conf}"
+cp "${SNAP}/share/metadata.yaml" "${conf}"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,1 @@
+install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,13 @@ description: |-
 
 confinement: strict
 
+slots:
+  ceph-conf:
+    interface: content
+    source:
+      read:
+        - "$SNAP_DATA/conf"
+
 environment:
   LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/compressor:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/crypto:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/erasure-code
   PYTHONPATH: $SNAP/lib/python3/dist-packages
@@ -112,6 +119,18 @@ apps:
 parts:
   ceph:
     plugin: nil
+    override-prime: |
+      snapcraftctl prime
+      pkg_version=$(
+            dpkg-deb -f \
+            $CRAFT_PART_SRC/../stage_packages/ceph-common*.deb Version)
+      git_version=$(
+            git -C $CRAFT_PROJECT_DIR describe \
+                --always \
+                --dirty \
+                --tags \
+                --abbrev=10 | sed -s 's/^v//')
+      printf "ceph-version: ${pkg_version}\nmicroceph-git: ${git_version}\n" > share/metadata.yaml
     stage-packages:
       - ceph-common
       - ceph-mds


### PR DESCRIPTION
This content-interface exposes ceph configuration, creds and metadata to enable deep integration with a MicroCeph cluster