### PR TITLE
Adds etc-ceph plug to MicroCeph

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,12 @@ slots:
       read:
         - "$SNAP_DATA/conf"
 
+plugs:
+  etc-ceph:
+    interface: system-files
+    read: /etc/ceph
+    write: /etc/ceph
+
 environment:
   LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/compressor:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/crypto:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/erasure-code
   PYTHONPATH: $SNAP/lib/python3/dist-packages
@@ -52,6 +58,7 @@ apps:
       - mount-observe
       - network
       - network-bind
+      - etc-ceph
     slots:
       - microceph
   mds:


### PR DESCRIPTION
# Description
Adds a `etc-ceph` plug to MicroCeph to automatically manage the `etc/ceph` contents.

Fixes #na

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?
[ ] - Add a test to check for cluster status using ceph-commons cli client `/etc/ceph` should be automatically managed.


## Contributor's Checklist

Please check that you have:

- [ ] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
