### PR TITLE
Update microcluster dependency

### DIFF
--- a/microceph/api/servers.go
+++ b/microceph/api/servers.go
@@ -8,7 +8,8 @@ import (
 
 var Servers = []rest.Server{
 	{
-		CoreAPI: true,
+		CoreAPI:   true,
+		ServeUnix: true,
 		Resources: []rest.Resources{
 			{
 				PathPrefix: types.ExtendedPathPrefix,

--- a/microceph/api/servers.go
+++ b/microceph/api/servers.go
@@ -24,7 +24,6 @@ var Servers = []rest.Server{
 					mdsServiceCmd,
 					mgrServiceCmd,
 					monServiceCmd,
-					rgwServiceCmd,
 					poolsCmd,
 					clientCmd,
 					clientConfigsCmd,

--- a/microceph/ceph/start.go
+++ b/microceph/ceph/start.go
@@ -3,12 +3,13 @@ package ceph
 import (
 	"context"
 	"database/sql"
-	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/microceph/microceph/interfaces"
 	"reflect"
 	"time"
 
+	"github.com/canonical/lxd/shared/logger"
+
 	"github.com/canonical/microceph/microceph/database"
+	"github.com/canonical/microceph/microceph/interfaces"
 )
 
 // Start is run on daemon startup.
@@ -19,7 +20,8 @@ func Start(s interfaces.StateInterface) error {
 
 		for {
 			// Check that the database is ready.
-			if !s.ClusterState().Database.IsOpen() {
+			err := s.ClusterState().Database.IsOpen(context.Background())
+			if err != nil {
 				logger.Debug("start: database not ready, waiting...")
 				time.Sleep(10 * time.Second)
 				continue
@@ -27,7 +29,7 @@ func Start(s interfaces.StateInterface) error {
 
 			// Get the current list of monitors.
 			monitors := []string{}
-			err := s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
+			err = s.ClusterState().Database.Transaction(s.ClusterState().Context, func(ctx context.Context, tx *sql.Tx) error {
 				serviceName := "mon"
 				services, err := database.GetServices(ctx, tx, database.ServiceFilter{Service: &serviceName})
 				if err != nil {

--- a/microceph/cmd/microceph/init.go
+++ b/microceph/cmd/microceph/init.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
 	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared/api"
 	microCli "github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
@@ -43,7 +45,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 
 	// Check if already initialized.
 	_, err = lc.GetClusterMembers(context.Background())
-	isUninitialized := err != nil && err.Error() == "Daemon not yet initialized"
+	isUninitialized := err != nil && api.StatusErrorCheck(err, http.StatusServiceUnavailable)
 	if err != nil && !isUninitialized {
 		return err
 	}

--- a/microceph/cmd/microcephd/main.go
+++ b/microceph/cmd/microcephd/main.go
@@ -63,7 +63,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
 }
 
 func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
-	m, err := microcluster.App(microcluster.Args{StateDir: c.flagStateDir, Verbose: c.global.flagLogVerbose, Debug: c.global.flagLogDebug, ExtensionServers: api.Servers})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.flagStateDir, Verbose: c.global.flagLogVerbose, Debug: c.global.flagLogDebug})
 	if err != nil {
 		return err
 	}
@@ -86,6 +86,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return ceph.Start(interf)
 	}
 
+	m.AddServers(api.Servers)
 	return m.Start(context.Background(), database.SchemaExtensions, nil, h)
 }
 

--- a/microceph/go.mod
+++ b/microceph/go.mod
@@ -5,7 +5,7 @@ go 1.22.4
 require (
 	github.com/Rican7/retry v0.3.1
 	github.com/canonical/lxd v0.0.0-20240620053341-f9f88f4e77ae
-	github.com/canonical/microcluster v0.0.0-20240620074518-efdde3f746b9
+	github.com/canonical/microcluster v0.0.0-20240703182409-ec0a2d6e0f31
 	github.com/djherbis/times v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.1

--- a/microceph/go.sum
+++ b/microceph/go.sum
@@ -56,8 +56,8 @@ github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2Ge
 github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/lxd v0.0.0-20240620053341-f9f88f4e77ae h1:hGqmOkL92DGFd0nxz7WaH2cTRyZ5zLtR6fUO2hSII5M=
 github.com/canonical/lxd v0.0.0-20240620053341-f9f88f4e77ae/go.mod h1:no3pt2T1PrTq/FME3rZ5N/JH4GtLClSEThhOtOUb1X8=
-github.com/canonical/microcluster v0.0.0-20240620074518-efdde3f746b9 h1:ogzDv0S33LI3DG44gRdRwtKb2ozV+SkPLp2/cBR3ksE=
-github.com/canonical/microcluster v0.0.0-20240620074518-efdde3f746b9/go.mod h1:hQyeUVMU2XaiXy5InYE8YkbNtyJdZp8BPXRTNL9G950=
+github.com/canonical/microcluster v0.0.0-20240703182409-ec0a2d6e0f31 h1:+ea1KwbFqKHUWmQsOiyAdBhkQ+Y4Kh66PF9Nmw5ucIU=
+github.com/canonical/microcluster v0.0.0-20240703182409-ec0a2d6e0f31/go.mod h1:hQyeUVMU2XaiXy5InYE8YkbNtyJdZp8BPXRTNL9G950=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
This introduces a bit more robust schema upgrade processing, as well as better error handling during first start.

In particular, during an upgrade, the cluster will report its current status instead of blocking. The table below shows `microceph cluster list` output when 1 node is refreshed and awaiting the upgrade to appear on all nodes before proceeding to apply the update:

```
+--------+----------------+-------+-----------------------------+---------------+
|  NAME  |    ADDRESS     |  ROLE |         FINGERPRINT         |    STATUS     |
+--------+----------------+-------+-----------------------------+---------------+
| micro0 | 127.0.0.1:9000 | voter | c3d485471729f2f04f6401530f7 |   UPGRADING   |
+--------+----------------+-------+-----------------------------+---------------+
| micro1 | 127.0.0.1:9001 | voter | 515c7eace0aba1f7a42761824ab | NEEDS UPGRADE |
+--------+----------------+-------+-----------------------------+---------------+
| micro2 | 127.0.0.1:9002 | voter | 4f461765de6659b0e683a5b11ed | NEEDS UPGRADE |
+--------+----------------+-------+-----------------------------+---------------+
| micro3 | 127.0.0.1:9003 | voter | d94955e2c26cb2e987489933bdz | NEEDS UPGRADE |
+--------+----------------+-------+-----------------------------+---------------+
```