### PR TITLE
Use square brackets around IPv6 in ceph.conf

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,6 +234,15 @@ jobs:
       run: |
         sudo snap logs microceph -n 1000
 
+    - name: Test square brackets around IPv6
+      run: |
+        sudo snap remove microceph
+        export MON_IP="fd42:7273:f336:a22::1"
+        sudo ip -6 addr add dev eth0 "${MON_IP}"
+        ~/actionutils.sh install_microceph "${MON_IP}"
+        cat /var/snap/microceph/current/conf/ceph.conf
+        fgrep -q "[${MON_IP}]" /var/snap/microceph/current/conf/ceph.conf
+
   multi-node-tests:
     name: Multi node testing
     runs-on: ubuntu-22.04

--- a/microceph/ceph/bootstrap.go
+++ b/microceph/ceph/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,12 +41,18 @@ func Bootstrap(ctx context.Context, s interfaces.StateInterface, data common.Boo
 		return err
 	}
 
+	// Ensure mon-ip is enclosed in square brackets if IPv6.
+	monIp := data.MonIp
+	if net.ParseIP(monIp) != nil && strings.Contains(monIp, ":") {
+		monIp = fmt.Sprintf("[%s]", monIp)
+	}
+
 	err = conf.WriteConfig(
 		map[string]any{
 			"fsid":   fsid,
 			"runDir": pathConsts.RunPath,
 			// First monitor bootstrap IP as passed to microcluster.
-			"monitors": data.MonIp,
+			"monitors": monIp,
 			"pubNet":   data.PublicNet,
 			"ipv4":     strings.Contains(data.PublicNet, "."),
 			"ipv6":     strings.Contains(data.PublicNet, ":"),

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -356,6 +356,9 @@ func UpdateConfig(ctx context.Context, s interfaces.StateInterface) error {
 		}
 	}
 
+	// Ensure that IPv6 addresses have square brackets around them (if IPv6 is used).
+	monitorAddresses = formatIPv6(monitorAddresses)
+
 	conf := NewCephConfig(constants.CephConfFileName)
 
 	// Check if host has IP address on the configured public network.
@@ -441,4 +444,19 @@ func getMonitorAddresses(configs map[string]string) []string {
 		}
 	}
 	return monHosts
+}
+
+// formatIPv6 returns a slice in which all IPv6 addresses are formatted with square brackets.
+func formatIPv6(addrs []string) []string {
+	formatted := []string{}
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip != nil && strings.Contains(addr, ":") {
+			addr = fmt.Sprintf("[%s]", addr)
+		}
+
+		formatted = append(formatted, addr)
+	}
+
+	return formatted
 }

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -16,6 +16,7 @@ function setup_lxd() {
 }
 
 function install_microceph() {
+    local mon_ip="${1}"
     # Install locally built microceph snap and connect interfaces
     sudo snap install --dangerous ~/microceph_*.snap
     sudo snap connect microceph:block-devices
@@ -26,7 +27,11 @@ function install_microceph() {
     sudo snap connect microceph:microceph-support
     sudo snap connect microceph:network-bind
 
-    sudo microceph cluster bootstrap
+    if [ -n "${mon_ip}" ]; then
+        sudo microceph cluster bootstrap --mon-ip "${mon_ip}"
+    else
+        sudo microceph cluster bootstrap
+    fi
     sudo microceph.ceph version
     sudo microceph.ceph status
 
@@ -34,7 +39,6 @@ function install_microceph() {
     sleep 30
     sudo microceph.ceph status
     sudo microceph.ceph health
-
 }
 
 function create_loop_devices() {


### PR DESCRIPTION
Small PR which adds square brackets around mon host addresses in `ceph.conf` if IPv6 is used.

Closes https://github.com/canonical/microceph/issues/424.