### PR TITLE
Fix: 4 Mon problem

### DIFF
--- a/microceph/ceph/join.go
+++ b/microceph/ceph/join.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+
 	"github.com/canonical/microceph/microceph/constants"
 	"github.com/canonical/microceph/microceph/interfaces"
-	"os"
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/microceph/microceph/common"
@@ -26,44 +27,21 @@ func Join(s interfaces.StateInterface) error {
 		}
 	}
 
-	// Generate the configuration from the database.
+	// Generate the configuration files from the database.
 	err := UpdateConfig(s)
 	if err != nil {
 		return fmt.Errorf("failed to generate the configuration: %w", err)
 	}
 
-	// Query existing core services.
-	srvMon := 0
-	srvMgr := 0
-	srvMds := 0
-
+	// check and create service records if needed to be spawned.
 	err = s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
-		// Monitors.
-		name := "mon"
-		services, err := database.GetServices(ctx, tx, database.ServiceFilter{Service: &name})
-		if err != nil {
-			return err
+		autoServices := []string{"mon", "mds", "mgr"}
+		for _, service := range autoServices {
+			err := checkAndCreateServiceRecord(s, ctx, tx, service)
+			if err != nil {
+				return err
+			}
 		}
-
-		srvMon = len(services)
-
-		// Managers.
-		name = "mgr"
-		services, err = database.GetServices(ctx, tx, database.ServiceFilter{Service: &name})
-		if err != nil {
-			return err
-		}
-
-		srvMgr = len(services)
-
-		// Metadata.
-		name = "mds"
-		services, err = database.GetServices(ctx, tx, database.ServiceFilter{Service: &name})
-		if err != nil {
-			return err
-		}
-
-		srvMds = len(services)
 
 		return nil
 	})
@@ -71,43 +49,19 @@ func Join(s interfaces.StateInterface) error {
 		return err
 	}
 
-	// Add additional services as required.
-	services := []string{}
-
-	if srvMon < 3 {
-		err := spt["mon"].ServiceInit(s)
-		if err != nil {
-			logger.Errorf("%v", err)
-			return err
-		}
-
-		services = append(services, "mon")
-	}
-
-	if srvMgr < 3 {
-		err := spt["mgr"].ServiceInit(s)
-		if err != nil {
-			logger.Errorf("%v", err)
-			return err
-		}
-
-		services = append(services, "mgr")
-	}
-
-	if srvMds < 3 {
-		err := spt["mds"].ServiceInit(s)
-		if err != nil {
-			logger.Errorf("%v", err)
-			return err
-		}
-
-		services = append(services, "mds")
-	}
-
-	// Update the database.
-	err = updateDatabasePostJoin(s, services)
+	// Get services recorded for this host.
+	plannedServices, err := getServicesForHost(s, s.ClusterState().Name())
 	if err != nil {
-		return fmt.Errorf("failed to update DB post join: %w", err)
+		return err
+	}
+
+	// spawn planned auto services.
+	for _, service := range plannedServices {
+		err := spt[service.Service].ServiceInit(s)
+		if err != nil {
+			logger.Errorf("%v", err)
+			return err
+		}
 	}
 
 	// Start OSD service.
@@ -119,29 +73,47 @@ func Join(s interfaces.StateInterface) error {
 	return nil
 }
 
-func updateDatabasePostJoin(s interfaces.StateInterface, services []string) error {
+// getServicesForHost get services needed to be spawned on this machine.
+func getServicesForHost(s interfaces.StateInterface, hostname string) ([]database.Service, error) {
+	hostname = s.ClusterState().Name()
+	var services []database.Service
 	err := s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
-		// Record the roles.
-		for _, service := range services {
-			_, err := database.CreateService(ctx, tx, database.Service{Member: s.ClusterState().Name(), Service: service})
-			if err != nil {
-				return fmt.Errorf("failed to record role: %w", err)
-			}
-
-			if service == "mon" {
-				err = updateDbForMon(s, ctx, tx)
-				if err != nil {
-					return fmt.Errorf("failed to record mon db entries: %w", err)
-				}
-			}
+		var err error
+		services, err = database.GetServices(ctx, tx, database.ServiceFilter{Member: &hostname})
+		if err != nil {
+			return err
 		}
 
 		return nil
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	return services, nil
+}
+
+// checkAndCreateServiceRecord check if service is required to be spawned.
+func checkAndCreateServiceRecord(s interfaces.StateInterface, ctx context.Context, tx *sql.Tx, name string) error {
+	services, err := database.GetServices(ctx, tx, database.ServiceFilter{Service: &name})
+	if err != nil {
 		return err
 	}
 
+	// create record if service is to be spawned.
+	if len(services) < 3 {
+		_, err := database.CreateService(ctx, tx, database.Service{Member: s.ClusterState().Name(), Service: name})
+		if err != nil {
+			return fmt.Errorf("failed to record role: %w", err)
+		}
+
+		if name == "mon" {
+			err = updateDbForMon(s, ctx, tx)
+			if err != nil {
+				return fmt.Errorf("failed to record mon db entries: %w", err)
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
# Description

Changes the decision logic for spawning new services at join. We now create the record in same transaction so that stale records do not cause more than 3 auto services to be spawned.

Fixes #351 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?
Manual tests using charm microceph (node count 4)

## Contributor's Checklist

Please check that you have:

- [ ] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
