### PR TITLE
Implement the operations for getting and setting log-level

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,6 +201,13 @@ jobs:
         sudo microceph pool set-rf --size 1 "*"
         sudo microceph.ceph osd pool get mypool size | fgrep -x "size: 1"
 
+    - name: Test log operations
+      run: |
+        set +e
+        sudo microceph log set-level warning
+        output=$(sudo microceph log get-level)
+        if [[ "$output" != "3" ]] ; then echo "incorrect log level: $output"; exit 1; fi 
+
   multi-node-tests:
     name: Multi node testing
     runs-on: ubuntu-22.04

--- a/microceph/api/endpoints.go
+++ b/microceph/api/endpoints.go
@@ -22,4 +22,5 @@ var Endpoints = []rest.Endpoint{
 	clientConfigsCmd,
 	clientConfigsKeyCmd,
 	poolsCmd,
+	logCmd,
 }

--- a/microceph/api/log.go
+++ b/microceph/api/log.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"encoding/json"
+	"github.com/canonical/lxd/shared/logger"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/ceph"
+)
+
+// /1.0/log-level endpoint.
+var logCmd = rest.Endpoint{
+	Path: "log-level",
+	Put:  rest.EndpointAction{Handler: logLevelPut, ProxyTarget: true},
+	Get:  rest.EndpointAction{Handler: logLevelGet, ProxyTarget: true},
+}
+
+func logLevelPut(s *state.State, r *http.Request) response.Response {
+	var req types.LogLevelPut
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	logger.Debugf("cmdLogLevelPut: %v", req)
+	err = ceph.SetLogLevel(req.Level)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	logger.Debugf("cmdLogLevelPut done: %v", req)
+	return response.EmptySyncResponse
+}
+
+func logLevelGet(s *state.State, r *http.Request) response.Response {
+	return response.SyncResponse(true, ceph.GetLogLevel())
+}

--- a/microceph/api/types/log.go
+++ b/microceph/api/types/log.go
@@ -1,0 +1,6 @@
+package types
+
+// Types for log management.
+type LogLevelPut struct {
+	Level string `json:"level" yaml:"level"`
+}

--- a/microceph/ceph/log.go
+++ b/microceph/ceph/log.go
@@ -1,0 +1,85 @@
+package ceph
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/sirupsen/logrus"
+)
+
+// The following is hack to access a private member in lxd's logger.
+
+type targetLogger interface {
+	Panic(args ...interface{})
+	Fatal(args ...interface{})
+	Error(args ...interface{})
+	Warn(args ...interface{})
+	Info(args ...interface{})
+	Debug(args ...interface{})
+	Trace(args ...interface{})
+	WithFields(fields logrus.Fields) *logrus.Entry
+}
+
+type logWrapper struct {
+	target targetLogger
+}
+
+func (lw *logWrapper) AddContext(ctx logger.Ctx) logger.Logger {
+	return &logWrapper{lw.target}
+}
+
+func (lw *logWrapper) Debug(string, ...logger.Ctx) {}
+func (lw *logWrapper) Error(string, ...logger.Ctx) {}
+func (lw *logWrapper) Fatal(string, ...logger.Ctx) {}
+func (lw *logWrapper) Warn(string, ...logger.Ctx)  {}
+func (lw *logWrapper) Info(string, ...logger.Ctx)  {}
+func (lw *logWrapper) Panic(string, ...logger.Ctx) {}
+func (lw *logWrapper) Trace(string, ...logger.Ctx) {}
+
+func parseLogLevel(level string) (int, error) {
+	level = strings.ToLower(level)
+
+	if level == "panic" {
+		return 0, nil
+	} else if level == "fatal" {
+		return 1, nil
+	} else if level == "error" {
+		return 2, nil
+	} else if level == "warning" {
+		return 3, nil
+	} else if level == "info" {
+		return 4, nil
+	} else if level == "debug" {
+		return 5, nil
+	} else if level == "trace" {
+		return 6, nil
+	}
+
+	return 0, fmt.Errorf("invalid log level: %s", level)
+}
+
+func SetLogLevel(level string) error {
+	ilvl, err := strconv.Atoi(level)
+	if err != nil {
+		// Level is a symbolic string.
+		ilvl, err = parseLogLevel(level)
+		if err != nil {
+			return err
+		}
+	} else if ilvl < 0 || ilvl > 6 {
+		return fmt.Errorf("log level must be between 0 and 6")
+	}
+
+	wrapper := logger.Log.(*logWrapper)
+	wrapper.target.(*logrus.Logger).SetLevel(logrus.Level(ilvl))
+
+	return nil
+}
+
+func GetLogLevel() uint32 {
+	wrapper := logger.Log.(*logWrapper)
+	ilvl := wrapper.target.(*logrus.Logger).GetLevel()
+	return uint32(ilvl)
+}

