### PR TITLE
Migrate auto services

### DIFF
--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -7,4 +7,4 @@ These how-to guides will cover key operations and processes in Microceph.
    :maxdepth: 1
 
    cluster-cfg
-
+   service-migration

--- a/docs/how-to/service-migration.rst
+++ b/docs/how-to/service-migration.rst
@@ -1,0 +1,24 @@
+Migrate Automatic Services Between Nodes
+========================================
+
+MicroCeph automatically deploys required services for Ceph (MON, MDS and MGRs). Sometimes, e.g. for maintenance reasons, it can be useful to move those automatic services from one node to another.
+
+This is the purpose of the `microceph cluster migrate` command. It will enable automatic services on a target node and disable them on the source node.
+
+  .. code-block:: shell
+
+     $ sudo microceph cluster migrate <src> <dst>
+
+Both `<src>` and `<dst>` should be node names and are required parameters.
+
+Note:
+
+- it's not possible (and not useful) to have more than one instance of automatic services on one node.
+- RGW services are not automatic; they are always enabled and disabled specifically on a node.
+
+Use the `microceph status` command to verify distribution of services among nodes.
+
+
+
+
+

--- a/microceph/ceph/monitor.go
+++ b/microceph/ceph/monitor.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/lxd/shared/logger"
 	"os"
 	"path/filepath"
 )
@@ -74,4 +75,14 @@ func joinMon(hostname string, path string) error {
 	}
 
 	return bootstrapMon(hostname, path, monmap, keyring)
+}
+
+// removeMon removes a monitor from the cluster.
+func removeMon(hostname string) error {
+	_, err := cephRun("mon", "rm", hostname)
+	if err != nil {
+		logger.Errorf("failed to remove monitor %q: %v", hostname, err)
+		return fmt.Errorf("failed to remove monitor %q: %w", hostname, err)
+	}
+	return nil
 }

--- a/microceph/ceph/rgw.go
+++ b/microceph/ceph/rgw.go
@@ -57,7 +57,7 @@ func DisableRGW(s common.StateInterface) error {
 		return fmt.Errorf("Failed to stop RGW service: %w", err)
 	}
 
-	err = rgwRemoveServiceDatabase(s)
+	err = removeServiceDatabase(s, "rgw")
 	if err != nil {
 		return err
 	}
@@ -94,24 +94,6 @@ func rgwCreateServiceDatabase(s common.StateInterface) error {
 		_, err := database.CreateService(ctx, tx, database.Service{Member: s.ClusterState().Name(), Service: "rgw"})
 		if err != nil {
 			return fmt.Errorf("Failed to record role: %w", err)
-		}
-
-		return nil
-	})
-	return err
-}
-
-// rgwRemoveServiceDatabase removes a rgw service record from the database.
-func rgwRemoveServiceDatabase(s common.StateInterface) error {
-	if s.ClusterState().Database == nil {
-		return fmt.Errorf("no database")
-	}
-
-	err := s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
-		// Remove the service.
-		err := database.DeleteService(ctx, tx, s.ClusterState().Name(), "rgw")
-		if err != nil {
-			return fmt.Errorf("Failed to remove role: %w", err)
 		}
 
 		return nil

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -3,6 +3,8 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/mocks"
@@ -69,4 +71,13 @@ func (s *servicesSuite) TestRestartServiceWorkerSuccess() {
 	// Handler is defined for both mon and osd services.
 	err := RestartCephServices(ts)
 	assert.Equal(s.T(), err, nil)
+}
+
+// TestCleanService tests the cleanService function.
+func (s *servicesSuite) TestCleanService() {
+	s.copyCephConfigs()
+	svcPath := filepath.Join(s.tmp, "SNAP_COMMON", "data", "mon", "ceph-foo-host")
+	os.MkdirAll(svcPath, 0770)
+	cleanService("foo-host", "mon")
+	assert.NoDirExists(s.T(), svcPath)
 }

--- a/microceph/client/services.go
+++ b/microceph/client/services.go
@@ -28,13 +28,17 @@ func GetServices(ctx context.Context, c *client.Client) (types.Services, error) 
 	return services, nil
 }
 
