### PR TITLE
WIP: Add MicroCeph tutorial

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,11 @@ to Ceph administrators and storage software developers.
 In this documentation
 ---------------------
 
-..  grid:: 1 1 1 1
+..  grid:: 1 2 1 2
+
+   ..  grid-item:: :doc:`Tutorial <tutorial/get-started>`
+
+      **A hands-on introduction** to MicroCeph for new users
 
    ..  grid-item:: :doc:`How-to guides <how-to/index>`
 
@@ -59,6 +63,7 @@ constructive feedback.
    :hidden:
    :maxdepth: 2
 
+   tutorial/index
    how-to/index
    reference/index
    explanation/index


### PR DESCRIPTION
# Description

We currently do not have a tutorial for new users in the MicroCeph documentation. The how-to section of our documentation would be useful for a user who is already familiar with Ceph and is looking to achieve certain goals with MicroCeph. But, a new user with no prior knowledge of Ceph would find it difficult to get started with MicroCeph, which is intended to make their experience as easy as possible.

This is, hopefully, a complete, end-to-end tutorial intended to serve as an entry point into Ceph for a new user, setting them up for their next steps, whether it is to use MicroCeph to accomplish certain tasks in their work (how-to guides, learn more about MicroCeph (explanation) or make quick references.


## Type of change

- [x] Documentation update (Doc only change)

