### PR TITLE
Fix storage unit test

### DIFF
--- a/microceph/common/storage.go
+++ b/microceph/common/storage.go
@@ -13,7 +13,7 @@ import (
 func IsMounted(device string) (bool, error) {
 	// Resolve any symlink and get the absolute path of the device.
 	// Note /proc/mounts contains the absolute path of the device as well.
-	resolvedPath, err := filepath.EvalSymlinks(device)
+	resolvedPath, err := filepath.EvalSymlinks(filepath.Join(constants.GetPathConst().RootFs, device))
 	if err != nil {
 		// Handle errors other than not existing differently as EvalSymlinks takes care of symlink resolution
 		return false, err

--- a/microceph/common/storage_test.go
+++ b/microceph/common/storage_test.go
@@ -22,11 +22,14 @@ func (s *StorageDeviceTestSuite) SetupTest() {
 	// create a temp file to use as a device
 	s.devicePath = filepath.Join(s.Tmp, "device")
 	os.Create(s.devicePath)
+	os.MkdirAll(filepath.Join(s.Tmp, "dev"), 0775)
+	os.Create(filepath.Join(s.Tmp, "dev", "sdb"))
+	os.Create(filepath.Join(s.Tmp, "dev", "sdc"))
 
 	// create a /proc/mounts like file
 	mountsFile := filepath.Join(s.Tmp, "proc", "mounts")
 	mountsContent := "/dev/root / ext4 rw,relatime,discard,errors=remount-ro 0 0\n"
-	mountsContent += "/dev/sdb /mnt ext2 rw,relatime 0 0\n"
+	mountsContent += filepath.Join(s.Tmp, "dev", "sdb") + " /mnt ext2 rw,relatime 0 0\n"
 	_ = os.WriteFile(mountsFile, []byte(mountsContent), 0644)
 
 }

--- a/microceph/constants/constants.go
+++ b/microceph/constants/constants.go
@@ -22,6 +22,7 @@ type PathConst struct {
 	RunPath  string
 	DataPath string
 	LogPath  string
+	RootFs   string
 	ProcPath string
 }
 
@@ -33,6 +34,7 @@ func GetPathConst() PathConst {
 		RunPath:  filepath.Join(os.Getenv("SNAP_DATA"), "run"),
 		DataPath: filepath.Join(os.Getenv("SNAP_COMMON"), "data"),
 		LogPath:  filepath.Join(os.Getenv("SNAP_COMMON"), "logs"),
+		RootFs:   filepath.Join(os.Getenv("TEST_ROOT_PATH"), "/"),
 		ProcPath: filepath.Join(os.Getenv("TEST_ROOT_PATH"), "/proc"),
 	}
 }


### PR DESCRIPTION
Edit: adding a local unit test run as the CI for unittests is broken:

```
peter@pirx ~/src/microceph/microceph ±fix/storage-unit-test » make check-unit 
go test ./...
?   	github.com/canonical/microceph/microceph/api	[no test files]
?   	github.com/canonical/microceph/microceph/api/types	[no test files]
?   	github.com/canonical/microceph/microceph/client	[no test files]
?   	github.com/canonical/microceph/microceph/cmd/microcephd	[no test files]
?   	github.com/canonical/microceph/microceph/constants	[no test files]
?   	github.com/canonical/microceph/microceph/database	[no test files]
?   	github.com/canonical/microceph/microceph/interfaces	[no test files]
?   	github.com/canonical/microceph/microceph/mocks	[no test files]
?   	github.com/canonical/microceph/microceph/tests	[no test files]
?   	github.com/canonical/microceph/microceph/version	[no test files]
ok  	github.com/canonical/microceph/microceph/ceph	0.021s
ok  	github.com/canonical/microceph/microceph/cmd/microceph	0.006s
ok  	github.com/canonical/microceph/microceph/common	0.006s
```