### PR TITLE
Adds support for RO cluster configs

### DIFF
--- a/microceph/ceph/bootstrap.go
+++ b/microceph/ceph/bootstrap.go
@@ -116,7 +116,7 @@ func Bootstrap(ctx context.Context, s interfaces.StateInterface, data common.Boo
 	}
 
 	// Configure defaults cluster configs for network.
-	err = setDefaultNetwork(data.ClusterNet)
+	err = setDefaultNetwork(data.ClusterNet, data.PublicNet)
 	if err != nil {
 		return err
 	}
@@ -131,11 +131,20 @@ func Bootstrap(ctx context.Context, s interfaces.StateInterface, data common.Boo
 }
 
 // setDefaultNetwork configures the cluster network on mon KV store.
-func setDefaultNetwork(cn string) error {
+func setDefaultNetwork(cn string, pn string) error {
 	// Cluster Network
 	err := SetConfigItem(apiTypes.Config{
 		Key:   "cluster_network",
 		Value: cn,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Public Network
+	err = SetConfigItemUnsafe(apiTypes.Config{
+		Key:   "public_network",
+		Value: pn,
 	})
 	if err != nil {
 		return err

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -18,12 +18,22 @@ import (
 	"github.com/canonical/microceph/microceph/database"
 )
 
+type ClusterConfigPermission string
+
+const (
+	ClusterConfigRO ClusterConfigPermission = "read_only"
+	ClusterConfigRW ClusterConfigPermission = "read_write"
+)
+
+type ClusterConfigDefinition struct {
+	Who        string                  // Ceph Config internal <who> against each key
+	Permission ClusterConfigPermission // read only or read write
+	Daemons    []string                // List of Daemons that need to be restarted across the cluster for the config change to take effect.
+}
+
 // Config Table is the source of additional information for each supported config key
 // Refer to GetConfigTable()
-type ConfigTable map[string]struct {
-	Who     string   // Ceph Config internal <who> against each key
-	Daemons []string // List of Daemons that need to be restarted across the cluster for the config change to take effect.
-}
+type ConfigTable map[string]ClusterConfigDefinition
 
 // Check if certain key is present in the map.
 func (c ConfigTable) isKeyPresent(key string) bool {
@@ -47,31 +57,32 @@ func (c ConfigTable) Keys() (keys []string) {
 func GetConstConfigTable() ConfigTable {
 	return ConfigTable{
 		// Cluster config keys
-		"cluster_network":             {"global", []string{"osd"}},
-		"osd_pool_default_crush_rule": {"global", []string{}},
+		"public_network":              {"global", ClusterConfigRO, []string{"osd"}},
+		"cluster_network":             {"global", ClusterConfigRW, []string{"osd"}},
+		"osd_pool_default_crush_rule": {"global", ClusterConfigRW, []string{}},
 		// RGW config keys
-		"rgw_s3_auth_use_keystone":                    {"global", []string{"rgw"}},
-		"rgw_keystone_url":                            {"global", []string{"rgw"}},
-		"rgw_keystone_admin_token":                    {"global", []string{"rgw"}},
-		"rgw_keystone_admin_token_path":               {"global", []string{"rgw"}},
-		"rgw_keystone_admin_user":                     {"global", []string{"rgw"}},
-		"rgw_keystone_admin_password":                 {"global", []string{"rgw"}},
-		"rgw_keystone_admin_password_path":            {"global", []string{"rgw"}},
-		"rgw_keystone_admin_project":                  {"global", []string{"rgw"}},
-		"rgw_keystone_admin_domain":                   {"global", []string{"rgw"}},
-		"rgw_keystone_service_token_enabled":          {"global", []string{"rgw"}},
-		"rgw_keystone_service_token_accepted_roles":   {"global", []string{"rgw"}},
-		"rgw_keystone_expired_token_cache_expiration": {"global", []string{"rgw"}},
-		"rgw_keystone_api_version":                    {"global", []string{"rgw"}},
-		"rgw_keystone_accepted_roles":                 {"global", []string{"rgw"}},
-		"rgw_keystone_accepted_admin_roles":           {"global", []string{"rgw"}},
-		"rgw_keystone_token_cache_size":               {"global", []string{"rgw"}},
-		"rgw_keystone_verify_ssl":                     {"global", []string{"rgw"}},
-		"rgw_keystone_implicit_tenants":               {"global", []string{"rgw"}},
-		"rgw_swift_account_in_url":                    {"global", []string{"rgw"}},
-		"rgw_swift_versioning_enabled":                {"global", []string{"rgw"}},
-		"rgw_swift_enforce_content_length":            {"global", []string{"rgw"}},
-		"rgw_swift_custom_header":                     {"global", []string{"rgw"}},
+		"rgw_s3_auth_use_keystone":                    {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_url":                            {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_token":                    {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_token_path":               {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_user":                     {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_password":                 {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_password_path":            {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_project":                  {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_admin_domain":                   {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_service_token_enabled":          {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_service_token_accepted_roles":   {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_expired_token_cache_expiration": {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_api_version":                    {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_accepted_roles":                 {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_accepted_admin_roles":           {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_token_cache_size":               {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_verify_ssl":                     {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_keystone_implicit_tenants":               {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_swift_account_in_url":                    {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_swift_versioning_enabled":                {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_swift_enforce_content_length":            {"global", ClusterConfigRW, []string{"rgw"}},
+		"rgw_swift_custom_header":                     {"global", ClusterConfigRW, []string{"rgw"}},
 	}
 }
 
@@ -94,33 +105,33 @@ type ConfigDumpItem struct {
 type ConfigDump []ConfigDumpItem
 
 func SetConfigItem(c types.Config) error {
-	configTable := GetConstConfigTable()
-
-	args := []string{
-		"config",
-		"set",
-		configTable[c.Key].Who,
-		c.Key,
-		c.Value,
-		"-f",
-		"json-pretty",
+	// safety checks
+	canSet, err := canSetConfig(c.Key)
+	if !canSet {
+		return fmt.Errorf("config set(%s) failed: %v", c.Key, err)
 	}
 
-	_, err := processExec.RunCommand("ceph", args...)
-	if err != nil {
-		return err
-	}
+	return setConfigItem(c)
+}
 
-	return nil
+func SetConfigItemUnsafe(c types.Config) error {
+	return setConfigItem(c)
 }
 
 func GetConfigItem(c types.Config) (types.Configs, error) {
 	var err error
-	configTable := GetConstConfigTable()
 	ret := make(types.Configs, 1)
+	configTable := GetConstConfigTable()
 	who := "mon"
 
+	// safety checks
+	canRead, err := canReadConfig(c.Key)
+	if !canRead {
+		return nil, err
+	}
+
 	// workaround to query global configs from mon entity
+	// otherwise use the provided entity.
 	if configTable[c.Key].Who != "global" {
 		who = configTable[c.Key].Who
 	}
@@ -142,15 +153,20 @@ func GetConfigItem(c types.Config) (types.Configs, error) {
 }
 
 func RemoveConfigItem(c types.Config) error {
-	configTable := GetConstConfigTable()
+	// safety checks
+	canSet, err := canSetConfig(c.Key)
+	if !canSet {
+		return err
+	}
+
 	args := []string{
 		"config",
 		"rm",
-		configTable[c.Key].Who,
+		GetConstConfigTable()[c.Key].Who,
 		c.Key,
 	}
 
-	_, err := processExec.RunCommand("ceph", args...)
+	_, err = processExec.RunCommand("ceph", args...)
 	if err != nil {
 		return err
 	}
@@ -186,6 +202,65 @@ func ListConfigs() (types.Configs, error) {
 	}
 
 	return configs, nil
+}
+
+// ****** Helper Functions ******//
+func setConfigItem(c types.Config) error {
+	args := []string{
+		"config",
+		"set",
+		GetConstConfigTable()[c.Key].Who,
+		c.Key,
+		c.Value,
+		"-f",
+		"json-pretty",
+	}
+
+	_, err := processExec.RunCommand("ceph", args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// canSetConfig checks if the config option is configurable.
+func canSetConfig(key string) (bool, error) {
+	config, err := getClusterConfigDefinition(key)
+	if err != nil {
+		logger.Warnf(err.Error())
+		return false, err
+	}
+
+	if config.Permission != ClusterConfigRW {
+		err := fmt.Errorf("requested key %s does not support write operation", key)
+		logger.Warnf(err.Error())
+		return false, err
+	}
+
+	return true, nil
+}
+
+func canReadConfig(key string) (bool, error) {
+	_, err := getClusterConfigDefinition(key)
+	if err != nil {
+		logger.Warnf(err.Error())
+		return false, err
+	}
+
+	return true, nil
+}
+
+func getClusterConfigDefinition(key string) (ClusterConfigDefinition, error) {
+	configTable := GetConstConfigTable()
+	config, ok := configTable[key]
+	if !ok {
+		err := fmt.Errorf("requested key %s is not a MicroCeph supported cluster config", key)
+		logger.Warnf(err.Error())
+		return config, err
+	}
+
+	return config, nil
 }
 
 // backwardCompatPubnet ensures that the public_network is set in the database

--- a/microceph/ceph/crush.go
+++ b/microceph/ceph/crush.go
@@ -3,8 +3,9 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/canonical/microceph/microceph/api/types"
 	"strings"
+
+	"github.com/canonical/microceph/microceph/api/types"
 
 	"github.com/tidwall/gjson"
 )

--- a/microceph/cmd/microceph/cluster_config_get.go
+++ b/microceph/cmd/microceph/cluster_config_get.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
 )
 
@@ -30,20 +29,14 @@ func (c *cmdClusterConfigGet) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigGet) Run(cmd *cobra.Command, args []string) error {
-	allowList := ceph.GetConstConfigTable()
-
 	// Get can be called with a single key.
 	if len(args) != 1 {
 		return cmd.Help()
 	}
 
-	if _, ok := allowList[args[0]]; !ok {
-		return fmt.Errorf("Key %s is invalid. \nPermitted Keys: %v", args[0], allowList.Keys())
-	}
-
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
 	if err != nil {
-		return fmt.Errorf("Unable to configure MicroCeph: %w", err)
+		return fmt.Errorf("unable to configure MicroCeph: %w", err)
 	}
 
 	cli, err := m.LocalClient()

--- a/microceph/cmd/microceph/cluster_config_reset.go
+++ b/microceph/cmd/microceph/cluster_config_reset.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
 )
 
@@ -34,13 +33,8 @@ func (c *cmdClusterConfigReset) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigReset) Run(cmd *cobra.Command, args []string) error {
-	allowList := ceph.GetConstConfigTable()
 	if len(args) != 1 {
 		return cmd.Help()
-	}
-
-	if _, ok := allowList[args[0]]; !ok {
-		return fmt.Errorf("resetting key %s is not allowed", args[0])
 	}
 
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})

--- a/microceph/cmd/microceph/cluster_config_set.go
+++ b/microceph/cmd/microceph/cluster_config_set.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/ceph"
 	"github.com/canonical/microceph/microceph/client"
 )
 
@@ -34,13 +33,8 @@ func (c *cmdClusterConfigSet) Command() *cobra.Command {
 }
 
 func (c *cmdClusterConfigSet) Run(cmd *cobra.Command, args []string) error {
-	allowList := ceph.GetConstConfigTable()
 	if len(args) != 2 {
 		return cmd.Help()
-	}
-
-	if _, ok := allowList[args[0]]; !ok {
-		return fmt.Errorf("configuring key %s is not allowed. \nPermitted Keys: %v", args[0], allowList.Keys())
 	}
 
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})


### PR DESCRIPTION
# Description
Adds support for RO cluster configs and exposes public_network as a RO config.

Fixes #353 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [X] added tests to verify effectiveness of this change.
