### PR TITLE
Implement the 'pool' endpoint and 'set-rf' command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,9 +194,12 @@ jobs:
       run: |
         set +e
         sudo microceph.ceph osd pool create mypool
-        sudo microceph pool set-rf --size 1
+        sudo microceph pool set-rf --size 1 ""
+        sudo microceph.ceph config get osd.1 osd_pool_default_size | fgrep -x "1"
         sudo microceph pool set-rf --size 3 mypool
+        sudo microceph.ceph osd pool get mypool size | fgrep -x "size: 3"
         sudo microceph pool set-rf --size 1 "*"
+        sudo microceph.ceph osd pool get mypool size | fgrep -x "size: 1"
 
   multi-node-tests:
     name: Multi node testing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -183,6 +183,14 @@ jobs:
         # Check service restarted
         if [ $ts3 -lt $ts2 ]; then echo "config check failed: TS2: $ts2 TS3: $ts3"; exit 1; fi
 
+    - name: Test pool operations
+      run: |
+        set +e
+        sudo microceph.ceph osd pool create mypool
+        sudo microceph pool set-rf --size 1
+        sudo microceph pool set-rf --size 3 mypool
+        sudo microceph pool set-rf --size 1 "*"
+
   multi-node-tests:
     name: Multi node testing
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.snap
 _build
+*.swp

--- a/microceph/api/endpoints.go
+++ b/microceph/api/endpoints.go
@@ -21,4 +21,5 @@ var Endpoints = []rest.Endpoint{
 	clientCmd,
 	clientConfigsCmd,
 	clientConfigsKeyCmd,
+	poolsCmd,
 }

