### PR TITLE
Adjust 'verify_health' iterations

### DIFF
--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -511,7 +511,7 @@ function verify_bootstrap_configs() {
 }
 
 function verify_health() {
-    for i in {0..9}; do
+    for i in {0..100}; do
         if [ "$( sudo microceph.ceph health )" = "HEALTH_OK" ] ; then
             echo "HEALTH_OK found"
             return


### PR DESCRIPTION
Adjust the number of iterations for the 'verify_health' bash helper. This is apparently needed for the 'require-osd-release' functionality recently introduced.
