### PR TITLE
Doc fix: loopback device

### DIFF
--- a/docs/tutorial/single-node.rst
+++ b/docs/tutorial/single-node.rst
@@ -13,7 +13,7 @@ three entire disks are required to be available on the machine.
 
 .. note::
 
-   Upstream Ceph development is underway to allow for loopback device support.
+   Development is underway to allow for loopback device support.
    This will filter down to MicroCeph which will allow for easier
    proof-of-concept and developer deployments.
 


### PR DESCRIPTION
Minor inaccuracy: support for loopback devices needs to land in snapd not Ceph, but this is a bit of a detail so just pared it down to "Development"