### PR TITLE
Update /conf file permissions

### DIFF
--- a/microceph/ceph/configwriter.go
+++ b/microceph/ceph/configwriter.go
@@ -26,7 +26,8 @@ func (c *Config) GetPath() string {
 
 // WriteConfig writes the configuration file given a data bag
 func (c *Config) WriteConfig(data map[string]any) error {
-	fd, err := os.OpenFile(c.GetPath(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0644)
+	mode := int(0640) // rw: user, r: group, others: none.
+	fd, err := os.OpenFile(c.GetPath(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, os.FileMode(mode))
 	if err != nil {
 		return fmt.Errorf("Couldn't write %s: %w", c.configFile, err)
 	}

--- a/microceph/ceph/testutils.go
+++ b/microceph/ceph/testutils.go
@@ -84,7 +84,7 @@ func copyTestConf(dir string, conf string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Join(dir, "SNAP_DATA", "conf", conf), source, 0644)
+	err = os.WriteFile(filepath.Join(dir, "SNAP_DATA", "conf", conf), source, 0640)
 	if err != nil {
 		return err
 	}

--- a/microceph/common/constants.go
+++ b/microceph/common/constants.go
@@ -27,7 +27,7 @@ func GetPathConst() PathConst {
 func GetPathFileMode() PathFileMode {
 	pathConsts := GetPathConst()
 	return PathFileMode{
-		pathConsts.ConfPath: 0755,
+		pathConsts.ConfPath: 0750,
 		pathConsts.RunPath:  0700,
 		pathConsts.DataPath: 0700,
 		pathConsts.LogPath:  0700,


### PR DESCRIPTION
```
$ cd /var/snap/microceph/current/conf/
$ whoami
ubuntu
$ ll
total 24
drwxr-xr-x 2 root root 4096 Aug 29 08:43 ./
drwxr-xr-x 4 root root 4096 Aug 29 08:43 ../
-rw------- 1 root root  151 Aug 29 08:43 ceph.client.admin.keyring
-rw-r----- 1 root root  263 Aug 29 08:44 ceph.conf
-rw-r----- 1 root root  102 Aug 29 08:44 ceph.keyring
-rw-r--r-- 1 root root   64 Aug 29 08:43 metadata.yaml
$ cat ceph.keyring 
cat: ceph.keyring: Permission denied
$ cat ceph.conf 
cat: ceph.conf: Permission denied
$ cat ceph.client.admin.keyring 
cat: ceph.client.admin.keyring: Permission denied
$ sudo cat ceph.keyring 
# Generated by MicroCeph, DO NOT EDIT.
[client.admin]
	key = AQCyr+1kE9cxChAA8A5pVgteASeXh24Hi796Sw==
```