### PR TITLE
doc: remove `woke-install` as prereq for building the docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -53,7 +53,7 @@ woke-install:
 .PHONY:  woke-install
 
 
-install: $(VENVDIR) woke-install
+install: $(VENVDIR)
 
 .PHONY:  install
 


### PR DESCRIPTION
# Description

`woke-install` is needed to run woke on the docs, but it is not required for building the documentation.

## Type of change

Please delete options that are not relevant.

- [x] CleanCode (Code refactor, test updates, does not introduce functional changes) for CI