### PR TITLE
fix: Use download-artifact@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -441,7 +441,7 @@ jobs:
     needs: build-microceph
     steps:
     - name: Download snap
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: snaps
         path: /home/runner


### PR DESCRIPTION
# Description

The newly introduced `Test maintenance mode` job was failing due to using an outdated version of `actions/download-artifact`


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

This is a CI fix, it's tested by having this CI green

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
