### PR TITLE
Fetch current OSD pool configuration over the API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,10 +214,13 @@ jobs:
         sudo microceph.ceph osd pool create mypool
         sudo microceph pool set-rf --size 1 ""
         sudo microceph.ceph config get osd.1 osd_pool_default_size | fgrep -x "1"
+        sudo microceph pool list | fgrep "mypool" | fgrep -q " 3 "
         sudo microceph pool set-rf --size 3 mypool
         sudo microceph.ceph osd pool get mypool size | fgrep -x "size: 3"
+        sudo microceph pool list | fgrep "mypool" | fgrep -q " 3 "
         sudo microceph pool set-rf --size 1 "*"
         sudo microceph.ceph osd pool get mypool size | fgrep -x "size: 1"
+        sudo microceph pool list | fgrep "mypool" | fgrep -q " 1 "
 
     - name: Test log operations
       run: |

--- a/microceph/api/pool.go
+++ b/microceph/api/pool.go
@@ -15,9 +15,27 @@ import (
 )
 
 // /1.0/pools-op endpoint.
-var poolsCmd = rest.Endpoint{
+var poolsOpCmd = rest.Endpoint{
 	Path: "pools-op",
 	Put:  rest.EndpointAction{Handler: cmdPoolsPut, ProxyTarget: true},
+}
+
+// /1.0/pools endpoint.
+var poolsCmd = rest.Endpoint{
+	Path: "pools",
+	Get:  rest.EndpointAction{Handler: cmdPoolsGet, ProxyTarget: true},
+}
+
+func cmdPoolsGet(s state.State, r *http.Request) response.Response {
+	logger.Debug("cmdPoolGet")
+	pools, err := ceph.GetOSDPools()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	logger.Debug("cmdPoolGet done")
+
+	return response.SyncResponse(true, pools)
 }
 
 func cmdPoolsPut(s state.State, r *http.Request) response.Response {

--- a/microceph/api/servers.go
+++ b/microceph/api/servers.go
@@ -24,6 +24,7 @@ var Servers = map[string]rest.Server{
 					mdsServiceCmd,
 					mgrServiceCmd,
 					monServiceCmd,
+					poolsOpCmd,
 					poolsCmd,
 					clientCmd,
 					clientConfigsCmd,

--- a/microceph/api/types/pool.go
+++ b/microceph/api/types/pool.go
@@ -5,3 +5,12 @@ type PoolPut struct {
 	Pools []string `json:"pools" yaml:"pools"`
 	Size  int64    `json:"size" yaml:"size"`
 }
+
+// Pool represents information about an OSD pool.
+type Pool struct {
+	Pool      string `json:"pool" yaml:"pool"`
+	PoolID    int64  `json:"pool_id" yaml:"pool_id"`
+	Size      int64  `json:"size" yaml:"size"`
+	MinSize   int64  `json:"min_size" yaml:"min_size"`
+	CrushRule string `json:"crush_rule" yaml:"crush_rule"`
+}

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -1096,12 +1096,15 @@ func SetReplicationFactor(pools []string, size int64) error {
 
 	if len(pools) == 1 && pools[0] == "*" {
 		// Apply setting to all existing pools.
-		out, err := processExec.RunCommand("ceph", "osd", "pool", "ls")
+		out, err := processExec.RunCommand("ceph", "osd", "pool", "ls", "--format", "json")
 		if err != nil {
 			return fmt.Errorf("failed to list pools: %w", err)
 		}
 
-		pools = strings.Split(out, "\n")
+		err = json.Unmarshal([]byte(out), &pools)
+		if err != nil {
+			return fmt.Errorf("Failed to parse OSD pool names: %w", err)
+		}
 	}
 
 	for _, pool := range pools {
@@ -1109,6 +1112,7 @@ func SetReplicationFactor(pools []string, size int64) error {
 		if pool == "" {
 			continue
 		}
+
 		_, err := processExec.RunCommand("ceph", "osd", "pool", "set", pool, "size", ssize, "--yes-i-really-mean-it")
 		if err != nil {
 			return fmt.Errorf("failed to set pool size for %s: %w", pool, err)

--- a/microceph/client/pool.go
+++ b/microceph/client/pool.go
@@ -23,3 +23,17 @@ func PoolSetReplicationFactor(ctx context.Context, c *microCli.Client, data *typ
 
 	return nil
 }
+
+func GetPools(ctx context.Context, c *microCli.Client) ([]types.Pool, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+
+	var pools []types.Pool
+	err := c.Query(queryCtx, "GET", types.ExtendedPathPrefix, api.NewURL().Path("pools"), nil, &pools)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch OSD pools: %w", err)
+	}
+
+	return pools, nil
+
+}


### PR DESCRIPTION
`PUT /1.0/pools-op` lets you set the replication size for several OSD pools. 

This PR adds the ability to fetch the current sizes (and some other relevant OSD pool information) via `GET /1.0/pools`. The goal of this is to obtain the correct OSD pool names to supply to `PUT /1.0/pools-op`, as well as to determine what the current size of each pool is. 

As discussed on mattermost: https://chat.canonical.com/canonical/pl/g3heo1kmz7r6db39re9qyzfw4w