### PR TITLE
add a note that explains that s3cmd needs to be installed and configured

### DIFF
--- a/docs/tutorial/get-started.rst
+++ b/docs/tutorial/get-started.rst
@@ -238,6 +238,13 @@ Then, run :command:`curl` from this node.
 Create an S3 bucket
 ~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+    In order to interact with S3 you need to make sure ``s3cmd`` utility is installed. If not, just simply run ``sudo apt install s3cmd``.
+    After that, ``s3cmd`` needs to be configured by running: ``s3cmd --configure``, answer the questions and you are done.
+    Keep in mind that this command crates a file called ``.s3cfg`` in your home directory with all the settings.
+
+
 You have verified that your cluster is accessible via RGW. Now, let's create a bucket using the ``s3cmd`` tool:
 
 .. code-block:: none


### PR DESCRIPTION
# Description

This small PR adds a `note` explaining that `s3cmd` needs to be installed and configured before creating a bucket.

Fixes https://github.com/canonical/microceph/issues/526

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [x] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Create a VM and follow the steps in the [Get started](https://canonical-microceph.readthedocs-hosted.com/en/latest/tutorial/get-started/#) guide.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
