### PR TITLE
Don't mute any warning unless an user explicitly does it

### DIFF
--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -1120,10 +1120,6 @@ func SetReplicationFactor(pools []string, size int64) error {
 		return fmt.Errorf("failed to set size one pool config option: %w", err)
 	}
 
-	// This only silences a warning and should thus not return an
-	// error on failure
-	_, _ = processExec.RunCommand("ceph", "health", "mute", "POOL_NO_REDUNDANCY")
-
 	if len(pools) == 1 && pools[0] == "*" {
 		// Apply setting to all existing pools.
 		out, err := processExec.RunCommand("ceph", "osd", "pool", "ls", "--format", "json")


### PR DESCRIPTION
Follow-up of: 992abdf578de98443345559a7183d0b3e00e7b03

Having no redundancy of data is a warning and we shouldn't mute it out of the box since users must know those status. If they really want to mute the warning explicitly on purpose, they can do so on their own by issuing:
    ceph health mute POOL_NO_REDUNDANCY

The automatic mute cause more issues than the benefit for example in the following cases.

Closes: #490
Related-Bug: [LP: #2104017](https://bugs.launchpad.net/snap-openstack/+bug/2104017)
Related-Bug: [LP: #2096921](https://bugs.launchpad.net/snap-openstack/+bug/2096921)

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [x] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
