### PR TITLE
fix: rgw --port is not respected

### DIFF
--- a/microceph/ceph/rgw.go
+++ b/microceph/ceph/rgw.go
@@ -40,7 +40,12 @@ func EnableRGW(s interfaces.StateInterface, port int, sslPort int, sslCertificat
 			return err
 		}
 	} else if sslCertificate == "" || sslPrivateKey == "" {
-		port = 80
+		// The default value is in the command line is 0 for the case where
+		// both SSL certificates and Private Key are provided, so we handle the
+		// default case here.
+		if port == 0 {
+			port = 80
+		}
 	}
 	configs := map[string]any{
 		"runDir":             pathConsts.RunPath,

--- a/microceph/ceph/rgw_test.go
+++ b/microceph/ceph/rgw_test.go
@@ -65,13 +65,13 @@ func (s *rgwSuite) TestEnableRGW() {
 
 	processExec = r
 
-	err := EnableRGW(s.TestStateInterface, 80, 443, "", "", []string{"10.1.1.1", "10.2.2.2"})
+	err := EnableRGW(s.TestStateInterface, 8081, 443, "", "", []string{"10.1.1.1", "10.2.2.2"})
 
 	assert.NoError(s.T(), err)
 
 	// check that the radosgw.conf file contains expected values
 	conf := s.ReadCephConfig("radosgw.conf")
-	assert.Contains(s.T(), conf, "rgw frontends = beast port=80\n")
+	assert.Contains(s.T(), conf, "rgw frontends = beast port=8081\n")
 	assert.Contains(s.T(), conf, "mon host = 10.1.1.1,10.2.2.2")
 }
 
@@ -149,7 +149,7 @@ func (s *rgwSuite) TestEnableRGWWithSSL() {
 
 	processExec = r
 
-	err := EnableRGW(s.TestStateInterface, 80, 443, validSSLCertificate, validSSLPrivateKey, []string{"10.1.1.1", "10.2.2.2"})
+	err := EnableRGW(s.TestStateInterface, 8081, 443, validSSLCertificate, validSSLPrivateKey, []string{"10.1.1.1", "10.2.2.2"})
 
 	assert.NoError(s.T(), err)
 
@@ -157,7 +157,7 @@ func (s *rgwSuite) TestEnableRGWWithSSL() {
 	conf := s.ReadCephConfig("radosgw.conf")
 	sslCertificatePath := filepath.Join(s.Tmp, "SNAP_COMMON", "server.crt")
 	sslPrivateKeyPath := filepath.Join(s.Tmp, "SNAP_COMMON", "server.key")
-	assert.Contains(s.T(), conf, "rgw frontends = beast port=80 ssl_port=443 ssl_certificate="+sslCertificatePath+" ssl_private_key="+sslPrivateKeyPath+"\n")
+	assert.Contains(s.T(), conf, "rgw frontends = beast port=8081 ssl_port=443 ssl_certificate="+sslCertificatePath+" ssl_private_key="+sslPrivateKeyPath+"\n")
 }
 
 func (s *rgwSuite) TestDisableRGW() {


### PR DESCRIPTION
# Description

In #355 a regression was added where the `--port` rgw option is not respected.
This PR fixes this regression, updates the tests in order to ensure that it is respected in all contexts.

Fixes #483 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

The unit tests were updated to reflect that change and confirm that the option is respected when it is passed.


## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
