### PR TITLE
Fix: remove automatic crush rule on upgrading

### DIFF
--- a/microceph/ceph/crush.go
+++ b/microceph/ceph/crush.go
@@ -70,6 +70,12 @@ func getCrushRuleID(name string) (string, error) {
 func getPoolsForDomain(domain string) ([]string, error) {
 	var pools []string
 
+	// check if the crush rule exists and bail if not
+	if !haveCrushRule(fmt.Sprintf("microceph_auto_%s", domain)) {
+		// nothing to do, bail
+		return pools, nil
+	}
+
 	ruleID, err := getCrushRuleID(fmt.Sprintf("microceph_auto_%s", domain))
 	if err != nil {
 		return nil, err

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -249,6 +249,11 @@ func updateFailureDomain(s *state.State) error {
 		if err != nil {
 			return fmt.Errorf("Failed to set host failure domain: %w", err)
 		}
+		err := removeCrushRule("microceph_auto_osd")
+		if err != nil {
+			return fmt.Errorf("Failed to remove microceph_auto_osd rule: %w", err)
+		}
+
 	}
 	return nil
 }

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -23,7 +23,7 @@ func TestOSD(t *testing.T) {
 
 // Expect: run ceph osd crush rule ls
 func addCrushRuleLsExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 4)...).Return("ok", nil).Once()
+	r.On("RunCommand", cmdAny("ceph", 4)...).Return("microceph_auto_osd", nil).Once()
 }
 
 // Expect: run ceph osd crush rule create-replicated
@@ -52,6 +52,11 @@ func addOsdPoolSetExpectations(r *mocks.Runner) {
 	r.On("RunCommand", cmdAny("ceph", 6)...).Return("ok", nil).Once()
 }
 
+// Expect: run ceph osd crush rule rm
+func addCrushRuleRmExpectations(r *mocks.Runner) {
+	r.On("RunCommand", cmdAny("ceph", 5)...).Return("ok", nil).Once()
+}
+
 func (s *osdSuite) SetupTest() {
 
 	s.baseSuite.SetupTest()
@@ -62,10 +67,15 @@ func (s *osdSuite) SetupTest() {
 // TestSetHostFailureDomain tests the setHostFailureDomain function
 func (s *osdSuite) TestSetHostFailureDomain() {
 	r := mocks.NewRunner(s.T())
+	// list and create crush rule
 	addCrushRuleLsExpectations(r)
 	addCrushRuleCreateExpectations(r)
+	// list and dump crush rule
+	addCrushRuleLsExpectations(r)
 	addCrushRuleDumpExpectations(r)
+	// list crush rule json
 	addCrushRuleLsJsonExpectations(r)
+	// set osd pool
 	addOsdPoolSetExpectations(r)
 
 	processExec = r
@@ -88,11 +98,19 @@ func (s *osdSuite) TestUpdateFailureDomain() {
 	}
 
 	r := mocks.NewRunner(s.T())
+	// list and create crush rule
 	addCrushRuleLsExpectations(r)
 	addCrushRuleCreateExpectations(r)
+	// list and dump crush rule
+	addCrushRuleLsExpectations(r)
 	addCrushRuleDumpExpectations(r)
+	// list crush rule json
 	addCrushRuleLsJsonExpectations(r)
+	// set osd pool
 	addOsdPoolSetExpectations(r)
+	// remove crush rule
+	addCrushRuleRmExpectations(r)
+
 	processExec = r
 
 	c := mocks.NewMemberCounterInterface(s.T())


### PR DESCRIPTION
Remove the osd rule to ensure new pools get the upgraded crush rule