### PR TITLE
Fix: add python3-packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -181,6 +181,7 @@ parts:
       - coreutils
       - uuid-runtime
       - python3-setuptools
+      - python3-packaging
     organize:
       usr/bin/: bin/
       usr/sbin/: bin/


### PR DESCRIPTION
Prometheus module needs python3-packaging
