### PR TITLE
Doc: need to restart microceph.daemon after dm-crypt conn

### DIFF
--- a/docs/explanation/fde-osd.rst
+++ b/docs/explanation/fde-osd.rst
@@ -26,7 +26,7 @@ Prerequisites
 To use FDE, the following prerequisites must be met:
 
 - The `dm-crypt` kernel module must be available. Note that some cloud-optimized kernels do not ship dm-crypt by default. Check by running `sudo modinfo dm-crypt`
-- The snap dm-crypt plug has to be connected: `sudo snap connect microceph:dm-crypt`
+- The snap dm-crypt plug has to be connected, and the microceph.daemon subsequently restarted: `sudo snap connect microceph:dm-crypt ; sudo snap restart microceph.daemon`
 - The installed snapd daemon version must be >= 2.59.1
 
 


### PR DESCRIPTION
This is a stop gap measure for #190. There is an issue to track this at https://bugs.launchpad.net/snapd/+bug/2034585 . For a more permanent workaround we could alternatively also restart microceph.daemon in an interface hook after dm-crypt connection, however it'd be preferable to fix this in snapd so as to avoid API interruptions.