### PR TITLE
snapcraft.yaml: add libatomic1 dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -182,6 +182,7 @@ parts:
       - uuid-runtime
       - python3-setuptools
       - python3-packaging
+      - libatomic1
     organize:
       usr/bin/: bin/
       usr/sbin/: bin/
@@ -207,6 +208,7 @@ parts:
       - lib/*/ceph
       - lib/*/libaio.so*
       - lib/*/libasn1.so*
+      - lib/*/libatomic.so*
       - lib/*/libboost_context.so*
       - lib/*/libboost_filesystem.so*
       - lib/*/libboost_iostreams.so*


### PR DESCRIPTION
Running on riscv64 requires the libatomic1 package.