### PR TITLE
Add sphinx-version-warning extension

### DIFF
--- a/docs/.sphinx/requirements.txt
+++ b/docs/.sphinx/requirements.txt
@@ -12,3 +12,4 @@ sphinx-reredirects
 sphinx-tabs
 sphinxcontrib-jquery
 sphinxext-opengraph
+sphinx-version-warning

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,8 @@ extensions = [
     'sphinxext.opengraph',
     'myst_parser',
     'sphinxcontrib.jquery',
-    'notfound.extension'
+    'notfound.extension',
+    'versionwarning.extension'
 ]
 extensions.extend(custom_extensions)
 


### PR DESCRIPTION
# Description

We need a warning banner for when a user is not on the latest stable version of our documentation. `sphinx-version-warning` is a Sphinx extension that compares the current version to the latest one and then displays this banner at the top of the documentation page if it is an older version.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Doc only change)