### PR TITLE
Allow access to $HOME for the ceph command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -97,6 +97,7 @@ apps:
     command: commands/ceph
     plugs:
       - network
+      - home
   "radosgw-admin":
     command: commands/radosgw-admin
     plugs:


### PR DESCRIPTION
For reading certificates, dumping crushmaps and similar operations