### PR TITLE
Fix run dir issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -549,7 +549,7 @@ jobs:
       run: ~/actionutils.sh headexec testrgw
 
     - name: Install local build
-      run: ~/actionutils.sh install_multinode
+      run: ~/actionutils.sh upgrade_multinode
 
     - name: Wait until 3 OSDs are up
       run:  ~/actionutils.sh headexec wait_for_osds 3

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -70,8 +70,8 @@ func GetConstConfigTable() ConfigTable {
 		"rgw_keystone_implicit_tenants":               {"global", []string{"rgw"}},
 		"rgw_swift_account_in_url":                    {"global", []string{"rgw"}},
 		"rgw_swift_versioning_enabled":                {"global", []string{"rgw"}},
-                "rgw_swift_enforce_content_length":            {"global", []string{"rgw"}},
-                "rgw_swift_custom_header":                     {"global", []string{"rgw"}},
+		"rgw_swift_enforce_content_length":            {"global", []string{"rgw"}},
+		"rgw_swift_custom_header":                     {"global", []string{"rgw"}},
 	}
 }
 
@@ -254,7 +254,7 @@ func backwardCompatMonitors(s interfaces.StateInterface) ([]string, error) {
 // UpdateConfig updates the ceph.conf file with the current configuration.
 func UpdateConfig(s interfaces.StateInterface) error {
 	confPath := filepath.Join(os.Getenv("SNAP_DATA"), "conf")
-	runPath := filepath.Join(os.Getenv("SNAP_DATA"), "run")
+	runPath := filepath.Join(filepath.Dir(os.Getenv("SNAP_DATA")), "current", "run")
 
 	err := backwardCompatPubnet(s)
 	if err != nil {

--- a/snapcraft/commands/common
+++ b/snapcraft/commands/common
@@ -1,7 +1,6 @@
 wait_for_config() {
-
   local confpath="${SNAP_DATA}/conf/ceph.conf"
-  local search_str="^run dir = ${SNAP_DATA}/run"
+  local search_str="^run dir = "
   local max_attempts=300
   local attempt=0
 
@@ -15,6 +14,6 @@ wait_for_config() {
     sleep 2
   done
 
-  echo "No updated conf found in ${confpath}"
+  echo "No conf found in ${confpath}"
   return 1
 }


### PR DESCRIPTION
# Description

With the from PR #378 microcephd daemons now wait for all nodes to be on the same schema level in a multinode upgrade scenario. However we used to depend on the microcephd to update the `run dir` parameter in ceph.conf; for sequential updates (where we iteratively upgrade nodes while keeping the cluster operational) this creates a circular dependency.

This PR removes the need for updateing run dir during an upgrade.

Also contains func test improvements to verify the sequential upgrade scenario.

Fixes #386 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Functional tests updated

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
