### PR TITLE
Refactor: split up common, testutils

### DIFF
--- a/microceph/api/client_configs.go
+++ b/microceph/api/client_configs.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"net/http"
 
@@ -41,7 +41,7 @@ func cmdClientConfigsGet(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	if req.Host == contants.ClientConfigGlobalHostConst {
+	if req.Host == constants.ClientConfigGlobalHostConst {
 		configs, err = database.ClientConfigQuery.GetAll(s)
 	} else {
 		configs, err = database.ClientConfigQuery.GetAllForHost(s, req.Host)
@@ -98,7 +98,7 @@ func clientConfigsKeyGet(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	if req.Host == contants.ClientConfigGlobalHostConst {
+	if req.Host == constants.ClientConfigGlobalHostConst {
 		configs, err = database.ClientConfigQuery.GetAllForKey(s, req.Key)
 	} else {
 		configs, err = database.ClientConfigQuery.GetAllForKeyAndHost(s, req.Key, req.Host)
@@ -143,7 +143,7 @@ func clientConfigsKeyDelete(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	if req.Host == contants.ClientConfigGlobalHostConst {
+	if req.Host == constants.ClientConfigGlobalHostConst {
 		err = database.ClientConfigQuery.RemoveAllForKey(s, req.Key)
 	} else {
 		err = database.ClientConfigQuery.RemoveOneForKeyAndHost(s, req.Key, req.Host)

--- a/microceph/api/disks.go
+++ b/microceph/api/disks.go
@@ -3,13 +3,13 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"net/http"
 	"net/url"
 	"strconv"
 	"sync"
 
 	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/response"
@@ -115,7 +115,7 @@ func cmdDisksDelete(s *state.State, r *http.Request) response.Response {
 	mu.Lock()
 	defer mu.Unlock()
 
-	cs := common.CephState{State: s}
+	cs := interfaces.CephState{State: s}
 	needDowngrade, err := ceph.IsDowngradeNeeded(cs, osdid)
 	if err != nil {
 		return response.InternalError(err)

--- a/microceph/api/services.go
+++ b/microceph/api/services.go
@@ -3,14 +3,13 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"net/http"
 	"path"
 
-	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/common"
-
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 
@@ -64,7 +63,7 @@ func cmdEnableServicePut(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err = ceph.ServicePlacementHandler(common.CephState{State: s}, payload)
+	err = ceph.ServicePlacementHandler(interfaces.CephState{State: s}, payload)
 	if err != nil {
 		return response.SyncResponse(false, err)
 	}
@@ -119,7 +118,7 @@ func cmdDeleteService(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err := ceph.DeleteService(common.CephState{State: s}, which)
+	err := ceph.DeleteService(interfaces.CephState{State: s}, which)
 	if err != nil {
 		return response.SyncResponse(false, err)
 	}
@@ -128,7 +127,7 @@ func cmdDeleteService(s *state.State, r *http.Request) response.Response {
 }
 
 func cmdRGWServiceDelete(s *state.State, r *http.Request) response.Response {
-	err := ceph.DisableRGW(common.CephState{State: s})
+	err := ceph.DisableRGW(interfaces.CephState{State: s})
 	if err != nil {
 		logger.Errorf("Failed disabling RGW: %v", err)
 		return response.SmartError(err)

--- a/microceph/ceph/bootstrap.go
+++ b/microceph/ceph/bootstrap.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
@@ -20,8 +20,8 @@ import (
 
 // Bootstrap will initialize a new Ceph deployment.
 func Bootstrap(s interfaces.StateInterface, data common.BootstrapConfig) error {
-	pathConsts := contants.GetPathConst()
-	pathFileMode := contants.GetPathFileMode()
+	pathConsts := constants.GetPathConst()
+	pathFileMode := constants.GetPathFileMode()
 
 	// Create our various paths.
 	for path, perm := range pathFileMode {

--- a/microceph/ceph/bootstrap.go
+++ b/microceph/ceph/bootstrap.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,9 +19,9 @@ import (
 )
 
 // Bootstrap will initialize a new Ceph deployment.
-func Bootstrap(s common.StateInterface, data common.BootstrapConfig) error {
-	pathConsts := common.GetPathConst()
-	pathFileMode := common.GetPathFileMode()
+func Bootstrap(s interfaces.StateInterface, data common.BootstrapConfig) error {
+	pathConsts := contants.GetPathConst()
+	pathFileMode := contants.GetPathFileMode()
 
 	// Create our various paths.
 	for path, perm := range pathFileMode {
@@ -141,7 +143,7 @@ func setDefaultNetwork(cn string) error {
 	return nil
 }
 
-func prepareCephBootstrapData(s common.StateInterface, data *common.BootstrapConfig) error {
+func prepareCephBootstrapData(s interfaces.StateInterface, data *common.BootstrapConfig) error {
 	var err error
 
 	// if no mon-ip is provided, either deduce from public network or fallback to default.
@@ -205,7 +207,7 @@ func createKeyrings(confPath string) (string, error) {
 	return path, nil
 }
 
-func createMonMap(s common.StateInterface, path string, fsid string, address string) error {
+func createMonMap(s interfaces.StateInterface, path string, fsid string, address string) error {
 	// Generate initial monitor map.
 	err := genMonmap(filepath.Join(path, "mon.map"), fsid)
 	if err != nil {
@@ -220,7 +222,7 @@ func createMonMap(s common.StateInterface, path string, fsid string, address str
 	return nil
 }
 
-func initMon(s common.StateInterface, dataPath string, path string) error {
+func initMon(s interfaces.StateInterface, dataPath string, path string) error {
 	// Bootstrap the initial monitor.
 	monDataPath := filepath.Join(dataPath, "mon", fmt.Sprintf("ceph-%s", s.ClusterState().Name()))
 
@@ -241,7 +243,7 @@ func initMon(s common.StateInterface, dataPath string, path string) error {
 	return nil
 }
 
-func initMgr(s common.StateInterface, dataPath string) error {
+func initMgr(s interfaces.StateInterface, dataPath string) error {
 	// Bootstrap the initial manager.
 	mgrDataPath := filepath.Join(dataPath, "mgr", fmt.Sprintf("ceph-%s", s.ClusterState().Name()))
 
@@ -263,7 +265,7 @@ func initMgr(s common.StateInterface, dataPath string) error {
 }
 
 // populateDatabase injects the bootstrap entries to the internal database.
-func populateDatabase(s common.StateInterface, fsid string, adminKey string, data common.BootstrapConfig) error {
+func populateDatabase(s interfaces.StateInterface, fsid string, adminKey string, data common.BootstrapConfig) error {
 	if s.ClusterState().Database == nil {
 		return fmt.Errorf("no database")
 	}
@@ -320,7 +322,7 @@ func enableMsgr2() error {
 	return nil
 }
 
-func startOSDs(s common.StateInterface, path string) error {
+func startOSDs(s interfaces.StateInterface, path string) error {
 	// Start OSD service.
 	err := snapStart("osd", true)
 	if err != nil {
@@ -329,7 +331,7 @@ func startOSDs(s common.StateInterface, path string) error {
 	return nil
 }
 
-func initMds(s common.StateInterface, dataPath string) error {
+func initMds(s interfaces.StateInterface, dataPath string) error {
 	// Bootstrap the initial metadata server.
 	mdsDataPath := filepath.Join(dataPath, "mds", fmt.Sprintf("ceph-%s", s.ClusterState().Name()))
 

--- a/microceph/ceph/bootstrap_test.go
+++ b/microceph/ceph/bootstrap_test.go
@@ -1,6 +1,8 @@
 package ceph
 
 import (
+	"github.com/canonical/microceph/microceph/interfaces"
+	"github.com/canonical/microceph/microceph/tests"
 	"testing"
 
 	"github.com/canonical/lxd/shared/api"
@@ -13,7 +15,7 @@ import (
 )
 
 type bootstrapSuite struct {
-	baseSuite
+	tests.BaseSuite
 	TestStateInterface *mocks.StateInterface
 }
 
@@ -23,48 +25,48 @@ func TestBootstrap(t *testing.T) {
 
 // Expect: run ceph-authtool 3 times
 func addCreateKeyringExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph-authtool", 8)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("ceph-authtool", 17)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("ceph-authtool", 3)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph-authtool", 8)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph-authtool", 17)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph-authtool", 3)...).Return("ok", nil).Once()
 }
 
 // Expect: run monmaptool 2 times
 func addCreateMonMapExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("monmaptool", 8)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("monmaptool", 17)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("monmaptool", 8)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("monmaptool", 17)...).Return("ok", nil).Once()
 }
 
 // Expect: run ceph-mon and snap start
 func addInitMonExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph-mon", 9)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("snapctl", 3)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph-mon", 9)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("snapctl", 3)...).Return("ok", nil).Once()
 }
 
 // Expect: run ceph and snap start
 func addInitMgrExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 11)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("snapctl", 3)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 11)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("snapctl", 3)...).Return("ok", nil).Once()
 }
 
 // Expect: run ceph and snap start
 func addInitMdsExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 13)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("snapctl", 3)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 13)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("snapctl", 3)...).Return("ok", nil).Once()
 }
 
 // Expect: run ceph and snap start
 func addEnableMsgr2Expectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 2)...).Return("ok", nil).Once()
-	r.On("RunCommand", cmdAny("snapctl", 3)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 2)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("snapctl", 3)...).Return("ok", nil).Once()
 }
 
 // Expect: check network coherency
-func addNetworkExpectationsBootstrap(nw *mocks.NetworkIntf, s common.StateInterface) {
+func addNetworkExpectationsBootstrap(nw *mocks.NetworkIntf, s interfaces.StateInterface) {
 	nw.On("IsIpOnSubnet", "1.1.1.1", "1.1.1.1/24").Return(true)
 }
 
 // Expect: check Bootstrap data prep
-func addNetworkExpectations(nw *mocks.NetworkIntf, s common.StateInterface) {
+func addNetworkExpectations(nw *mocks.NetworkIntf, s interfaces.StateInterface) {
 	nw.On("IsIpOnSubnet", "1.1.1.1", "1.1.1.1/24").Return(true)
 	nw.On("FindNetworkAddress", "1.1.1.1").Return("1.1.1.1/24", nil)
 	nw.On("FindIpOnSubnet", "1.1.1.1/24").Return("1.1.1.1", nil)
@@ -74,8 +76,8 @@ func addNetworkExpectations(nw *mocks.NetworkIntf, s common.StateInterface) {
 
 func (s *bootstrapSuite) SetupTest() {
 
-	s.baseSuite.SetupTest()
-	s.copyCephConfigs()
+	s.BaseSuite.SetupTest()
+	s.CopyCephConfigs()
 
 	s.TestStateInterface = mocks.NewStateInterface(s.T())
 	u := api.NewURL()

--- a/microceph/ceph/client_config.go
+++ b/microceph/ceph/client_config.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"reflect"
 
 	"github.com/canonical/microceph/microceph/common"
@@ -21,7 +22,7 @@ type ClientConfigT struct {
 }
 
 // GetClientConfigForHost fetches all the applicable client configurations for the provided host.
-func GetClientConfigForHost(s common.StateInterface, hostname string) (ClientConfigT, error) {
+func GetClientConfigForHost(s interfaces.StateInterface, hostname string) (ClientConfigT, error) {
 	retval := ClientConfigT{}
 
 	// Get all client configs for the current host.

--- a/microceph/ceph/client_config_test.go
+++ b/microceph/ceph/client_config_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/microceph/microceph/tests"
 	"reflect"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 )
 
 type ClientConfigSuite struct {
-	baseSuite
+	tests.BaseSuite
 	TestStateInterface *mocks.StateInterface
 }
 
@@ -22,7 +23,7 @@ func TestClientConfig(t *testing.T) {
 }
 
 func (ccs *ClientConfigSuite) SetupTest() {
-	ccs.baseSuite.SetupTest()
+	ccs.BaseSuite.SetupTest()
 
 	ccs.TestStateInterface = mocks.NewStateInterface(ccs.T())
 	state := &state.State{}

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
 	"strings"
@@ -162,7 +163,7 @@ func ListConfigs() (types.Configs, error) {
 }
 
 // updates the ceph config file.
-func UpdateConfig(s common.StateInterface) error {
+func UpdateConfig(s interfaces.StateInterface) error {
 	confPath := filepath.Join(os.Getenv("SNAP_DATA"), "conf")
 	runPath := filepath.Join(os.Getenv("SNAP_DATA"), "run")
 

--- a/microceph/ceph/config_test.go
+++ b/microceph/ceph/config_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"encoding/json"
+	"github.com/canonical/microceph/microceph/tests"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/api/types"
@@ -11,7 +12,7 @@ import (
 )
 
 type configSuite struct {
-	baseSuite
+	tests.BaseSuite
 }
 
 func TestConfig(t *testing.T) {
@@ -20,7 +21,7 @@ func TestConfig(t *testing.T) {
 
 // Set up test suite
 func (s *configSuite) SetupTest() {
-	s.baseSuite.SetupTest()
+	s.BaseSuite.SetupTest()
 }
 
 func addConfigSetExpectations(r *mocks.Runner, key string, value string) {

--- a/microceph/ceph/configwriter_test.go
+++ b/microceph/ceph/configwriter_test.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"github.com/canonical/microceph/microceph/tests"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 type configWriterSuite struct {
-	baseSuite
+	tests.BaseSuite
 }
 
 func TestConfigWriter(t *testing.T) {
@@ -18,12 +19,12 @@ func TestConfigWriter(t *testing.T) {
 
 // Set up test suite
 func (s *configWriterSuite) SetupTest() {
-	s.baseSuite.SetupTest()
+	s.BaseSuite.SetupTest()
 }
 
 // Test ceph config writing
 func (s *configWriterSuite) TestWriteCephConfig() {
-	config := newCephConfig(s.tmp)
+	config := newCephConfig(s.Tmp)
 	err := config.WriteConfig(
 		map[string]any{
 			"fsid":     "fsid1234",
@@ -45,7 +46,7 @@ func (s *configWriterSuite) TestWriteCephConfig() {
 
 // Test ceph config writing
 func (s *configWriterSuite) TestWriteRadosGWConfig() {
-	config := newRadosGWConfig(s.tmp)
+	config := newRadosGWConfig(s.Tmp)
 	err := config.WriteConfig(
 		map[string]any{
 			"monitors": "foohost",
@@ -64,7 +65,7 @@ func (s *configWriterSuite) TestWriteRadosGWConfig() {
 
 // Test ceph keyring writing
 func (s *configWriterSuite) TestWriteCephKeyring() {
-	keyring := newCephKeyring(s.tmp, "ceph.keyring")
+	keyring := newCephKeyring(s.Tmp, "ceph.keyring")
 	err := keyring.WriteConfig(
 		map[string]any{
 			"name": "client.admin",

--- a/microceph/ceph/join.go
+++ b/microceph/ceph/join.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 
 	"github.com/canonical/lxd/shared/logger"
@@ -12,8 +14,8 @@ import (
 )
 
 // Join will join an existing Ceph deployment.
-func Join(s common.StateInterface) error {
-	pathFileMode := common.GetPathFileMode()
+func Join(s interfaces.StateInterface) error {
+	pathFileMode := contants.GetPathFileMode()
 	var spt = GetServicePlacementTable()
 
 	// Create our various paths.
@@ -117,7 +119,7 @@ func Join(s common.StateInterface) error {
 	return nil
 }
 
-func updateDatabasePostJoin(s common.StateInterface, services []string) error {
+func updateDatabasePostJoin(s interfaces.StateInterface, services []string) error {
 	err := s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
 		// Record the roles.
 		for _, service := range services {
@@ -143,7 +145,7 @@ func updateDatabasePostJoin(s common.StateInterface, services []string) error {
 	return nil
 }
 
-func updateDbForMon(s common.StateInterface, ctx context.Context, tx *sql.Tx) error {
+func updateDbForMon(s interfaces.StateInterface, ctx context.Context, tx *sql.Tx) error {
 	// Fetch public network
 	configItem, err := database.GetConfigItem(ctx, tx, "public_network")
 	if err != nil {

--- a/microceph/ceph/join.go
+++ b/microceph/ceph/join.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 
@@ -15,7 +15,7 @@ import (
 
 // Join will join an existing Ceph deployment.
 func Join(s interfaces.StateInterface) error {
-	pathFileMode := contants.GetPathFileMode()
+	pathFileMode := constants.GetPathFileMode()
 	var spt = GetServicePlacementTable()
 
 	// Create our various paths.

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"math"
 	"os"
@@ -440,7 +440,7 @@ func validateBulkDiskAdditionArgs(disks []types.DiskParameter, wal *types.DiskPa
 
 	// check if loop spec is provided in batch request arguments.
 	for _, disk := range disks {
-		if strings.HasPrefix(disk.Path, contants.LoopSpecId) {
+		if strings.HasPrefix(disk.Path, constants.LoopSpecId) {
 			err := fmt.Errorf("cannot add loop spec '%s', add a single loop spec or one or more block device paths", disk.Path)
 			logger.Error(err.Error())
 			return err
@@ -494,7 +494,7 @@ func AddBulkDisks(s *state.State, disks []types.DiskParameter, wal *types.DiskPa
 
 // AddSingleDisk is a wrapper around AddOSD which logs disk addition failures and returns a formatted response.
 func AddSingleDisk(s *state.State, disk types.DiskParameter, wal *types.DiskParameter, db *types.DiskParameter) types.DiskAddReport {
-	if strings.Contains(disk.Path, contants.LoopSpecId) {
+	if strings.Contains(disk.Path, constants.LoopSpecId) {
 		// Add file based OSDs.
 		err := AddLoopBackOSDs(s, disk.Path)
 		if err != nil {
@@ -559,7 +559,7 @@ func AddOSD(s *state.State, data types.DiskParameter, wal *types.DiskParameter, 
 
 	logger.Debugf("Created disk record for osd.%d", nr)
 
-	osdDataPath := filepath.Join(contants.GetPathConst().DataPath, "osd", fmt.Sprintf("ceph-%d", nr))
+	osdDataPath := filepath.Join(constants.GetPathConst().DataPath, "osd", fmt.Sprintf("ceph-%d", nr))
 
 	// if we fail later, make sure we free up the record
 	revert.Add(func() {

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"github.com/canonical/microceph/microceph/tests"
 	"testing"
 
 	"github.com/canonical/lxd/shared/api"
@@ -14,7 +15,7 @@ import (
 
 // osdSuite is the test suite for adding OSDs.
 type osdSuite struct {
-	baseSuite
+	tests.BaseSuite
 	TestStateInterface *mocks.StateInterface
 }
 
@@ -24,14 +25,14 @@ func TestOSD(t *testing.T) {
 
 // Expect: run ceph osd crush rule ls
 func addCrushRuleLsExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 4)...).Return("microceph_auto_osd", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 4)...).Return("microceph_auto_osd", nil).Once()
 }
 
 // Expect: run ceph osd crush rule dump
 func addCrushRuleDumpExpectations(r *mocks.Runner) {
 	json := `{ "rule_id": 77 }`
 
-	r.On("RunCommand", cmdAny("ceph", 5)...).Return(json, nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 5)...).Return(json, nil).Once()
 }
 
 // Expect: run ceph osd crush rule ls json
@@ -40,17 +41,17 @@ func addCrushRuleLsJsonExpectations(r *mocks.Runner) {
         "crush_rule": 77
         "pool_name": "foopool",
     }]`
-	r.On("RunCommand", cmdAny("ceph", 5)...).Return(json, nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 5)...).Return(json, nil).Once()
 }
 
 // Expect: run ceph osd pool set
 func addOsdPoolSetExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 6)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 6)...).Return("ok", nil).Once()
 }
 
 // Expect: run ceph config set
 func addSetDefaultRuleExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 7)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 7)...).Return("ok", nil).Once()
 }
 
 // Expect: run ceph osd tree
@@ -94,14 +95,14 @@ func addOsdTreeExpectations(r *mocks.Runner) {
   ], "stray" : [{ "id": 77,
           "name": "osd.77",
           "exists": 1} ]}`
-	r.On("RunCommand", cmdAny("ceph", 4)...).Return(json, nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 4)...).Return(json, nil).Once()
 
 }
 
 func (s *osdSuite) SetupTest() {
 
-	s.baseSuite.SetupTest()
-	s.copyCephConfigs()
+	s.BaseSuite.SetupTest()
+	s.CopyCephConfigs()
 
 }
 

--- a/microceph/ceph/rgw.go
+++ b/microceph/ceph/rgw.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
 
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microceph/microceph/database"
 )
 
 // EnableRGW enables the RGW service on the cluster and adds initial configuration given a service port number.
-func EnableRGW(s common.StateInterface, port int) error {
-	pathConsts := common.GetPathConst()
+func EnableRGW(s interfaces.StateInterface, port int) error {
+	pathConsts := contants.GetPathConst()
 
 	// Create RGW configuration.
 	conf := newRadosGWConfig(pathConsts.ConfPath)
@@ -50,8 +51,8 @@ func EnableRGW(s common.StateInterface, port int) error {
 }
 
 // DisableRGW disables the RGW service on the cluster.
-func DisableRGW(s common.StateInterface) error {
-	pathConsts := common.GetPathConst()
+func DisableRGW(s interfaces.StateInterface) error {
+	pathConsts := contants.GetPathConst()
 
 	err := stopRGW()
 	if err != nil {
@@ -85,7 +86,7 @@ func DisableRGW(s common.StateInterface) error {
 }
 
 // rgwCreateServiceDatabase creates a rgw service record in the database.
-func rgwCreateServiceDatabase(s common.StateInterface) error {
+func rgwCreateServiceDatabase(s interfaces.StateInterface) error {
 	if s.ClusterState().Database == nil {
 		return fmt.Errorf("no database")
 	}

--- a/microceph/ceph/rgw.go
+++ b/microceph/ceph/rgw.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
@@ -14,7 +14,7 @@ import (
 
 // EnableRGW enables the RGW service on the cluster and adds initial configuration given a service port number.
 func EnableRGW(s interfaces.StateInterface, port int) error {
-	pathConsts := contants.GetPathConst()
+	pathConsts := constants.GetPathConst()
 
 	// Create RGW configuration.
 	conf := newRadosGWConfig(pathConsts.ConfPath)
@@ -52,7 +52,7 @@ func EnableRGW(s interfaces.StateInterface, port int) error {
 
 // DisableRGW disables the RGW service on the cluster.
 func DisableRGW(s interfaces.StateInterface) error {
-	pathConsts := contants.GetPathConst()
+	pathConsts := constants.GetPathConst()
 
 	err := stopRGW()
 	if err != nil {

--- a/microceph/ceph/rgw_test.go
+++ b/microceph/ceph/rgw_test.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"github.com/canonical/microceph/microceph/tests"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +14,7 @@ import (
 )
 
 type rgwSuite struct {
-	baseSuite
+	tests.BaseSuite
 	TestStateInterface *mocks.StateInterface
 }
 
@@ -23,18 +24,18 @@ func TestRGW(t *testing.T) {
 
 // Expect: run ceph auth
 func addCreateRGWKeyringExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("ceph", 9)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("ceph", 9)...).Return("ok", nil).Once()
 }
 
 // Expect: run snapctl service stop
 func addStopRGWExpectations(r *mocks.Runner) {
-	r.On("RunCommand", cmdAny("snapctl", 3)...).Return("ok", nil).Once()
+	r.On("RunCommand", tests.CmdAny("snapctl", 3)...).Return("ok", nil).Once()
 }
 
 // Set up test suite
 func (s *rgwSuite) SetupTest() {
-	s.baseSuite.SetupTest()
-	s.copyCephConfigs()
+	s.BaseSuite.SetupTest()
+	s.CopyCephConfigs()
 
 	s.TestStateInterface = mocks.NewStateInterface(s.T())
 	u := api.NewURL()
@@ -66,7 +67,7 @@ func (s *rgwSuite) TestEnableRGW() {
 	assert.EqualError(s.T(), err, "no database")
 
 	// check that the radosgw.conf file contains expected values
-	conf := s.readCephConfig("radosgw.conf")
+	conf := s.ReadCephConfig("radosgw.conf")
 	assert.Contains(s.T(), conf, "rgw frontends = beast port=80")
 }
 
@@ -83,10 +84,10 @@ func (s *rgwSuite) TestDisableRGW() {
 	assert.EqualError(s.T(), err, "no database")
 
 	// check that the radosgw.conf file is absent
-	_, err = os.Stat(filepath.Join(s.tmp, "SNAP_DATA", "conf", "radosgw.conf"))
+	_, err = os.Stat(filepath.Join(s.Tmp, "SNAP_DATA", "conf", "radosgw.conf"))
 	assert.True(s.T(), os.IsNotExist(err))
 
 	// check that the keyring file is absent
-	_, err = os.Stat(filepath.Join(s.tmp, "SNAP_COMMON", "data", "radosgw", "ceph-radosgw.gateway", "keyring"))
+	_, err = os.Stat(filepath.Join(s.Tmp, "SNAP_COMMON", "data", "radosgw", "ceph-radosgw.gateway", "keyring"))
 	assert.True(s.T(), os.IsNotExist(err))
 }

--- a/microceph/ceph/service_placement_mon.go
+++ b/microceph/ceph/service_placement_mon.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microceph/microceph/database"
 )
 
@@ -14,27 +14,27 @@ type MonServicePlacement struct {
 }
 
 // Populate json payload data to the service object.
-func (msp *MonServicePlacement) PopulateParams(s common.StateInterface, payload string) error {
+func (msp *MonServicePlacement) PopulateParams(s interfaces.StateInterface, payload string) error {
 	return nil
 }
 
 // Check if host is hospitable to the new service to be enabled.
-func (msp *MonServicePlacement) HospitalityCheck(s common.StateInterface) error {
+func (msp *MonServicePlacement) HospitalityCheck(s interfaces.StateInterface) error {
 	return genericHospitalityCheck(msp.Name)
 }
 
 // Initialise the new service.
-func (msp *MonServicePlacement) ServiceInit(s common.StateInterface) error {
+func (msp *MonServicePlacement) ServiceInit(s interfaces.StateInterface) error {
 	return genericServiceInit(s, msp.Name)
 }
 
 // Perform Post Placement checks for the service
-func (msp *MonServicePlacement) PostPlacementCheck(s common.StateInterface) error {
+func (msp *MonServicePlacement) PostPlacementCheck(s interfaces.StateInterface) error {
 	return genericPostPlacementCheck(msp.Name)
 }
 
 // Perform DB updates to persist the service enablement changes.
-func (msp *MonServicePlacement) DbUpdate(s common.StateInterface) error {
+func (msp *MonServicePlacement) DbUpdate(s interfaces.StateInterface) error {
 	// Update the database.
 	err := s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
 		// Record the role.

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
@@ -147,7 +147,7 @@ func ListServices(s *state.State) (types.Services, error) {
 
 // cleanService removes conf data for a service from the cluster.
 func cleanService(hostname, service string) error {
-	paths := contants.GetPathConst()
+	paths := constants.GetPathConst()
 	dataPath := filepath.Join(paths.DataPath, service, fmt.Sprintf("ceph-%s", hostname))
 	err := os.RemoveAll(dataPath)
 	if err != nil {

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
 	"time"
@@ -145,7 +147,7 @@ func ListServices(s *state.State) (types.Services, error) {
 
 // cleanService removes conf data for a service from the cluster.
 func cleanService(hostname, service string) error {
-	paths := common.GetPathConst()
+	paths := contants.GetPathConst()
 	dataPath := filepath.Join(paths.DataPath, service, fmt.Sprintf("ceph-%s", hostname))
 	err := os.RemoveAll(dataPath)
 	if err != nil {
@@ -156,7 +158,7 @@ func cleanService(hostname, service string) error {
 }
 
 // removeServiceDatabase removes a service record from the database.
-func removeServiceDatabase(s common.StateInterface, service string) error {
+func removeServiceDatabase(s interfaces.StateInterface, service string) error {
 	if s.ClusterState().Database == nil {
 		return fmt.Errorf("no database")
 	}
@@ -174,7 +176,7 @@ func removeServiceDatabase(s common.StateInterface, service string) error {
 }
 
 // DeleteService deletes a service from the node.
-func DeleteService(s common.StateInterface, service string) error {
+func DeleteService(s interfaces.StateInterface, service string) error {
 	err := snapStop(service, true)
 	if err != nil {
 		logger.Errorf("failed to stop daemon %q: %v", service, err)

--- a/microceph/ceph/services_placement.go
+++ b/microceph/ceph/services_placement.go
@@ -2,24 +2,24 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/common"
 )
 
 // PlacementIntf is the interface used for running various services in a MicroCeph cluster.
 type PlacementIntf interface {
 	// Populate json payload data to the service object.
-	PopulateParams(common.StateInterface, string) error
+	PopulateParams(interfaces.StateInterface, string) error
 	// Check if host is hospitable to the new service to be enabled.
-	HospitalityCheck(common.StateInterface) error
+	HospitalityCheck(interfaces.StateInterface) error
 	// Initialise the new service.
-	ServiceInit(common.StateInterface) error
+	ServiceInit(interfaces.StateInterface) error
 	// Perform Post Placement checks for the service
-	PostPlacementCheck(common.StateInterface) error
+	PostPlacementCheck(interfaces.StateInterface) error
 	// Perform DB updates to persist the service enablement changes.
-	DbUpdate(common.StateInterface) error
+	DbUpdate(interfaces.StateInterface) error
 }
 
 func GetServicePlacementTable() map[string](PlacementIntf) {
@@ -31,7 +31,7 @@ func GetServicePlacementTable() map[string](PlacementIntf) {
 	}
 }
 
-func ServicePlacementHandler(s common.StateInterface, payload types.EnableService) error {
+func ServicePlacementHandler(s interfaces.StateInterface, payload types.EnableService) error {
 	var ok bool
 	var spt = GetServicePlacementTable()
 	var sp PlacementIntf
@@ -63,7 +63,7 @@ func ServicePlacementHandler(s common.StateInterface, payload types.EnableServic
 	return nil
 }
 
-func EnableService(s common.StateInterface, payload types.EnableService, item PlacementIntf) error {
+func EnableService(s interfaces.StateInterface, payload types.EnableService, item PlacementIntf) error {
 
 	// Populate json payload data to the service object.
 	err := item.PopulateParams(s, payload.Payload)

--- a/microceph/ceph/services_placement_generic.go
+++ b/microceph/ceph/services_placement_generic.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
@@ -67,8 +67,8 @@ func genericServiceInit(s interfaces.StateInterface, name string) error {
 	var ok bool
 	var addService func(string, string) error
 	hostname := s.ClusterState().Name()
-	pathConsts := contants.GetPathConst()
-	pathFileMode := contants.GetPathFileMode()
+	pathConsts := constants.GetPathConst()
+	pathFileMode := constants.GetPathFileMode()
 	serviceDataPath := filepath.Join(pathConsts.DataPath, name, fmt.Sprintf("ceph-%s", hostname))
 	addServiceTable := GetAddServiceTable()
 

--- a/microceph/ceph/services_placement_generic.go
+++ b/microceph/ceph/services_placement_generic.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microceph/microceph/database"
 )
 
@@ -28,24 +29,24 @@ type GenericServicePlacement struct {
 	Name string
 }
 
-func (gsp *GenericServicePlacement) PopulateParams(s common.StateInterface, payload string) error {
+func (gsp *GenericServicePlacement) PopulateParams(s interfaces.StateInterface, payload string) error {
 	// No params needed to initialise generic service
 	return nil
 }
 
-func (gsp *GenericServicePlacement) HospitalityCheck(s common.StateInterface) error {
+func (gsp *GenericServicePlacement) HospitalityCheck(s interfaces.StateInterface) error {
 	return genericHospitalityCheck(gsp.Name)
 }
 
-func (gsp *GenericServicePlacement) ServiceInit(s common.StateInterface) error {
+func (gsp *GenericServicePlacement) ServiceInit(s interfaces.StateInterface) error {
 	return genericServiceInit(s, gsp.Name)
 }
 
-func (gsp *GenericServicePlacement) PostPlacementCheck(s common.StateInterface) error {
+func (gsp *GenericServicePlacement) PostPlacementCheck(s interfaces.StateInterface) error {
 	return genericPostPlacementCheck(gsp.Name)
 }
 
-func (gsp *GenericServicePlacement) DbUpdate(s common.StateInterface) error {
+func (gsp *GenericServicePlacement) DbUpdate(s interfaces.StateInterface) error {
 	return genericDbUpdate(s, gsp.Name)
 }
 
@@ -62,12 +63,12 @@ func genericHospitalityCheck(service string) error {
 	return nil
 }
 
-func genericServiceInit(s common.StateInterface, name string) error {
+func genericServiceInit(s interfaces.StateInterface, name string) error {
 	var ok bool
 	var addService func(string, string) error
 	hostname := s.ClusterState().Name()
-	pathConsts := common.GetPathConst()
-	pathFileMode := common.GetPathFileMode()
+	pathConsts := contants.GetPathConst()
+	pathFileMode := contants.GetPathFileMode()
 	serviceDataPath := filepath.Join(pathConsts.DataPath, name, fmt.Sprintf("ceph-%s", hostname))
 	addServiceTable := GetAddServiceTable()
 
@@ -119,7 +120,7 @@ func genericPostPlacementCheck(service string) error {
 	return nil
 }
 
-func genericDbUpdate(s common.StateInterface, service string) error {
+func genericDbUpdate(s interfaces.StateInterface, service string) error {
 	// Update the database.
 	err := s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
 		// Record the roles.

--- a/microceph/ceph/services_placement_rgw.go
+++ b/microceph/ceph/services_placement_rgw.go
@@ -2,15 +2,14 @@ package ceph
 
 import (
 	"encoding/json"
-
-	"github.com/canonical/microceph/microceph/common"
+	"github.com/canonical/microceph/microceph/interfaces"
 )
 
 type RgwServicePlacement struct {
 	Port int
 }
 
-func (rgw *RgwServicePlacement) PopulateParams(s common.StateInterface, payload string) error {
+func (rgw *RgwServicePlacement) PopulateParams(s interfaces.StateInterface, payload string) error {
 
 	err := json.Unmarshal([]byte(payload), &rgw)
 	if err != nil {
@@ -20,18 +19,18 @@ func (rgw *RgwServicePlacement) PopulateParams(s common.StateInterface, payload 
 	return nil
 }
 
-func (rgw *RgwServicePlacement) HospitalityCheck(s common.StateInterface) error {
+func (rgw *RgwServicePlacement) HospitalityCheck(s interfaces.StateInterface) error {
 	return genericHospitalityCheck("rgw")
 }
 
-func (rgw *RgwServicePlacement) ServiceInit(s common.StateInterface) error {
+func (rgw *RgwServicePlacement) ServiceInit(s interfaces.StateInterface) error {
 	return EnableRGW(s, rgw.Port)
 }
 
-func (rgw *RgwServicePlacement) PostPlacementCheck(s common.StateInterface) error {
+func (rgw *RgwServicePlacement) PostPlacementCheck(s interfaces.StateInterface) error {
 	return genericPostPlacementCheck("rgw")
 }
 
-func (rgw *RgwServicePlacement) DbUpdate(s common.StateInterface) error {
+func (rgw *RgwServicePlacement) DbUpdate(s interfaces.StateInterface) error {
 	return genericDbUpdate(s, "rgw")
 }

--- a/microceph/ceph/services_placement_test.go
+++ b/microceph/ceph/services_placement_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/microceph/microceph/tests"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/api/types"
@@ -11,7 +12,7 @@ import (
 )
 
 type servicesPlacementSuite struct {
-	baseSuite
+	tests.BaseSuite
 	TestStateInterface *mocks.StateInterface
 }
 
@@ -21,7 +22,7 @@ func TestServicesPlacement(t *testing.T) {
 
 // Set up test suite
 func (s *servicesPlacementSuite) SetupTest() {
-	s.baseSuite.SetupTest()
+	s.BaseSuite.SetupTest()
 }
 
 func addSnapServiceActiveExpectations(r *mocks.Runner, service string, retStr string, retErr error) {

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/tests"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +14,7 @@ import (
 )
 
 type servicesSuite struct {
-	baseSuite
+	tests.BaseSuite
 	// TestStateInterface *mocks.StateInterface
 }
 
@@ -23,7 +24,7 @@ func TestServices(t *testing.T) {
 
 // Set up test suite
 func (s *servicesSuite) SetupTest() {
-	s.baseSuite.SetupTest()
+	s.BaseSuite.SetupTest()
 }
 
 func addOsdDumpExpectations(r *mocks.Runner) {
@@ -75,8 +76,8 @@ func (s *servicesSuite) TestRestartServiceWorkerSuccess() {
 
 // TestCleanService tests the cleanService function.
 func (s *servicesSuite) TestCleanService() {
-	s.copyCephConfigs()
-	svcPath := filepath.Join(s.tmp, "SNAP_COMMON", "data", "mon", "ceph-foo-host")
+	s.CopyCephConfigs()
+	svcPath := filepath.Join(s.Tmp, "SNAP_COMMON", "data", "mon", "ceph-foo-host")
 	os.MkdirAll(svcPath, 0770)
 	cleanService("foo-host", "mon")
 	assert.NoDirExists(s.T(), svcPath)

--- a/microceph/ceph/start.go
+++ b/microceph/ceph/start.go
@@ -3,15 +3,15 @@ package ceph
 import (
 	"context"
 	"database/sql"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"reflect"
 	"time"
 
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microceph/microceph/database"
 )
 
 // Start is run on daemon startup.
-func Start(s common.StateInterface) error {
+func Start(s interfaces.StateInterface) error {
 	// Start background loop to refresh the config every minute if needed.
 	go func() {
 		oldMonitors := []string{}

--- a/microceph/client/client_configs.go
+++ b/microceph/client/client_configs.go
@@ -3,12 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"time"
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microcluster/client"
 )
 
@@ -78,7 +78,7 @@ func UpdateClientConf(ctx context.Context, c *client.Client) error {
 }
 
 // Sends the update conf request to every other member of the cluster.
-func SendUpdateClientConfRequestToClusterMembers(s common.StateInterface) error {
+func SendUpdateClientConfRequestToClusterMembers(s interfaces.StateInterface) error {
 	// Get a collection of clients to every other cluster member, with the notification user-agent set.
 	cluster, err := s.ClusterState().Cluster(nil)
 	if err != nil {

--- a/microceph/cmd/microceph/client_config_reset.go
+++ b/microceph/cmd/microceph/client_config_reset.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/ceph"
@@ -49,7 +49,7 @@ func (c *cmdClientConfigReset) Run(cmd *cobra.Command, args []string) error {
 
 	if !c.flagForce {
 		return fmt.Errorf("WARNING: this will *PERMANENTLY REMOVE* all records of the %s key. %s",
-			args[0], contants.CliForcePrompt)
+			args[0], constants.CliForcePrompt)
 	}
 
 	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})

--- a/microceph/cmd/microceph/client_config_reset.go
+++ b/microceph/cmd/microceph/client_config_reset.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 )
@@ -49,7 +49,7 @@ func (c *cmdClientConfigReset) Run(cmd *cobra.Command, args []string) error {
 
 	if !c.flagForce {
 		return fmt.Errorf("WARNING: this will *PERMANENTLY REMOVE* all records of the %s key. %s",
-			args[0], common.CliForcePrompt)
+			args[0], contants.CliForcePrompt)
 	}
 
 	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})

--- a/microceph/cmd/microceph/cluster_bootstrap.go
+++ b/microceph/cmd/microceph/cluster_bootstrap.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
 	"os"
 	"time"
 
@@ -52,7 +53,7 @@ func (c *cmdClusterBootstrap) Run(cmd *cobra.Command, args []string) error {
 
 	// Get system address for microcluster bootstrap.
 	address := util.NetworkInterfaceAddress()
-	address = util.CanonicalNetworkAddress(address, common.BootstrapPortConst)
+	address = util.CanonicalNetworkAddress(address, contants.BootstrapPortConst)
 
 	// Set parameter data for Ceph bootstrap.
 	data := common.BootstrapConfig{

--- a/microceph/cmd/microceph/cluster_bootstrap.go
+++ b/microceph/cmd/microceph/cluster_bootstrap.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"os"
 	"time"
 
@@ -53,7 +53,7 @@ func (c *cmdClusterBootstrap) Run(cmd *cobra.Command, args []string) error {
 
 	// Get system address for microcluster bootstrap.
 	address := util.NetworkInterfaceAddress()
-	address = util.CanonicalNetworkAddress(address, contants.BootstrapPortConst)
+	address = util.CanonicalNetworkAddress(address, constants.BootstrapPortConst)
 
 	// Set parameter data for Ceph bootstrap.
 	data := common.BootstrapConfig{

--- a/microceph/cmd/microceph/disk_add.go
+++ b/microceph/cmd/microceph/disk_add.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"sort"
 	"strings"
 
@@ -99,7 +99,7 @@ func (c *cmdDiskAdd) Run(cmd *cobra.Command, args []string) error {
 		// Pass space separated params as disk paths.
 		req.Path = args
 
-		if !strings.HasPrefix(req.Path[0], contants.LoopSpecId) {
+		if !strings.HasPrefix(req.Path[0], constants.LoopSpecId) {
 			if c.walDevice != "" {
 				req.WALDev = &c.walDevice
 				req.WALWipe = c.walWipe
@@ -191,7 +191,7 @@ func (c *cmdDiskAdd) validateBatchArgs(args []string) error {
 	}
 
 	for _, diskPath := range args {
-		if strings.HasPrefix(diskPath, contants.LoopSpecId) {
+		if strings.HasPrefix(diskPath, constants.LoopSpecId) {
 			return fmt.Errorf("loop spec %s is not supported as an argument to batch disk addition, use separately", diskPath)
 		}
 	}

--- a/microceph/cmd/microceph/disk_add.go
+++ b/microceph/cmd/microceph/disk_add.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
 	"sort"
 	"strings"
 
@@ -12,7 +13,6 @@ import (
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
-	"github.com/canonical/microceph/microceph/common"
 )
 
 type cmdDiskAdd struct {
@@ -99,7 +99,7 @@ func (c *cmdDiskAdd) Run(cmd *cobra.Command, args []string) error {
 		// Pass space separated params as disk paths.
 		req.Path = args
 
-		if !strings.HasPrefix(req.Path[0], common.LoopSpecId) {
+		if !strings.HasPrefix(req.Path[0], contants.LoopSpecId) {
 			if c.walDevice != "" {
 				req.WALDev = &c.walDevice
 				req.WALWipe = c.walWipe
@@ -191,7 +191,7 @@ func (c *cmdDiskAdd) validateBatchArgs(args []string) error {
 	}
 
 	for _, diskPath := range args {
-		if strings.HasPrefix(diskPath, common.LoopSpecId) {
+		if strings.HasPrefix(diskPath, contants.LoopSpecId) {
 			return fmt.Errorf("loop spec %s is not supported as an argument to batch disk addition, use separately", diskPath)
 		}
 	}

--- a/microceph/cmd/microceph/disk_list.go
+++ b/microceph/cmd/microceph/disk_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
 	"os"
 	"sort"
 
@@ -16,7 +17,6 @@ import (
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
-	"github.com/canonical/microceph/microceph/common"
 )
 
 type cmdDiskList struct {
@@ -168,12 +168,12 @@ func getUnpartitionedDisks(cli *microCli.Client) ([]Disk, error) {
 		}
 
 		// Minimum size set to 2GB i.e. 2*1024*1024*1024
-		if disk.Size < common.MinOSDSize {
+		if disk.Size < contants.MinOSDSize {
 			logger.Debugf("Ignoring device %s, size less than 2GB", disk.DeviceID)
 			continue
 		}
 
-		devicePath := fmt.Sprintf("%s%s", common.DevicePathPrefix, disk.DeviceID)
+		devicePath := fmt.Sprintf("%s%s", contants.DevicePathPrefix, disk.DeviceID)
 
 		found := false
 		// check if disk already employed as an OSD.

--- a/microceph/cmd/microceph/disk_list.go
+++ b/microceph/cmd/microceph/disk_list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 	"os"
 	"sort"
 
@@ -168,12 +168,12 @@ func getUnpartitionedDisks(cli *microCli.Client) ([]Disk, error) {
 		}
 
 		// Minimum size set to 2GB i.e. 2*1024*1024*1024
-		if disk.Size < contants.MinOSDSize {
+		if disk.Size < constants.MinOSDSize {
 			logger.Debugf("Ignoring device %s, size less than 2GB", disk.DeviceID)
 			continue
 		}
 
-		devicePath := fmt.Sprintf("%s%s", contants.DevicePathPrefix, disk.DeviceID)
+		devicePath := fmt.Sprintf("%s%s", constants.DevicePathPrefix, disk.DeviceID)
 
 		found := false
 		// check if disk already employed as an OSD.

--- a/microceph/cmd/microcephd/main.go
+++ b/microceph/cmd/microcephd/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"github.com/canonical/microceph/microceph/interfaces"
 	"math/rand"
 	"os"
 	"time"
@@ -70,18 +71,18 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	h := &config.Hooks{}
 	h.OnBootstrap = func(s *state.State, initConfig map[string]string) error {
 		data := common.BootstrapConfig{}
-		interf := common.CephState{State: s}
+		interf := interfaces.CephState{State: s}
 		common.DecodeBootstrapConfig(initConfig, &data)
 		return ceph.Bootstrap(interf, data)
 	}
 
 	h.PostJoin = func(s *state.State, initConfig map[string]string) error {
-		interf := common.CephState{State: s}
+		interf := interfaces.CephState{State: s}
 		return ceph.Join(interf)
 	}
 
 	h.OnStart = func(s *state.State) error {
-		interf := common.CephState{State: s}
+		interf := interfaces.CephState{State: s}
 		return ceph.Start(interf)
 	}
 

--- a/microceph/common/cluster.go
+++ b/microceph/common/cluster.go
@@ -1,8 +1,11 @@
 package common
 
-import "github.com/canonical/lxd/shared/logger"
+import (
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microceph/microceph/interfaces"
+)
 
-func GetClusterMemberNames(s StateInterface) ([]string, error) {
+func GetClusterMemberNames(s interfaces.StateInterface) ([]string, error) {
 	leader, err := s.ClusterState().Leader()
 	if err != nil {
 		return nil, err

--- a/microceph/constants/constants.go
+++ b/microceph/constants/constants.go
@@ -1,5 +1,5 @@
 // Package common
-package contants
+package constants
 
 import (
 	"os"
@@ -33,7 +33,7 @@ func GetPathConst() PathConst {
 		RunPath:  filepath.Join(os.Getenv("SNAP_DATA"), "run"),
 		DataPath: filepath.Join(os.Getenv("SNAP_COMMON"), "data"),
 		LogPath:  filepath.Join(os.Getenv("SNAP_COMMON"), "logs"),
-		ProcPath: filepath.Join(os.Getenv("TEST_ROOT_PATH"), "proc"),
+		ProcPath: filepath.Join(os.Getenv("TEST_ROOT_PATH"), "/proc"),
 	}
 }
 

--- a/microceph/contants/constants.go
+++ b/microceph/contants/constants.go
@@ -1,5 +1,5 @@
 // Package common
-package common
+package contants
 
 import (
 	"os"
@@ -22,6 +22,7 @@ type PathConst struct {
 	RunPath  string
 	DataPath string
 	LogPath  string
+	ProcPath string
 }
 
 type PathFileMode map[string]os.FileMode
@@ -32,6 +33,7 @@ func GetPathConst() PathConst {
 		RunPath:  filepath.Join(os.Getenv("SNAP_DATA"), "run"),
 		DataPath: filepath.Join(os.Getenv("SNAP_COMMON"), "data"),
 		LogPath:  filepath.Join(os.Getenv("SNAP_COMMON"), "logs"),
+		ProcPath: filepath.Join(os.Getenv("TEST_ROOT_PATH"), "proc"),
 	}
 }
 

--- a/microceph/database/client_config_extras.go
+++ b/microceph/database/client_config_extras.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/canonical/microceph/microceph/contants"
 
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/state"
 )
@@ -48,7 +48,7 @@ func (cci ClientConfigItems) GetClientConfigSlice() types.ClientConfigs {
 		if len(configItem.Host) > 0 {
 			host = configItem.Host
 		} else {
-			host = common.ClientConfigGlobalHostConst
+			host = contants.ClientConfigGlobalHostConst
 		}
 
 		ccs[i] = types.ClientConfig{
@@ -184,7 +184,7 @@ func (ccq ClientConfigQueryImpl) GetGlobalConfigs(s *state.State, key string) ([
 
 	// scan handler for global configs.
 	dest := func(scan func(dest ...any) error) error {
-		c := ClientConfigItem{Host: common.ClientConfigGlobalHostConst}
+		c := ClientConfigItem{Host: contants.ClientConfigGlobalHostConst}
 		err := scan(&c.ID, &c.Key, &c.Value)
 		if err != nil {
 			return err
@@ -248,7 +248,7 @@ func createOrUpdateClientConfigItem(ctx context.Context, tx *sql.Tx, object Clie
 	var args []any
 
 	// Populate the statement arguments.
-	if object.Host == common.ClientConfigGlobalHostConst {
+	if object.Host == contants.ClientConfigGlobalHostConst {
 		args = append(args, object.Key)
 		args = append(args, object.Value)
 		stmtIndex = globalClientConfigItemCreateOrUpdate

--- a/microceph/database/client_config_extras.go
+++ b/microceph/database/client_config_extras.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/canonical/microceph/microceph/contants"
+	"github.com/canonical/microceph/microceph/constants"
 
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
@@ -48,7 +48,7 @@ func (cci ClientConfigItems) GetClientConfigSlice() types.ClientConfigs {
 		if len(configItem.Host) > 0 {
 			host = configItem.Host
 		} else {
-			host = contants.ClientConfigGlobalHostConst
+			host = constants.ClientConfigGlobalHostConst
 		}
 
 		ccs[i] = types.ClientConfig{
@@ -184,7 +184,7 @@ func (ccq ClientConfigQueryImpl) GetGlobalConfigs(s *state.State, key string) ([
 
 	// scan handler for global configs.
 	dest := func(scan func(dest ...any) error) error {
-		c := ClientConfigItem{Host: contants.ClientConfigGlobalHostConst}
+		c := ClientConfigItem{Host: constants.ClientConfigGlobalHostConst}
 		err := scan(&c.ID, &c.Key, &c.Value)
 		if err != nil {
 			return err
@@ -248,7 +248,7 @@ func createOrUpdateClientConfigItem(ctx context.Context, tx *sql.Tx, object Clie
 	var args []any
 
 	// Populate the statement arguments.
-	if object.Host == contants.ClientConfigGlobalHostConst {
+	if object.Host == constants.ClientConfigGlobalHostConst {
 		args = append(args, object.Key)
 		args = append(args, object.Value)
 		stmtIndex = globalClientConfigItemCreateOrUpdate

--- a/microceph/interfaces/state.go
+++ b/microceph/interfaces/state.go
@@ -1,5 +1,5 @@
 // Package common interfaces the microcluster cluster state
-package common
+package interfaces
 
 import (
 	"github.com/canonical/microcluster/state"

--- a/microceph/mocks/OSDQueryInterface.go
+++ b/microceph/mocks/OSDQueryInterface.go
@@ -27,17 +27,27 @@ func (_m *OSDQueryInterface) Delete(s *state.State, osd int64) error {
 }
 
 // HaveOSD provides a mock function with given fields: s, osd
-func (_m *OSDQueryInterface) HaveOSD(s *state.State, osd int64) bool {
+func (_m *OSDQueryInterface) HaveOSD(s *state.State, osd int64) (bool, error) {
 	ret := _m.Called(s, osd)
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*state.State, int64) (bool, error)); ok {
+		return rf(s, osd)
+	}
 	if rf, ok := ret.Get(0).(func(*state.State, int64) bool); ok {
 		r0 = rf(s, osd)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(*state.State, int64) error); ok {
+		r1 = rf(s, osd)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // List provides a mock function with given fields: s
@@ -88,6 +98,20 @@ func (_m *OSDQueryInterface) Path(s *state.State, osd int64) (string, error) {
 	}
 
 	return r0, r1
+}
+
+// UpdatePath provides a mock function with given fields: s, osd, path
+func (_m *OSDQueryInterface) UpdatePath(s *state.State, osd int64, path string) error {
+	ret := _m.Called(s, osd, path)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*state.State, int64, string) error); ok {
+		r0 = rf(s, osd, path)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // NewOSDQueryInterface creates a new instance of OSDQueryInterface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/microceph/mocks/PlacementIntf.go
+++ b/microceph/mocks/PlacementIntf.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	common "github.com/canonical/microceph/microceph/common"
+	interfaces "github.com/canonical/microceph/microceph/interfaces"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -13,11 +13,11 @@ type PlacementIntf struct {
 }
 
 // DbUpdate provides a mock function with given fields: _a0
-func (_m *PlacementIntf) DbUpdate(_a0 common.StateInterface) error {
+func (_m *PlacementIntf) DbUpdate(_a0 interfaces.StateInterface) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(common.StateInterface) error); ok {
+	if rf, ok := ret.Get(0).(func(interfaces.StateInterface) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
@@ -27,11 +27,11 @@ func (_m *PlacementIntf) DbUpdate(_a0 common.StateInterface) error {
 }
 
 // HospitalityCheck provides a mock function with given fields: _a0
-func (_m *PlacementIntf) HospitalityCheck(_a0 common.StateInterface) error {
+func (_m *PlacementIntf) HospitalityCheck(_a0 interfaces.StateInterface) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(common.StateInterface) error); ok {
+	if rf, ok := ret.Get(0).(func(interfaces.StateInterface) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
@@ -41,11 +41,11 @@ func (_m *PlacementIntf) HospitalityCheck(_a0 common.StateInterface) error {
 }
 
 // PopulateParams provides a mock function with given fields: _a0, _a1
-func (_m *PlacementIntf) PopulateParams(_a0 common.StateInterface, _a1 string) error {
+func (_m *PlacementIntf) PopulateParams(_a0 interfaces.StateInterface, _a1 string) error {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(common.StateInterface, string) error); ok {
+	if rf, ok := ret.Get(0).(func(interfaces.StateInterface, string) error); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)
@@ -55,11 +55,11 @@ func (_m *PlacementIntf) PopulateParams(_a0 common.StateInterface, _a1 string) e
 }
 
 // PostPlacementCheck provides a mock function with given fields: _a0
-func (_m *PlacementIntf) PostPlacementCheck(_a0 common.StateInterface) error {
+func (_m *PlacementIntf) PostPlacementCheck(_a0 interfaces.StateInterface) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(common.StateInterface) error); ok {
+	if rf, ok := ret.Get(0).(func(interfaces.StateInterface) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
@@ -69,11 +69,11 @@ func (_m *PlacementIntf) PostPlacementCheck(_a0 common.StateInterface) error {
 }
 
 // ServiceInit provides a mock function with given fields: _a0
-func (_m *PlacementIntf) ServiceInit(_a0 common.StateInterface) error {
+func (_m *PlacementIntf) ServiceInit(_a0 interfaces.StateInterface) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(common.StateInterface) error); ok {
+	if rf, ok := ret.Get(0).(func(interfaces.StateInterface) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)

--- a/microceph/tests/testutils.go
+++ b/microceph/tests/testutils.go
@@ -1,4 +1,4 @@
-package ceph
+package tests
 
 import (
 	"os"
@@ -10,26 +10,26 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type baseSuite struct {
+type BaseSuite struct {
 	suite.Suite
-	tmp string
+	Tmp string
 }
 
-// createTmp creates a temporary directory for the test
-func (s *baseSuite) createTmp() {
+// CreateTmp creates a temporary directory for the test
+func (s *BaseSuite) CreateTmp() {
 	var err error
-	s.tmp, err = os.MkdirTemp("", "microceph-test")
+	s.Tmp, err = os.MkdirTemp("", "microceph-test")
 	if err != nil {
-		s.T().Fatal("error creating tmp:", err)
+		s.T().Fatal("error creating Tmp:", err)
 	}
 }
 
 // copyCephConfigs copies a test config file to the test directory
-func (s *baseSuite) copyCephConfigs() {
+func (s *BaseSuite) CopyCephConfigs() {
 	var err error
 
 	for _, d := range []string{"SNAP_DATA", "SNAP_COMMON"} {
-		p := filepath.Join(s.tmp, d)
+		p := filepath.Join(s.Tmp, d)
 		err = os.MkdirAll(p, 0770)
 		if err != nil {
 			s.T().Fatal("error creating dir:", err)
@@ -37,7 +37,7 @@ func (s *baseSuite) copyCephConfigs() {
 		os.Setenv(d, p)
 	}
 	for _, d := range []string{"SNAP_DATA/conf", "SNAP_DATA/run", "SNAP_COMMON/data", "SNAP_COMMON/logs"} {
-		p := filepath.Join(s.tmp, d)
+		p := filepath.Join(s.Tmp, d)
 		err = os.Mkdir(p, 0770)
 		if err != nil {
 			s.T().Fatal("error creating dir:", err)
@@ -45,7 +45,7 @@ func (s *baseSuite) copyCephConfigs() {
 	}
 
 	for _, f := range []string{"ceph.client.admin.keyring", "ceph.conf"} {
-		err = copyTestConf(s.tmp, f)
+		err = CopyTestConf(s.Tmp, f)
 		if err != nil {
 			s.T().Fatal("error copying testconf:", err)
 		}
@@ -53,21 +53,23 @@ func (s *baseSuite) copyCephConfigs() {
 }
 
 // readCephConfig reads a config file from the test directory
-func (s *baseSuite) readCephConfig(conf string) string {
+func (s *BaseSuite) ReadCephConfig(conf string) string {
 	// Read the config file
-	data, _ := os.ReadFile(filepath.Join(s.tmp, "SNAP_DATA", "conf", conf))
+	data, _ := os.ReadFile(filepath.Join(s.Tmp, "SNAP_DATA", "conf", conf))
 	return string(data)
 }
 
-func (s *baseSuite) SetupTest() {
-	s.createTmp()
+func (s *BaseSuite) SetupTest() {
+	s.CreateTmp()
+	os.Setenv("TEST_ROOT_PATH", s.Tmp)
+	os.MkdirAll(filepath.Join(s.Tmp, "proc"), 0775)
 }
 
-func (s *baseSuite) TearDownTest() {
-	os.RemoveAll(s.tmp)
+func (s *BaseSuite) TearDownTest() {
+	os.RemoveAll(s.Tmp)
 }
 
-func cmdAny(cmd string, no int) []interface{} {
+func CmdAny(cmd string, no int) []interface{} {
 	any := make([]interface{}, no+1)
 	for i := range any {
 		any[i] = mock.Anything
@@ -76,7 +78,7 @@ func cmdAny(cmd string, no int) []interface{} {
 	return any
 }
 
-func copyTestConf(dir string, conf string) error {
+func CopyTestConf(dir string, conf string) error {
 	_, tfile, _, _ := runtime.Caller(0)
 	pkgDir := path.Join(path.Dir(tfile), "..")
 


### PR DESCRIPTION
Centralize testutils, split up common to avoid import cycles. Also fix up some whitespace inconsistency