### PR TITLE
snap/snapcraft: replace deprecated CRAFT_ARCH_TRIPLET with CRAFT_ARCH_TRIPLET_BUILD_FOR

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,14 +23,14 @@ slots:
         - "$SNAP_DATA/conf"
 
 environment:
-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/compressor:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/crypto:$SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph/erasure-code
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph:$SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph/compressor:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph/crypto:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph/erasure-code
   PYTHONPATH: $SNAP/lib/python3/dist-packages
 
 layout:
-  /usr/lib/$CRAFT_ARCH_TRIPLET/ceph:
-    symlink: $SNAP/lib/$CRAFT_ARCH_TRIPLET/ceph
-  /usr/lib/$CRAFT_ARCH_TRIPLET/rados-classes:
-    symlink: $SNAP/lib/$CRAFT_ARCH_TRIPLET/rados-classes
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph:
+    symlink: $SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/ceph
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/rados-classes:
+    symlink: $SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/rados-classes
   /etc/ceph:
     bind: $SNAP_DATA/conf
   /usr/share/ceph:


### PR DESCRIPTION
# Description

`CRAFT_ARCH_TRIPLET` is deprecated for core22 and doesn't exist for core24 as described [here](https://snapcraft.io/docs/reference-architectures#core22).

The patch also fixes the following warnings during the build that could also be seen in "Build microceph snap" job during "Build snaps" step for every PR:

> CRAFT_ARCH_TRIPLET is deprecated, use CRAFT_ARCH_TRIPLET_BUILD_{ON|FOR}

Fixes #-

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

I tested it locally using `snapcraft pack -v`. The deprecation warning is no longer there.

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.