### PR TITLE
Use microcluster API to remove cluster members

### DIFF
--- a/microceph/ceph/pre_remove_test.go
+++ b/microceph/ceph/pre_remove_test.go
@@ -1,12 +1,13 @@
-package main
+package ceph
 
 import (
+	"testing"
+
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
 	"github.com/canonical/microceph/microceph/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"testing"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -46,7 +47,6 @@ func (s *clusterRemoveSuite) TestRemoveNode() {
 		nil,
 	)
 	m.On("DeleteService", mock.Anything, "foonode", "mon").Return(nil).Once()
-	m.On("DeleteClusterMember", mock.Anything, "foonode", false).Return(nil).Once()
 
 	err := removeNode(nil, "foonode", false)
 
@@ -68,9 +68,6 @@ func (s *clusterRemoveSuite) TestRemoveNodeWithDisks() {
 	err := removeNode(nil, "foonode", false)
 
 	assert.Error(s.T(), err)
-
-	// assert that we didn't try to delete the node
-	m.AssertNotCalled(s.T(), "DeleteClusterMember", mock.Anything, "foonode", false)
 }
 
 // TestRemoveNodeLastMon tests that we don't try to delete a node that has the last mon
@@ -93,9 +90,6 @@ func (s *clusterRemoveSuite) TestRemoveNodeLastMon() {
 	err := removeNode(nil, "foonode", false)
 
 	assert.Error(s.T(), err)
-
-	// assert that we didn't try to delete the node
-	m.AssertNotCalled(s.T(), "DeleteClusterMember", mock.Anything, "foonode", false)
 }
 
 // TestRemoveNodeForce tests that we don't check prerequisites and delete a node if forced
@@ -114,7 +108,6 @@ func (s *clusterRemoveSuite) TestRemoveNodeForce() {
 		nil,
 	)
 	m.On("DeleteService", mock.Anything, "foonode", "mon").Return(nil).Once()
-	m.On("DeleteClusterMember", mock.Anything, "foonode", true).Return(nil).Once()
 
 	err := removeNode(nil, "foonode", true)
 

