### PR TITLE
Doc: use ceph alias

### DIFF
--- a/docs/tutorial/add_osds.rst
+++ b/docs/tutorial/add_osds.rst
@@ -11,7 +11,7 @@ Your ceph status should now show three OSDs as well:
 
 .. code-block:: shell
 
-    $ lxc exec microceph-1 microceph.ceph status
+    $ lxc exec microceph-1 ceph status
     cluster:
         id:     a95eaf13-c3fe-466a-8278-d92186effbec
         health: HEALTH_OK

--- a/docs/tutorial/initial_setup.rst
+++ b/docs/tutorial/initial_setup.rst
@@ -26,7 +26,7 @@ You should now have a Ceph monitor cluster with quorum:
 
 .. code-block:: shell
 
-    $ lxc exec microceph-1 microceph.ceph status
+    $ lxc exec microceph-1 ceph status
     cluster:
         id:     a95eaf13-c3fe-466a-8278-d92186effbec
         health: HEALTH_WARN

--- a/docs/tutorial/update.rst
+++ b/docs/tutorial/update.rst
@@ -24,7 +24,7 @@ In order to do so, we run the following command on one of the nodes:
 
 .. code-block:: shell
 
-    microceph.ceph status
+    ceph status
 
 The output should be something like the following:
 
@@ -58,7 +58,7 @@ The order in which we run the commands is important. It should be as follows:
 2. Monitors (mon)
 3. All other entities (osd, rgw, etc.)
 
-The output of the 'microceph.ceph status' command should provide us with the hostnames of the mons and managers ('microceph-1' et al in this example).
+The output of the 'ceph status' command should provide us with the hostnames of the mons and managers ('microceph-1' et al in this example).
 
 At present time, managers and monitors reside on the same nodes, but that may not always be the case.
 


### PR DESCRIPTION
MicroCeph has been granted aliases for ceph commands, update the docs to reflect this.