### PR TITLE
Try harder when clustering

### DIFF
--- a/microceph/cmd/microceph/cluster_bootstrap.go
+++ b/microceph/cmd/microceph/cluster_bootstrap.go
@@ -46,5 +46,5 @@ func (c *cmdClusterBootstrap) Run(cmd *cobra.Command, args []string) error {
 	address := util.NetworkInterfaceAddress()
 	address = util.CanonicalNetworkAddress(address, 7443)
 
-	return m.NewCluster(hostname, address, time.Second*30)
+	return m.NewCluster(hostname, address, time.Minute*5)
 }

--- a/microceph/cmd/microceph/cluster_join.go
+++ b/microceph/cmd/microceph/cluster_join.go
@@ -46,5 +46,5 @@ func (c *cmdClusterJoin) Run(cmd *cobra.Command, args []string) error {
 	address := util.NetworkInterfaceAddress()
 	address = util.CanonicalNetworkAddress(address, 7443)
 
-	return m.JoinCluster(hostname, address, args[0], time.Second*30)
+	return m.JoinCluster(hostname, address, args[0], time.Minute*5)
 }

--- a/microceph/cmd/microceph/init.go
+++ b/microceph/cmd/microceph/init.go
@@ -81,7 +81,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			}
 
 			// Bootstrap the cluster.
-			err = m.NewCluster(hostName, address, time.Second*30)
+			err = m.NewCluster(hostName, address, time.Minute*2)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			err = m.JoinCluster(hostName, address, token, time.Second*30)
+			err = m.JoinCluster(hostName, address, token, time.Minute*2)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Increase timeouts on clustering operations. Setting up the dqlite infra can be resource intensive and might land into timeouts on loaded systems otherwise.