### PR TITLE
Fix: add the ceph-conf helper

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -153,6 +153,7 @@ parts:
       - bin/ceph-mgr
       - bin/ceph-mon
       - bin/ceph-osd
+      - bin/ceph-conf
       - bin/monmaptool
       - bin/rbd
       - bin/rados


### PR DESCRIPTION
Needed by e.g. `ceph daemon`