### PR TITLE
Use the less common TCP port 18000

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -80,7 +80,7 @@ epub: install
 
 
 serve: html
-	cd "$(BUILDDIR)"; python3 -m http.server 8000
+	cd "$(BUILDDIR)"; python3 -m http.server 18000
 
 .PHONY: serve
 


### PR DESCRIPTION
# Description

When trying to run my local build of the docs, I run into this:

`ERROR:    [Errno 98] error while attempting to bind on address ('127.0.0.1', 8000): address already in use
make: *** [Makefile:62: run] Error 1`

Port 8000 seems to be a poor choice to use as it is very common, so I have modified the Makefile to use a different, less common port.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (Doc only change)
