### PR TITLE
Fixup build check

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -284,7 +284,7 @@ parts:
       go get -d -v ./...
     override-build: |
       set -ex
-      git_diff="$( git -C $CRAFT_PROJECT_DIR status --porcelain )"
+      git_diff="$( git -C $CRAFT_PROJECT_DIR status -uno --porcelain )"
       if [ -n "$git_diff" ]; then
         echo "=================================================="
         echo "STOP the build: dirty worktree detected"


### PR DESCRIPTION
Don't check untracked files so as not to fail for parts/ and stage/ dirs