### PR TITLE
docs: Fix up section headers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ## Table of Contents
 * [💡 Philosophy](#-philosophy)
 * [🎯 Features](#-features)
+* [󱐋 Quickstart](#-quickstart)
 * [📖 Documentation](#-documentation)
 * [💫 Project & community](#-project--community)
 * [📰 License](#-license)
@@ -31,7 +32,23 @@ Deploying and operating a Ceph cluster is complex because Ceph is designed to be
 4. Built-in clustering so you don't have to worry about it!
 5. Tailored for small scale (or just your Laptop).
 
-## ⚡️Quickstart
+## 󱐋 Quickstart
+
+The below commands will set you up with a testing environment on a single
+machine using file-backed OSDs - you'll need about 15 GiB of available space on
+your root drive:
+
+    sudo snap install microceph --channel quincy/edge
+    sudo snap refresh --hold microceph
+    sudo microceph cluster bootstrap
+    sudo microceph disk add loop,4G,3
+    sudo ceph status
+
+You're done!
+
+You can remove everything cleanly with:
+
+    sudo snap remove microceph
 
 ## 📖 Documentation
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 
 ## Table of Contents
-1. [💡 Philosophy](#💡-philosophy)
-2. [🎯 Features](#🎯-features)
-3. [📖 Documentation](#📖-documentation)
-4. [⚡️ Quickstart](#⚡️-quickstart)
-5. [👍 How Can I Contribute ?](#👍-how-can-i-contribute)
+* [💡 Philosophy](#-philosophy)
+* [🎯 Features](#-features)
+* [📖 Documentation](#-documentation)
+* [💫 Project & community](#-project--community)
+* [📰 License](#-license)
 
 ## 💡 Philosophy
 
@@ -33,118 +33,33 @@ Deploying and operating a Ceph cluster is complex because Ceph is designed to be
 
 ## 📖 Documentation
 
-Refer to the [QuickStart](#⚡️-quickstart) section for your first setup. If you want to read _official_ _documentation_, please visit our hosted [Docs](https://canonical-microceph.readthedocs-hosted.com/en/latest/).
+The documentation is found in the [`docs`][docs-dir-microceph] directory. It is
+written in RST format, built with Sphinx, and published on Read The Docs:
 
-## ⚡️ Quickstart
+[MicroCeph documentation][rtd-microceph]
 
-### ⚙️ Installation and Bootstrapping Ceph cluster
-```bash
-# Install MicroCeph
-$ sudo snap install microceph
+## 💫 Project & community
 
-# Bootstrapping the Ceph Cluster
-$ sudo microceph cluster bootstrap
-$ sudo microceph.ceph status
-    cluster:
-        id:     c8d120af-d7dc-45db-a216-4340e88e5a0e
-        health: HEALTH_WARN
-                OSD count 0 < osd_pool_default_size 3
-    
-    services:
-        mon: 1 daemons, quorum host (age 1m)
-        mgr: host(active, since 1m)
-        osd: 0 osds: 0 up, 0 in
-    
-    data:
-        pools:   0 pools, 0 pgs
-        objects: 0 objects, 0 B
-        usage:   0 B used, 0 B / 0 B avail
-        pgs: 
-```
+* [Join our online forum][matrix-microceph] - **Ubuntu Ceph** on Matrix
+* [Contributing guidelines][contrib-microceph]
+* [Code of conduct][ubuntu-coc]
+* [File a bug][bug-microceph]
 
-![Dashboard](/assets/bootstrap.png)
+Excited about MicroCeph? Become one of our [Stargazers][stargazers-microceph]!
 
-> **_NOTE:_**
-You might've noticed that the Ceph cluster is not _functional_ yet, We need OSDs!<br>
-But before that, if you are only interested in deploying on a single node, it would be worthwhile to change the CRUSH rules. With the below commands, we're re-creating the default rule to have a failure domain of osd (instead of the default host failure domain)
+## 📰 License
 
-```bash
-# Change Ceph failure domain to OSD
-$ sudo microceph.ceph osd crush rule rm replicated_rule
-$ sudo microceph.ceph osd crush rule create-replicated single default osd
-```
-### ⚙️ Adding OSDs and RGW
-```bash
-# Adding OSD Disks
-$ sudo microceph disk list
-    Disks configured in MicroCeph:
-    +-----+----------+------+
-    | OSD | LOCATION | PATH |
-    +-----+----------+------+
+MicroCeph is free software, distributed under the AGPLv3 license (GNU Affero
+General Public License version 3.0). Refer to the [COPYING][license-microceph]
+file (the actual license) for more information.
 
-    Available unpartitioned disks on this system:
-    +-------+----------+--------+---------------------------------------------+
-    | MODEL | CAPACITY |  TYPE  |                    PATH                     |
-    +-------+----------+--------+---------------------------------------------+
-    |       | 10.00GiB | virtio | /dev/disk/by-id/virtio-46c76c00-48fd-4f8d-9 |
-    +-------+----------+--------+---------------------------------------------+
-    |       | 10.00GiB | virtio | /dev/disk/by-id/virtio-2171ea8f-e8a9-44c7-8 |
-    +-------+----------+--------+---------------------------------------------+
-    |       | 10.00GiB | virtio | /dev/disk/by-id/virtio-cf9c6e20-306f-4296-b |
-    +-------+----------+--------+---------------------------------------------+
+<!-- LINKS -->
 
-$ sudo microceph disk add --wipe /dev/disk/by-id/virtio-46c76c00-48fd-4f8d-9
-$ sudo microceph disk add --wipe /dev/disk/by-id/virtio-2171ea8f-e8a9-44c7-8
-$ sudo microceph disk add --wipe /dev/disk/by-id/virtio-cf9c6e20-306f-4296-b
-$ sudo microceph disk list
-    Disks configured in MicroCeph:
-    +-----+---------------+---------------------------------------------+
-    | OSD |   LOCATION    |                    PATH                     |
-    +-----+---------------+---------------------------------------------+
-    | 0   | host | /dev/disk/by-id/virtio-46c76c00-48fd-4f8d-9 |
-    +-----+---------------+---------------------------------------------+
-    | 1   | host | /dev/disk/by-id/virtio-2171ea8f-e8a9-44c7-8 |
-    +-----+---------------+---------------------------------------------+
-    | 2   | host | /dev/disk/by-id/virtio-cf9c6e20-306f-4296-b |
-    +-----+---------------+---------------------------------------------+
-
-    Available unpartitioned disks on this system:
-    +-------+----------+--------+------------------+
-    | MODEL | CAPACITY |  TYPE  |       PATH       |
-    +-------+----------+--------+------------------+
-```
-
-![Dashboard](/assets/add_osd.png)
-
-```bash
-# Adding RGW Service
-$ sudo microceph enable rgw
-# Perform IO and Check cluster status
-$ sudo microceph.ceph status
-    cluster:
-        id:     a8f9b673-f3f3-4e3f-b427-a9cf0d2f2323
-        health: HEALTH_OK
-    
-    services:
-        mon: 1 daemons, quorum host (age 12m)
-        mgr: host(active, since 12m)
-        osd: 3 osds: 3 up (since 5m), 3 in (since 5m)
-        rgw: 1 daemon active (1 hosts, 1 zones)
-    
-    data:
-        pools:   7 pools, 193 pgs
-        objects: 341 objects, 504 MiB
-        usage:   1.6 GiB used, 28 GiB / 30 GiB avail
-        pgs:     193 active+clean
-```
-
-![Dashboard](/assets/enable_rgw.png)
-
-## 👍 How Can I Contribute ?
-
-1. Checkout [MicroCeph Hacking Guide](/HACKING.md) to start building and contributing to the codebase.
-2. Excited about [MicroCeph](https://snapcraft.io/microceph) ? Join our [Stargazers](https://github.com/canonical/microceph/stargazers)
-3. Write reviews or tutorials to help spread the knowledge 📖
-4. Participate in [Pull Requests](https://github.com/canonical/microceph/pulls) and help fix [Issues](https://github.com/canonical/microceph/issues)
-
-You can also find us on Matrix @[Ubuntu Ceph](https://matrix.to/#/#ubuntu-ceph:matrix.org)
+[rtd-microceph]: https://canonical-microceph.readthedocs-hosted.com/
+[docs-dir-microceph]: https://github.com/canonical/microceph/tree/main/docs
+[contrib-microceph]: ./CONTRIBUTING.md
+[license-microceph]: ./COPYING
+[ubuntu-coc]: https://ubuntu.com/community/ethos/code-of-conduct
+[bug-microceph]: https://github.com/canonical/microceph/issues/new
+[stargazers-microceph]: https://github.com/canonical/microceph/stargazers
+[matrix-microceph]: https://matrix.to/#/#ubuntu-ceph:matrix.org

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Deploying and operating a Ceph cluster is complex because Ceph is designed to be
 4. Built-in clustering so you don't have to worry about it!
 5. Tailored for small scale (or just your Laptop).
 
+## ⚡️Quickstart
+
 ## 📖 Documentation
 
 The documentation is found in the [`docs`][docs-dir-microceph] directory. It is


### PR DESCRIPTION
* Repair table of contents - links were broken
* Remove documentation content (**Quickstart** section)
* Add **Documentation** section, and point to published content
* Replace **How Can I Contribute** section with **Project & community** section
* Add **License** section

Proposed organisation is based on consistency across projects. Some customisation is fine (e.g. table of contents).