-// DisableRGW requests Ceph configures the RGW service.
-func DisableRGW(ctx context.Context, c *client.Client, data *types.RGWService) error {
+// DeleteService requests MicroCeph deconfigures a service on a given target node.
+func DeleteService(ctx context.Context, c *client.Client, target string, service string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
 	defer cancel()
-	err := c.Query(queryCtx, "DELETE", api.NewURL().Path("services", "rgw"), data, nil)
+
+	// Send this request to target.
+	c = c.UseTarget(target)
+
+	err := c.Query(queryCtx, "DELETE", api.NewURL().Path("services", service), nil, nil)
 	if err != nil {
-		return fmt.Errorf("failed disabling RGW: %w", err)
+		return fmt.Errorf("failed disabling service %s: %w", service, err)
 	}
 
 	return nil

--- a/microceph/cmd/microceph/cluster.go
+++ b/microceph/cmd/microceph/cluster.go
@@ -42,6 +42,10 @@ func (c *cmdCluster) Command() *cobra.Command {
 	clusterConfigCmd := cmdClusterConfig{common: c.common, cluster: c}
 	cmd.AddCommand(clusterConfigCmd.Command())
 
+	// Migrate Subcommand
+	clusterMigrateCmd := cmdClusterMigrate{common: c.common, cluster: c}
+	cmd.AddCommand(clusterMigrateCmd.Command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }

--- a/microceph/cmd/microceph/cluster_migrate.go
+++ b/microceph/cmd/microceph/cluster_migrate.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+)
+
+type cmdClusterMigrate struct {
+	common  *CmdControl
+	cluster *cmdCluster
+}
+
+func (c *cmdClusterMigrate) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate <SRC> <DST",
+		Short: "Migrate automatic services from one node to another",
+		RunE:  c.Run,
+	}
+	return cmd
+}
+
+func (c *cmdClusterMigrate) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	autoServices := []string{"mds", "mgr", "mon"}
+	// Enable auto services on dst node
+	req := &types.EnableService{
+		Wait:    true,
+		Payload: "",
+	}
+	for _, service := range autoServices {
+		req.Name = service
+		logger.Infof("Enabling %s on %s", service, args[1])
+		err = client.SendServicePlacementReq(context.Background(), cli, req, args[1])
+		if err != nil {
+			logger.Errorf("Failed to enable %s on %s, bailing: %v", service, args[1], err)
+			return err
+		}
+	}
+
+	// Disable auto services on src node
+	for _, service := range autoServices {
+		req.Name = service
+		logger.Infof("Disabling %s on %s", service, args[0])
+		err = client.DeleteService(context.Background(), cli, args[0], service)
+		if err != nil {
+			logger.Errorf("Failed to disable %s on %s, bailing: %v", service, args[0], err)
+			return err
+		}
+	}
+
+	return nil
+
+}

--- a/microceph/cmd/microceph/disable_rgw.go
+++ b/microceph/cmd/microceph/disable_rgw.go
@@ -6,7 +6,6 @@ import (
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 
-	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
 )
 
@@ -37,13 +36,8 @@ func (c *cmdDisableRGW) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cli = cli.UseTarget(c.flagTarget)
 
-	req := &types.RGWService{
-		Enabled: false,
-	}
-
-	err = client.DisableRGW(context.Background(), cli, req)
+	err = client.DeleteService(context.Background(), cli, c.flagTarget, "rgw")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Implement a new command that migrates automatic services (mon, mgr,
mds) from a source to a dest node.

Manual testing:

```
ubuntu@bc-0:~$ sudo microceph status
MicroCeph deployment summary:
- bc-0 (10.0.8.6)
  Services: mds, mgr, mon, rgw, osd
  Disks: 1
- bc-1 (10.0.8.65)
  Services: osd
  Disks: 1
- bc-2 (10.0.8.106)
  Services: mds, mgr, mon, osd
  Disks: 1
- bc-3 (10.0.8.107)
  Services: mds, mgr, mon
  Disks: 0
ubuntu@bc-0:~$ sudo microceph cluster migrate bc-0 bc-1
ubuntu@bc-0:~$ sudo microceph status
MicroCeph deployment summary:
- bc-0 (10.0.8.6)
  Services: rgw, osd
  Disks: 1
- bc-1 (10.0.8.65)
  Services: mds, mgr, mon, osd
  Disks: 1
- bc-2 (10.0.8.106)
  Services: mds, mgr, mon, osd
  Disks: 1
- bc-3 (10.0.8.107)
  Services: mds, mgr, mon
  Disks: 0
ubuntu@bc-0:~$ sudo microceph.ceph -s
  cluster:
    id:     3c074278-0190-4d1b-818e-4148016f247b
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum bc-2,bc-3,bc-1 (age 39m)
    mgr: bc-2(active, since 38m), standbys: bc-3, bc-1
    osd: 3 osds: 3 up (since 12h), 3 in (since 23h)
    rgw: 1 daemon active (1 hosts, 1 zones)
 
  data:
    pools:   5 pools, 129 pgs
    objects: 223 objects, 581 KiB
    usage:   184 MiB used, 11 GiB / 11 GiB avail
    pgs:     129 active+clean

```