### PR TITLE
Fix: tighten requirements for removing nodes

### DIFF
--- a/microceph/cmd/microceph/cluster_remove.go
+++ b/microceph/cmd/microceph/cluster_remove.go
@@ -118,23 +118,23 @@ func checkPrerequisites(cli *microCli.Client, name string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting services: %v", err)
 	}
-	// create a map of service names to bool values
+	// create a map of service names counters
 	// init with false
-	foundMap := map[string]bool{
-		"mon": false,
-		"mgr": false,
-		"mds": false,
+	foundMap := map[string]int{
+		"mon": 0,
+		"mgr": 0,
+		"mds": 0,
 	}
-	// loop through services and check if we have any services that are not on the named node
+	// loop through services and check service counts
 	for _, service := range services {
 		if service.Location == name {
 			continue
 		}
-		foundMap[service.Service] = true
+		foundMap[service.Service]++
 	}
 	logger.Debugf("Services: %v, foundMap: %v", services, foundMap)
-	if !foundMap["mon"] || !foundMap["mgr"] || !foundMap["mds"] {
-		return fmt.Errorf("Need at least one mon, mds, and mgr besides %v", name)
+	if foundMap["mon"] < 3 || foundMap["mgr"] < 1 || foundMap["mds"] < 1 {
+		return fmt.Errorf("Need at least 3 mon, 1 mds, and 1 mgr besides %v", name)
 	}
 
 	return nil

--- a/microceph/cmd/microceph/cluster_remove_test.go
+++ b/microceph/cmd/microceph/cluster_remove_test.go
@@ -30,25 +30,19 @@ func (s *clusterRemoveSuite) TestRemoveNode() {
 	client.MClient = m
 	m.On("GetClusterMembers", mock.Anything).Return([]string{"foonode", "barnode", "quuxnode"}, nil).Once()
 	m.On("GetDisks", mock.Anything).Return(types.Disks{}, nil).Once()
+
+	services := []string{"mon", "mon", "mgr", "mds", "mon", "mgr", "mds", "mon", "mgr", "mds"}
+	var servicesData types.Services
+	for _, service := range services {
+		// Add each service to the array
+		servicesData = append(servicesData, types.Service{Service: service})
+		// For the first entry, set location to "foonode"
+		if service == "mon" && servicesData[0].Location == "" {
+			servicesData[0].Location = "foonode"
+		}
+	}
 	m.On("GetServices", mock.Anything).Return(
-		types.Services{
-			{
-				Service:  "mon",
-				Location: "foonode",
-			},
-			{
-				Service:  "mon",
-				Location: "barnode",
-			},
-			{
-				Service:  "mgr",
-				Location: "barnode",
-			},
-			{
-				Service:  "mds",
-				Location: "barnode",
-			},
-		},
+		servicesData,
 		nil,
 	)
 	m.On("DeleteService", mock.Anything, "foonode", "mon").Return(nil).Once()


### PR DESCRIPTION
In testing we are seeing situations where a quorum could not be established. Require a min. of 3 mons in the non-forced case to prevent this.