--- a/microceph/api/pool.go
+++ b/microceph/api/pool.go
@@ -16,23 +16,23 @@ import (
 // /1.0/pool endpoint.
 var poolsCmd = rest.Endpoint{
 	Path: "pools",
-	Post: rest.EndpointAction{Handler: cmdPoolsPost, ProxyTarget: true},
+	Put: rest.EndpointAction{Handler: cmdPoolsPut, ProxyTarget: true},
 }
 
-func cmdPoolsPost(s *state.State, r *http.Request) response.Response {
-	var req types.PoolPost
+func cmdPoolsPut(s *state.State, r *http.Request) response.Response {
+	var req types.PoolPut
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	logger.Debugf("cmdPoolPost: %v", req)
+	logger.Debugf("cmdPoolPut: %v", req)
 	err = ceph.SetReplicationFactor(req.Pools, req.Size)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	logger.Debugf("cmdPoolPost done: %v", req)
+	logger.Debugf("cmdPoolPut done: %v", req)
 	return response.EmptySyncResponse
 }

--- a/microceph/api/pool.go
+++ b/microceph/api/pool.go
@@ -15,7 +15,7 @@ import (
 
 // /1.0/pool endpoint.
 var poolsCmd = rest.Endpoint{
-	Path: "pools",
+	Path: "pools-op",
 	Put: rest.EndpointAction{Handler: cmdPoolsPut, ProxyTarget: true},
 }
 

--- a/microceph/api/pool.go
+++ b/microceph/api/pool.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"github.com/canonical/lxd/shared/logger"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/ceph"
+)
+
+// /1.0/pool endpoint.
+var poolsCmd = rest.Endpoint{
+	Path: "pools",
+	Post: rest.EndpointAction{Handler: cmdPoolsPost, ProxyTarget: true},
+}
+
+func cmdPoolsPost(s *state.State, r *http.Request) response.Response {
+	var req types.PoolPost
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	logger.Debugf("cmdPoolPost: %v", req)
+	err = ceph.SetReplicationFactor(req.Pools, req.Size)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	logger.Debugf("cmdPoolPost done: %v", req)
+	return response.EmptySyncResponse
+}

--- a/microceph/api/types/pool.go
+++ b/microceph/api/types/pool.go
@@ -1,7 +1,7 @@
 package types
 
 // Types for pool management.
-type PoolPost struct {
-	Pools string `json:"pools" yaml:"pools"`
-	Size  int64  `json:"size" yaml:"size"`
+type PoolPut struct {
+	Pools []string `json:"pools" yaml:"pools"`
+	Size  int64    `json:"size" yaml:"size"`
 }

--- a/microceph/api/types/pool.go
+++ b/microceph/api/types/pool.go
@@ -1,0 +1,7 @@
+package types
+
+// Types for pool management.
+type PoolPost struct {
+	Pools string `json:"pools" yaml:"pools"`
+	Size  int64  `json:"size" yaml:"size"`
+}

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -982,14 +982,14 @@ func killOSD(osd int64) error {
 
 func SetReplicationFactor(pools []string, size int64) error {
 	ssize := fmt.Sprintf("%d", size)
+    _, err := processExec.RunCommand("ceph", "config", "set", "global",
+                                     "osd_pool_default_size", ssize)
+    if err != nil {
+        return fmt.Errorf("failed to set pool size default: %w", err)
+    }
+
     if len(pools) == 1 && pools[0] == "" {
 		// Apply setting globally.
-		_, err := processExec.RunCommand("ceph", "config", "set", "global",
-			"osd_pool_default_size", ssize)
-		if err != nil {
-			return fmt.Errorf("failed to set pool size default: %w", err)
-		}
-
 		allowSizeOne := "true"
 		if size != 1 {
 			allowSizeOne = "false"

--- a/microceph/client/pool.go
+++ b/microceph/client/pool.go
@@ -16,9 +16,9 @@ func PoolSetReplicationFactor(ctx context.Context, c *microCli.Client, data *typ
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
 	defer cancel()
 
-	err := c.Query(queryCtx, "POST", api.NewURL().Path("pools"), data, nil)
+	err := c.Query(queryCtx, "PUT", api.NewURL().Path("pools"), data, nil)
 	if err != nil {
-		return fmt.Errorf("failed adding new disk: %w", err)
+		return fmt.Errorf("failed setting replication factor: %w", err)
 	}
 
 	return nil

--- a/microceph/client/pool.go
+++ b/microceph/client/pool.go
@@ -1,0 +1,25 @@
+// Package client provides a full Go API client.
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	microCli "github.com/canonical/microcluster/client"
+
+	"github.com/canonical/microceph/microceph/api/types"
+)
+
+func PoolSetReplicationFactor(ctx context.Context, c *microCli.Client, data *types.PoolPost) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+
+	err := c.Query(queryCtx, "POST", api.NewURL().Path("pools"), data, nil)
+	if err != nil {
+		return fmt.Errorf("failed adding new disk: %w", err)
+	}
+
+	return nil
+}

--- a/microceph/client/pool.go
+++ b/microceph/client/pool.go
@@ -16,7 +16,7 @@ func PoolSetReplicationFactor(ctx context.Context, c *microCli.Client, data *typ
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
 	defer cancel()
 
-	err := c.Query(queryCtx, "PUT", api.NewURL().Path("pools"), data, nil)
+	err := c.Query(queryCtx, "PUT", api.NewURL().Path("pools-op"), data, nil)
 	if err != nil {
 		return fmt.Errorf("failed setting replication factor: %w", err)
 	}

--- a/microceph/client/pool.go
+++ b/microceph/client/pool.go
@@ -12,7 +12,7 @@ import (
 	"github.com/canonical/microceph/microceph/api/types"
 )
 
-func PoolSetReplicationFactor(ctx context.Context, c *microCli.Client, data *types.PoolPost) error {
+func PoolSetReplicationFactor(ctx context.Context, c *microCli.Client, data *types.PoolPut) error {
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
 	defer cancel()
 

--- a/microceph/cmd/microceph/main.go
+++ b/microceph/cmd/microceph/main.go
@@ -66,6 +66,9 @@ func main() {
 	var cmdClient = cmdClient{common: &commonCmd}
 	app.AddCommand(cmdClient.Command())
 
+    var cmdPool = cmdPool{common: &commonCmd}
+    app.AddCommand(cmdPool.Command())
+
 	app.InitDefaultHelpCmd()
 
 	err := app.Execute()

--- a/microceph/cmd/microceph/pool.go
+++ b/microceph/cmd/microceph/pool.go
@@ -67,7 +67,7 @@ func (c *cmdPool) Command() *cobra.Command {
 		Short: "Manage microceph pools",
 	}
 
-	// Set-RF.
+	// set-rf.
 	poolSetRFCmd := cmdPoolSetRF{common: c.common, poolRF: c}
 	cmd.AddCommand(poolSetRFCmd.Command())
 

--- a/microceph/cmd/microceph/pool.go
+++ b/microceph/cmd/microceph/pool.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+)
+
+type cmdPool struct {
+	common *CmdControl
+}
+
+type cmdPoolSetRF struct {
+	common *CmdControl
+	poolRF *cmdPool
+}
+
+func (c *cmdPoolSetRF) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-rf <POOLS> <SIZE>",
+		Short: "Set the replication factor for pools",
+		Long: `Set the replication factor for <POOLS>
+    POOLS is either a comma-separated list of pools such as pool1,pool2, an asterisk
+    or an empty string. If it's an asterisk, the size is set for all existing pools,
+    but not future ones, whereas an empty string implies setting the default pool size.
+    Otherwise, the size is set for the specified pools.`,
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdPoolSetRF) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	size, err := strconv.ParseInt(args[1], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	req := &types.PoolPost{
+		Pools: args[0],
+		Size:  size,
+	}
+
+	return client.PoolSetReplicationFactor(context.Background(), cli, req)
+}
+
+func (c *cmdPool) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pool",
+		Short: "Manage microceph pools",
+	}
+
+	// Set-RF.
+	poolSetRFCmd := cmdPoolSetRF{common: c.common, poolRF: c}
+	cmd.AddCommand(poolSetRFCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+
+	return cmd
+}

--- a/microceph/cmd/microceph/pool.go
+++ b/microceph/cmd/microceph/pool.go
@@ -32,6 +32,9 @@ func (c *cmdPoolSetRF) Command() *cobra.Command {
 		RunE: c.Run,
 	}
 
+    cmd.Flags().Int64Var(&c.poolSize, "size", 3, "Pool size")
+    cmd.MarkFlagRequired("size")
+
 	return cmd
 }
 


### PR DESCRIPTION
This PR implements the pool endpoint and inside it, the 'set-rf' command to set the replication factor of a list of pools.