### PR TITLE
Allow skipping daemon restart post config op

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -556,3 +556,50 @@ jobs:
 
     - name: Exercise RGW again
       run: ~/actionutils.sh headexec testrgw
+
+  cluster-tests:
+    name: Test MicroCeph Cluster features.
+    runs-on: ubuntu-22.04
+    needs: build-microceph
+    steps:
+    - name: Download snap
+      uses: actions/download-artifact@v3
+      with:
+        name: snaps
+        path: /home/runner
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Copy utils
+      run: cp tests/scripts/actionutils.sh $HOME
+
+    - name: Clear FORWARD firewall rules
+      run: ~/actionutils.sh cleaript
+
+    - name: Free disk
+      run: ~/actionutils.sh free_runner_disk
+
+    - name: Install and setup
+      run: ~/actionutils.sh install_microceph
+
+    - name: Add loopback file OSDs
+      run: |
+        set -uex
+        sudo microceph disk add loop,1G,3
+        ~/actionutils.sh wait_for_osds 3
+        sudo microceph.ceph -s
+
+    - name: Enable RGW
+      run: ~/actionutils.sh enable_rgw
+
+    - name: Exercise RGW
+      run: ~/actionutils.sh testrgw
+
+    - name: Bombard MicroCeph with cluster configs
+      run: ~/actionutils.sh bombard_rgw_configs
+
+    - name: Exercise RGW again
+      run: ~/actionutils.sh testrgw "newFile"

--- a/docs/reference/commands/cluster.rst
+++ b/docs/reference/commands/cluster.rst
@@ -128,7 +128,8 @@ Flags:
 
 .. code-block:: none
 
-   --wait   Wait for required ceph services to restart post config reset.
+   --wait           Wait for required ceph services to restart post config reset.
+   --skip-restart   Don't perform the daemon restart for current config.
 
 
 ``config set``
@@ -147,7 +148,8 @@ Flags:
 
 .. code-block:: none
 
-   --wait   Wait for required ceph services to restart post config set.
+   --wait           Wait for required ceph services to restart post config set.
+   --skip-restart   Don't perform the daemon restart for current config.
 
 
 ``join``

--- a/microceph/api/configs.go
+++ b/microceph/api/configs.go
@@ -62,8 +62,10 @@ func cmdConfigsPut(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	services := configTable[req.Key].Daemons
-	configChangeRefresh(s, services, req.Wait)
+	if !req.SkipRestart {
+		services := configTable[req.Key].Daemons
+		configChangeRefresh(s, services, req.Wait)
+	}
 
 	return response.EmptySyncResponse
 }
@@ -83,8 +85,10 @@ func cmdConfigsDelete(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	services := configTable[req.Key].Daemons
-	configChangeRefresh(s, services, req.Wait)
+	if !req.SkipRestart {
+		services := configTable[req.Key].Daemons
+		configChangeRefresh(s, services, req.Wait)
+	}
 
 	return response.EmptySyncResponse
 }

--- a/microceph/api/types/configs.go
+++ b/microceph/api/types/configs.go
@@ -3,9 +3,10 @@ package types
 
 // Configs holds the key value pair
 type Config struct {
-	Key   string `json:"key" yaml:"key"`
-	Value string `json:"value" yaml:"value"`
-	Wait  bool   `json:"wait" yaml:"wait"`
+	Key         string `json:"key" yaml:"key"`
+	Value       string `json:"value" yaml:"value"`
+	Wait        bool   `json:"wait" yaml:"wait"`
+	SkipRestart bool   `json:"skip_restart" yaml:"skip_restart"`
 }
 
 // Configs is a slice of configs

--- a/microceph/cmd/microceph/cluster_config_set.go
+++ b/microceph/cmd/microceph/cluster_config_set.go
@@ -17,7 +17,8 @@ type cmdClusterConfigSet struct {
 	cluster       *cmdCluster
 	clusterConfig *cmdClusterConfig
 
-	flagWait bool
+	flagWait        bool
+	flagSkipRestart bool
 }
 
 func (c *cmdClusterConfigSet) Command() *cobra.Command {
@@ -28,6 +29,7 @@ func (c *cmdClusterConfigSet) Command() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&c.flagWait, "wait", false, "Wait for required ceph services to restart post config set.")
+	cmd.Flags().BoolVar(&c.flagSkipRestart, "skip-restart", false, "Don't perform the daemon restart for current config.")
 	return cmd
 }
 
@@ -38,12 +40,12 @@ func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, ok := allowList[args[0]]; !ok {
-		return fmt.Errorf("Configuring key %s is not allowed. \nPermitted Keys: %v", args[0], allowList.Keys())
+		return fmt.Errorf("configuring key %s is not allowed. \nPermitted Keys: %v", args[0], allowList.Keys())
 	}
 
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
-		return fmt.Errorf("Unable to configure MicroCeph: %w", err)
+		return fmt.Errorf("unable to configure MicroCeph: %w", err)
 	}
 
 	cli, err := m.LocalClient()
@@ -52,9 +54,10 @@ func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	req := &types.Config{
-		Key:   args[0],
-		Value: args[1],
-		Wait:  c.flagWait,
+		Key:         args[0],
+		Value:       args[1],
+		Wait:        c.flagWait,
+		SkipRestart: c.flagSkipRestart,
 	}
 
 	err = client.SetConfig(context.Background(), cli, req)


### PR DESCRIPTION
# Description

Allow the operator to skip daemon restart when applying bulk configurations to prevent repeated restarts of the service.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?
Added CI test to bombard the cluster with RGW configs but restart the RGW deamon only for the last config set. The expectation is that RGW IO tests should function as they did before the configs.

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [X] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