--- a/microceph/ceph/log.go
+++ b/microceph/ceph/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unsafe"
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/sirupsen/logrus"
@@ -25,18 +26,6 @@ type targetLogger interface {
 type logWrapper struct {
 	target targetLogger
 }
-
-func (lw *logWrapper) AddContext(ctx logger.Ctx) logger.Logger {
-	return &logWrapper{lw.target}
-}
-
-func (lw *logWrapper) Debug(string, ...logger.Ctx) {}
-func (lw *logWrapper) Error(string, ...logger.Ctx) {}
-func (lw *logWrapper) Fatal(string, ...logger.Ctx) {}
-func (lw *logWrapper) Warn(string, ...logger.Ctx)  {}
-func (lw *logWrapper) Info(string, ...logger.Ctx)  {}
-func (lw *logWrapper) Panic(string, ...logger.Ctx) {}
-func (lw *logWrapper) Trace(string, ...logger.Ctx) {}
 
 func parseLogLevel(level string) (int, error) {
 	level = strings.ToLower(level)
@@ -72,14 +61,14 @@ func SetLogLevel(level string) error {
 		return fmt.Errorf("log level must be between 0 and 6")
 	}
 
-	wrapper := logger.Log.(*logWrapper)
+	wrapper := (*logWrapper)(unsafe.Pointer(&logger.Log))
 	wrapper.target.(*logrus.Logger).SetLevel(logrus.Level(ilvl))
 
 	return nil
 }
 
 func GetLogLevel() uint32 {
-	wrapper := logger.Log.(*logWrapper)
+	wrapper := (*logWrapper)(unsafe.Pointer(&logger.Log))
 	ilvl := wrapper.target.(*logrus.Logger).GetLevel()
 	return uint32(ilvl)
 }

--- a/microceph/ceph/log.go
+++ b/microceph/ceph/log.go
@@ -62,13 +62,13 @@ func SetLogLevel(level string) error {
 	}
 
 	wrapper := (*logWrapper)(unsafe.Pointer(&logger.Log))
-	wrapper.target.(*logrus.Logger).SetLevel(logrus.Level(ilvl))
-
+	target := (*logrus.Logger)(unsafe.Pointer(&wrapper.target))
+	target.SetLevel(logrus.Level(ilvl))
 	return nil
 }
 
 func GetLogLevel() uint32 {
 	wrapper := (*logWrapper)(unsafe.Pointer(&logger.Log))
-	ilvl := wrapper.target.(*logrus.Logger).GetLevel()
-	return uint32(ilvl)
+	target := (*logrus.Logger)(unsafe.Pointer(&wrapper.target))
+	return uint32(target.GetLevel())
 }

--- a/microceph/client/log.go
+++ b/microceph/client/log.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	microCli "github.com/canonical/microcluster/client"
+
+	"github.com/canonical/microceph/microceph/api/types"
+)
+
+func LogLevelSet(ctx context.Context, c *microCli.Client, data *types.LogLevelPut) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+
+	err := c.Query(queryCtx, "PUT", api.NewURL().Path("log-level"), data, nil)
+	if err != nil {
+		return fmt.Errorf("failed setting log level: %w", err)
+	}
+
+	return nil
+}
+
+func LogLevelGet(ctx context.Context, c *microCli.Client) (uint32, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	level := uint32(0)
+
+	err := c.Query(queryCtx, "GET", api.NewURL().Path("log-level"), nil, &level)
+	if err != nil {
+		return 0, fmt.Errorf("failed getting log level: %w", err)
+	}
+
+	return level, nil
+}

--- a/microceph/cmd/microceph/log.go
+++ b/microceph/cmd/microceph/log.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+)
+
+type cmdLog struct {
+	common *CmdControl
+}
+
+type cmdLogSetLevel struct {
+	common      *CmdControl
+	logSetLevel *cmdLog
+	logLevel    string
+}
+
+type cmdLogGetLevel struct {
+	common      *CmdControl
+	logGetLevel *cmdLog
+}
+
+func (c *cmdLogSetLevel) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-level <LEVEL>",
+		Short: "Set the log level for the microceph daemon",
+		Long: `Set the log level for the microceph daemon.
+    LEVEL is either a symbolic string, or an integer that
+    specifies the new level. The mapping is as follows:
+    0 - PANIC
+    1 - FATAL
+    2 - ERROR
+    3 - WARNING
+    4 - INFO
+    5 - DEBUG
+    6 - TRACE.`,
+		RunE: c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdLogGetLevel) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-level",
+		Short: "Get the current log level, as an integer",
+	}
+
+	return cmd
+}
+
+func (c *cmdLogSetLevel) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	req := &types.LogLevelPut{
+		Level: args[0],
+	}
+
+	return client.LogLevelSet(context.Background(), cli, req)
+}
+
+func (c *cmdLogGetLevel) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	lvl, err := client.LogLevelGet(context.Background(), cli)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%u\n", lvl)
+	return nil
+}
+
+func (c *cmdLog) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "log",
+		Short: "Manage microceph logs",
+	}
+
+	// set-level.
+	logLevelSetCmd := cmdLogSetLevel{common: c.common, logSetLevel: c}
+	cmd.AddCommand(logLevelSetCmd.Command())
+
+	// get-level.
+	logLevelGetCmd := cmdLogGetLevel{common: c.common, logGetLevel: c}
+	cmd.AddCommand(logLevelGetCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+
+	return cmd
+}

--- a/microceph/cmd/microceph/log.go
+++ b/microceph/cmd/microceph/log.go
@@ -50,6 +50,7 @@ func (c *cmdLogGetLevel) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-level",
 		Short: "Get the current log level, as an integer",
+        RunE: c.Run,
 	}
 
 	return cmd
@@ -97,7 +98,7 @@ func (c *cmdLogGetLevel) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("%u\n", lvl)
+	fmt.Printf("%d\n", lvl)
 	return nil
 }
 

--- a/microceph/cmd/microceph/main.go
+++ b/microceph/cmd/microceph/main.go
@@ -72,6 +72,9 @@ func main() {
     var cmdPool = cmdPool{common: &commonCmd}
     app.AddCommand(cmdPool.Command())
 
+    var cmdLog = cmdLog{common: &commonCmd}
+    app.AddCommand(cmdLog.Command())
+
 	app.InitDefaultHelpCmd()
 
 	err := app.Execute()


### PR DESCRIPTION
This PR implements the setter and getter for log levels as used by the microceph daemon. It needs to jump through some hoops, as the lxd libraries don't expose this functionality themselves.