### PR TITLE
docs: refer to command microceph.ceph instead of ceph

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ your root drive:
 
 You're done! Check Ceph status:
 
-    sudo ceph status
+    sudo microceph.ceph status
 
 You can remove everything cleanly with:
 

--- a/docs/how-to/enable-metrics.rst
+++ b/docs/how-to/enable-metrics.rst
@@ -25,7 +25,7 @@ Ceph-Mgr Prometheus module is responsible for serving the metrics endpoint which
 
 .. code-block:: none
 
-   ceph mgr module enable prometheus
+   microceph.ceph mgr module enable prometheus
 
 Configuring metrics endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,8 +34,8 @@ By default, it will accept HTTP requests on port 9283 on all IPv4 and IPv6 addre
 
 .. code-block:: none
 
-   ceph config set mgr mgr/prometheus/server_addr <addr>
-   ceph config set mgr mgr/prometheus/port <port>
+   microceph.ceph config set mgr mgr/prometheus/server_addr <addr>
+   microceph.ceph config set mgr mgr/prometheus/port <port>
 
 For details on how metrics endpoint can be further configured visit `Ceph Prometheus module <https://docs.ceph.com/en/quincy/mgr/prometheus/>`_
 

--- a/docs/how-to/import-remote-cluster.rst
+++ b/docs/how-to/import-remote-cluster.rst
@@ -34,7 +34,7 @@ Check remote ceph cluster status
 
 .. code-block:: none
 
-   sudo ceph -s --cluster simple --id magical
+   sudo microceph.ceph -s --cluster simple --id magical
    cluster:
     id:     7abfc0bb-6204-43af-8844-2874868cba74
     health: HEALTH_OK

--- a/docs/how-to/major-upgrade.rst
+++ b/docs/how-to/major-upgrade.rst
@@ -27,7 +27,7 @@ Firstly, before initiating the upgrade, ensure that the cluster is healthy. Use 
 
 .. code-block:: none
 
-    sudo ceph -s
+    sudo microceph.ceph -s
 
 **Note**: Do not start the upgrade if the cluster is unhealthy.
 
@@ -47,7 +47,7 @@ Carry out these precautionary steps before initiating the upgrade:
 
 .. code-block:: none
 
-   sudo ceph osd set noout
+   sudo microceph.ceph osd set noout
 
 
 Upgrading Each Cluster Node
@@ -68,7 +68,7 @@ Once the upgrade process is done, verify that all components have been upgraded 
 
 .. code-block:: none
    
-   sudo ceph versions
+   sudo microceph.ceph versions
 
 
 Unsetting Noout
@@ -78,7 +78,7 @@ If you had previously set noout, unset it with this command:
 
 .. code-block:: none
    
-   sudo ceph osd unset noout
+   sudo microceph.ceph osd unset noout
 
 
 You have now successfully upgraded your Ceph cluster.

--- a/docs/how-to/mount-block-device.rst
+++ b/docs/how-to/mount-block-device.rst
@@ -22,7 +22,7 @@ Check Ceph cluster's status:
 
 .. code-block:: none
 
-    $ sudo ceph -s
+    $ sudo microceph.ceph -s
     cluster:
         id:     90457806-a798-47f2-aca1-a8a93739941a
         health: HEALTH_OK
@@ -42,10 +42,10 @@ Create a pool for RBD images:
 
 .. code-block:: none
 
-    $ sudo ceph osd pool create block_pool
+    $ sudo microceph.ceph osd pool create block_pool
     pool 'block_pool' created
 
-    $ sudo ceph osd lspools
+    $ sudo microceph.ceph osd lspools
     1 .mgr
     2 block_pool
 
@@ -152,7 +152,7 @@ Ceph cluster state post IO:
 
 .. code-block:: none
 
-    $ sudo ceph -s
+    $ sudo microceph.ceph -s
     cluster:
         id:     90457806-a798-47f2-aca1-a8a93739941a
         health: HEALTH_OK

--- a/docs/how-to/mount-cephfs-share.rst
+++ b/docs/how-to/mount-cephfs-share.rst
@@ -15,7 +15,7 @@ Check Ceph cluster's status:
 
 .. code-block:: none
 
-    $ sudo ceph -s
+    $ sudo microceph.ceph -s
     cluster:
         id:     90457806-a798-47f2-aca1-a8a93739941a
         health: HEALTH_OK
@@ -35,16 +35,16 @@ Create data/metadata pools for CephFs:
 
 .. code-block:: none
 
-    $ sudo ceph osd pool create cephfs_meta 
-    $ sudo ceph osd pool create cephfs_data 
+    $ sudo microceph.ceph osd pool create cephfs_meta 
+    $ sudo microceph.ceph osd pool create cephfs_data 
 
 Create CephFs share:
 
 .. code-block:: none
 
-    $ sudo ceph fs new newFs cephfs_meta cephfs_data
+    $ sudo microceph.ceph fs new newFs cephfs_meta cephfs_data
     new fs with metadata pool 4 and data pool 3
-    $ sudo ceph fs ls
+    $ sudo microceph.ceph fs ls
     name: newFs, metadata pool: cephfs_meta, data pools: [cephfs_data ]
 
 Client Operations:
@@ -88,7 +88,7 @@ Mount the filesystem:
 .. code-block:: none
 
     $ sudo mkdir /mnt/mycephfs
-    $ sudo mount -t ceph :/ /mnt/mycephfs/ -o name=admin,fs=newFs
+    $ sudo mount -t microceph.ceph :/ /mnt/mycephfs/ -o name=admin,fs=newFs
 
 Here, we provide the CephX user (admin in our example) and the fs created earlier (newFs).
 
@@ -114,7 +114,7 @@ Ceph cluster state post IO:
 
 .. code-block:: none
 
-    $ sudo ceph -s
+    $ sudo microceph.ceph -s
     cluster:
         id:     90457806-a798-47f2-aca1-a8a93739941a
         health: HEALTH_OK

--- a/docs/how-to/multi-node.rst
+++ b/docs/how-to/multi-node.rst
@@ -182,7 +182,7 @@ commands are not yet available for a desired task:
 
 .. code-block:: none
 
-   ceph status
+   microceph.ceph status
 
 This gives:
 

--- a/docs/how-to/remove-disk.rst
+++ b/docs/how-to/remove-disk.rst
@@ -27,7 +27,7 @@ First get an overview of the cluster and its OSDs:
 
 .. code-block:: none
 
-   ceph status
+   microcepth.ceph status
 
 Example output:
 
@@ -54,7 +54,7 @@ Ceph) :command:`ceph osd tree` command:
 
 .. code-block:: none
 
-   ceph osd tree
+   microceph.ceph osd tree
 
 Sample output:
 
@@ -85,7 +85,7 @@ Verify that the OSD has been removed:
 
 .. code-block:: none
 
-   ceph osd tree
+   microceph.ceph osd tree
 
 Output:
 
@@ -106,7 +106,7 @@ Finally, confirm cluster status and health:
 
 .. code-block:: none
 
-   ceph status
+   microceph.ceph status
 
 Output:
 

--- a/docs/how-to/single-node.rst
+++ b/docs/how-to/single-node.rst
@@ -115,7 +115,7 @@ commands are not yet available for a desired task:
 
 .. code-block:: none
 
-   sudo ceph status
+   sudo microceph.ceph status
 
 The cluster built during this tutorial gives the following output:
 


### PR DESCRIPTION
There is no /snap/bin/ceph. But /snap/bin/microceph.ceph exists. Reflect this in the documentation.