### PR TITLE
Backport mon.host entry cleanup from main to reef

### DIFF
--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -217,6 +217,15 @@ func removeServiceDatabase(s interfaces.StateInterface, service string) error {
 			return fmt.Errorf("failed to remove service from db %q: %w", service, err)
 		}
 
+		// Clear mon host entry from config table.
+		if service == "mon" {
+			key := fmt.Sprintf("mon.host.%s", s.ClusterState().Name())
+			err = database.DeleteConfigItem(ctx, tx, key)
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 	return err


### PR DESCRIPTION
# Description
Adds a patch to remove mon.host entries on mon service cleanup.

Fixes #444 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
CI

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