--- a/microceph/ceph/remove.go
+++ b/microceph/ceph/remove.go
@@ -1,0 +1,120 @@
+package ceph
+
+import (
+	"fmt"
+
+	"github.com/canonical/lxd/shared/logger"
+	microCli "github.com/canonical/microcluster/client"
+
+	"github.com/canonical/microceph/microceph/client"
+)
+
+func removeNode(cli *microCli.Client, node string, force bool) error {
+
+	logger.Debugf("Removing cluster member %v, force: %v", node, force)
+
+	// check prerquisites unless we're forcing
+	if !force {
+		err := checkPrerequisites(cli, node)
+		if err != nil {
+			return err
+		}
+	}
+
+	// delete from ceph
+	err := deleteNodeServices(cli, node)
+	if err != nil {
+		// forcing makes errs non-fatal
+		if !force {
+			return err
+		}
+		logger.Warnf("Error deleting services from node %v: %v", node, err)
+	}
+
+	// delete from cluster db
+	err = client.MClient.DeleteClusterMember(cli, node, force)
+	logger.Debugf("DeleteClusterMember %v: %v", node, err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkPrerequisites(cli *microCli.Client, name string) error {
+	// check if member exists
+	clusterMembers, err := client.MClient.GetClusterMembers(cli)
+	if err != nil {
+		return fmt.Errorf("Error getting cluster members: %v", err)
+	}
+	found := false
+	for _, member := range clusterMembers {
+		if member == name {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("Node %v not found", name)
+	}
+
+	// check if any OSDs present
+	disks, err := client.MClient.GetDisks(cli)
+	if err != nil {
+		return fmt.Errorf("Error getting disks: %v", err)
+	}
+	found = false
+	for _, disk := range disks {
+		if disk.Location == name {
+			found = true
+		}
+	}
+	logger.Debugf("Disks: %v, found: %v", disks, found)
+	if found {
+		return fmt.Errorf("Node %v still has disks configured, remove before proceeding", name)
+	}
+
+	// check if this node has the last mon
+	services, err := client.MClient.GetServices(cli)
+	if err != nil {
+		return fmt.Errorf("Error getting services: %v", err)
+	}
+	// create a map of service names counters
+	// init with false
+	foundMap := map[string]int{
+		"mon": 0,
+		"mgr": 0,
+		"mds": 0,
+	}
+	// loop through services and check service counts
+	for _, service := range services {
+		if service.Location == name {
+			continue
+		}
+		foundMap[service.Service]++
+	}
+	logger.Debugf("Services: %v, foundMap: %v", services, foundMap)
+	if foundMap["mon"] < 3 || foundMap["mgr"] < 1 || foundMap["mds"] < 1 {
+		return fmt.Errorf("Need at least 3 mon, 1 mds, and 1 mgr besides %v", name)
+	}
+
+	return nil
+}
+
+func deleteNodeServices(cli *microCli.Client, name string) error {
+	services, err := client.MClient.GetServices(cli)
+	if err != nil {
+		return err
+	}
+	for _, service := range services {
+		logger.Debugf("Check for deletion: %s", service)
+		if service.Location == name {
+			logger.Debugf("Deleting service %s", service)
+			err = client.MClient.DeleteService(cli, service.Location, service.Service)
+			if err != nil {
+				logger.Warnf("Fault deleting service %v on node %v: %v", service.Service, service.Location, err)
+			}
+		}
+	}
+	return nil
+
+}

--- a/microceph/cmd/microceph/cluster_remove.go
+++ b/microceph/cmd/microceph/cluster_remove.go
@@ -1,14 +1,10 @@
 package main
 
 import (
-	"fmt"
+	"context"
 
-	"github.com/canonical/lxd/shared/logger"
-	microCli "github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
-
-	"github.com/canonical/microceph/microceph/client"
 )
 
 type cmdClusterRemove struct {
@@ -45,115 +41,5 @@ func (c *cmdClusterRemove) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return removeNode(cli, args[0], c.flagForce)
-}
-
-func removeNode(cli *microCli.Client, node string, force bool) error {
-
-	logger.Debugf("Removing cluster member %v, force: %v", node, force)
-
-	// check prerquisites unless we're forcing
-	if !force {
-		err := checkPrerequisites(cli, node)
-		if err != nil {
-			return err
-		}
-	}
-
-	// delete from ceph
-	err := deleteNodeServices(cli, node)
-	if err != nil {
-		// forcing makes errs non-fatal
-		if !force {
-			return err
-		}
-		logger.Warnf("Error deleting services from node %v: %v", node, err)
-	}
-
-	// delete from cluster db
-	err = client.MClient.DeleteClusterMember(cli, node, force)
-	logger.Debugf("DeleteClusterMember %v: %v", node, err)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func checkPrerequisites(cli *microCli.Client, name string) error {
-	// check if member exists
-	clusterMembers, err := client.MClient.GetClusterMembers(cli)
-	if err != nil {
-		return fmt.Errorf("Error getting cluster members: %v", err)
-	}
-	found := false
-	for _, member := range clusterMembers {
-		if member == name {
-			found = true
-		}
-	}
-	if !found {
-		return fmt.Errorf("Node %v not found", name)
-	}
-
-	// check if any OSDs present
-	disks, err := client.MClient.GetDisks(cli)
-	if err != nil {
-		return fmt.Errorf("Error getting disks: %v", err)
-	}
-	found = false
-	for _, disk := range disks {
-		if disk.Location == name {
-			found = true
-		}
-	}
-	logger.Debugf("Disks: %v, found: %v", disks, found)
-	if found {
-		return fmt.Errorf("Node %v still has disks configured, remove before proceeding", name)
-	}
-
-	// check if this node has the last mon
-	services, err := client.MClient.GetServices(cli)
-	if err != nil {
-		return fmt.Errorf("Error getting services: %v", err)
-	}
-	// create a map of service names counters
-	// init with false
-	foundMap := map[string]int{
-		"mon": 0,
-		"mgr": 0,
-		"mds": 0,
-	}
-	// loop through services and check service counts
-	for _, service := range services {
-		if service.Location == name {
-			continue
-		}
-		foundMap[service.Service]++
-	}
-	logger.Debugf("Services: %v, foundMap: %v", services, foundMap)
-	if foundMap["mon"] < 3 || foundMap["mgr"] < 1 || foundMap["mds"] < 1 {
-		return fmt.Errorf("Need at least 3 mon, 1 mds, and 1 mgr besides %v", name)
-	}
-
-	return nil
-}
-
-func deleteNodeServices(cli *microCli.Client, name string) error {
-	services, err := client.MClient.GetServices(cli)
-	if err != nil {
-		return err
-	}
-	for _, service := range services {
-		logger.Debugf("Check for deletion: %s", service)
-		if service.Location == name {
-			logger.Debugf("Deleting service %s", service)
-			err = client.MClient.DeleteService(cli, service.Location, service.Service)
-			if err != nil {
-				logger.Warnf("Fault deleting service %v on node %v: %v", service.Service, service.Location, err)
-			}
-		}
-	}
-	return nil
-
+	return cli.DeleteClusterMember(context.Background(), args[0], c.flagForce)
 }

--- a/microceph/cmd/microcephd/main.go
+++ b/microceph/cmd/microcephd/main.go
@@ -86,6 +86,8 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return ceph.Start(interf)
 	}
 
+	h.PreRemove = ceph.PreRemove(m)
+
 	m.AddServers(api.Servers)
 	return m.Start(context.Background(), database.SchemaExtensions, nil, h)
 }


### PR DESCRIPTION
Closes #255 

As discussed in Riga, this refactors the node removal process to rely on the microcluster API instead of directly implementing removal in the MicroCeph CLI.

The main changes are that the `removeNode` function and all its helpers have been moved to the `ceph` package. The `removeNode` function itself has been wrapped in a `PreRemove` to match the corresponding hook in microcluster. Now in the CLI, we can simply call `DeleteClusterMember` and the `PreRemove` hook will automatically execute on that node as it is passed to microcluster when we call `app.Start`.


This will allow MicroCloud to utilize MicroCeph's API to tear down the cluster in case of an error during initialization. Additionally, it cleans up MicroCeph so there isn't so much internal implementation in the CLI package. 
 