### PR TITLE
Add interfaces: rbd kernel module and support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,9 @@ jobs:
         if [[ $rc -eq 0 ]] ; then echo "Batch disk addition should fail with db device: $rc"; exit 1; fi
 
     - name: Add OSDs
-      run: ~/actionutils.sh add_encrypted_osds
+      run: |
+        ~/actionutils.sh add_encrypted_osds
+        ~/actionutils.sh add_lvm_vol
 
     - name: Enable RGW
       run: ~/actionutils.sh enable_rgw

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,13 @@ description: |-
 
 confinement: strict
 
+plugs:
+  load-rbd:
+    interface: kernel-module-load
+    modules:
+      - name: rbd
+        load: on-boot
+
 slots:
   ceph-conf:
     interface: content
@@ -47,6 +54,7 @@ apps:
       - mount-observe
       - network
       - network-bind
+      - microceph-support
     slots:
       - microceph
   mds:
@@ -84,6 +92,7 @@ apps:
       - hardware-observe
       - network
       - network-bind
+      - microceph-support
 
   rgw:
     command: commands/rgw.start
@@ -115,6 +124,9 @@ apps:
     command: commands/rbd
     plugs:
       - network
+      - network-bind
+      - microceph-support
+      - dm-crypt
   rados:
     command: commands/rados
     plugs:


### PR DESCRIPTION
# Description

Add interfaces. Allow loading the rbd kernel module and add the microceph-support interface which allows additional block device types

Fixes #254  #251

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

As a test using an lvm vol as an OSD. RBD map support is not complete yet.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
