### PR TITLE
Added python3-onelogin-saml2 to stage-packages in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,6 +170,7 @@ parts:
       - coreutils
       - uuid-runtime
       - python3-setuptools
+      - python3-onelogin-saml2
     organize:
       usr/bin/: bin/
       usr/sbin/: bin/


### PR DESCRIPTION
# Description

This PR adds the python3-onelogin-saml2 package to the stage-packages in the snapcraft.yaml file to attempt to resolve the missing python3-saml error when enabling SSO on the Ceph Dashboard. This change is related to the issue preventing the setup of SAML2 SSO due to a missing library.

Fixes #397 (in progress, further testing required).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The change has been implemented, and I verified that the python3-onelogin-saml2 package is included in the snap by building it and checking the installed libraries. However, the issue still persists. This PR aims to test the change using GitHub builds to further investigate the problem.

## Contributor's Checklist

Please check that you have:

- [ ] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
