### PR TITLE
Use appropriate {public,cluster}_network examples

### DIFF
--- a/docs/how-to/cluster-cfg.rst
+++ b/docs/how-to/cluster-cfg.rst
@@ -18,44 +18,43 @@ The microceph cluster configuration CLI supports setting, getting, resetting and
 
   .. code-block:: shell
 
-    $ sudo microceph cluster config set cluster_network 10.5.2.165/16
+    $ sudo microceph cluster config set cluster_network 10.5.0.0/16
 
 2. Config value for a particular key could be queried using the 'get' command:
 
   .. code-block:: shell
 
     $ sudo microceph cluster config get cluster_network
-    +---+-----------------+---------------+
-    | # |       KEY       |     VALUE     |
-    +---+-----------------+---------------+
-    | 0 | cluster_network | 10.5.2.165/16 |
-    +---+-----------------+---------------+
+    +---+-----------------+-------------+
+    | # |       KEY       |     VALUE   |
+    +---+-----------------+-------------+
+    | 0 | cluster_network | 10.5.0.0/16 |
+    +---+-----------------+-------------+
 
 3. A list of all the configured keys can be fetched using the 'list' command:
 
   .. code-block:: shell
 
-    $ sudo microceph cluster config set public_network 10.5.2.165/16
+    $ sudo microceph cluster config set public_network 10.5.0.0/16
     $ sudo microceph cluster config list
-    +---+-----------------+---------------+
-    | # |       KEY       |     VALUE     |
-    +---+-----------------+---------------+
-    | 0 | cluster_network | 10.5.2.165/16 |
-    +---+-----------------+---------------+
-    | 1 | public_network  | 10.5.2.165/16 |
-    +---+-----------------+---------------+
+    +---+-----------------+-------------+
+    | # |       KEY       |     VALUE   |
+    +---+-----------------+-------------+
+    | 0 | cluster_network | 10.5.0.0/16 |
+    +---+-----------------+-------------+
+    | 1 | public_network  | 10.5.0.0/16 |
+    +---+-----------------+-------------+
 
 4. Resetting a config key (i.e. setting the key to its default value) can performed using the 'reset' command:
 
   .. code-block:: shell
 
+   $ sudo microceph cluster config reset cluster_network
    $ sudo microceph cluster config reset public_network
    $ sudo microceph cluster config list
-   +---+-----------------+---------------+
-   | # |       KEY       |     VALUE     |
-   +---+-----------------+---------------+
-   | 0 | cluster_network | 10.5.2.165/16 |
-   +---+-----------------+---------------+
+   +---+-----+-------+
+   | # | KEY | VALUE |
+   +---+-----+-------+
 
 For more explanations and implementation details refer to `explanation <../../explanation/cluster-cfg/>`_
 


### PR DESCRIPTION
{public,cluster}_network values passed to microceph will be written to the Ceph config database as {public,cluster}_network as is. That means the values are used as cluster wide setting instead of per-node config.

According to the upstream configuration reference[1], the previous example doesn't make sense as 10.5.2.165 looks like a real IP address of a node instead of a network address. Let's use a network address and be clearer about the reset step too.

```
$ sudo microceph cluster config set cluster_network 192.168.102.0/24

$ sudo microceph.ceph config dump
WHO     MASK  LEVEL     OPTION           VALUE             RO
global        advanced  cluster_network  192.168.102.0/24  *
```

[1] https://docs.ceph.com/en/latest/rados/configuration/network-config-ref/#confval-cluster_network