### PR TITLE
Add setuptools dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -227,6 +227,7 @@ parts:
       - lib/*/rados-classes
       - lib/*/libtcmalloc.so*
       - lib/*/libunwind.so*
+      - lib/*/liblmdb.so*
       - share/ceph
 
   dqlite:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,8 +1,7 @@
 name: microceph
-base: core24
+base: core22
 adopt-info: ceph
-build-base: devel
-grade: devel
+grade: stable
 source-code: https://github.com/canonical/microceph.git
 license: AGPL-3.0
 summary: Simple clustered Ceph deployment
@@ -11,10 +10,10 @@ description: |-
 
 confinement: strict
 
-# package-repositories:
-#   - type: apt
-#     cloud: bobcat
-#     priority: always
+package-repositories:
+  - type: apt
+    cloud: caracal
+    priority: always
 
 slots:
   ceph-conf:
@@ -163,6 +162,7 @@ parts:
       - radosgw
       - coreutils
       - uuid-runtime
+      - python3-setuptools
     organize:
       usr/bin/: bin/
       usr/sbin/: bin/


### PR DESCRIPTION
Ceph has a dependency on distutils, which was removed from the packaging since it was an undeclared package dependency. This change adds setuptools package to work around this dependency.

Since distutils has been removed from python 12, this also reverts to core22.
