### PR TITLE
Microcloud integration annotations

### DIFF
--- a/docs/how-to/multi-node.rst
+++ b/docs/how-to/multi-node.rst
@@ -2,6 +2,15 @@
 Multi-node install
 ==================
 
+.. The note below is only visible when viewed through MicroCloud's docs site:
+   https://documentation.ubuntu.com/microcloud/latest/microceph/
+.. only:: integrated
+
+   .. admonition:: For MicroCloud users
+      :class: note
+      
+      The MicroCloud setup process handles MicroCeph installation. Thus, you do not need to follow the steps on this page.
+
 This tutorial will show how to install MicroCeph on three machines,
 thereby creating a multi-node cluster. For this tutorial, we will
 utilise physical block devices for storage.

--- a/docs/how-to/single-node.rst
+++ b/docs/how-to/single-node.rst
@@ -1,6 +1,15 @@
 How to install MicroCeph on a single node
 =========================================
 
+.. The note below is only visible when viewed through MicroCloud's docs site:
+   https://documentation.ubuntu.com/microcloud/latest/microceph/
+.. only:: integrated
+
+   .. admonition:: For MicroCloud users
+      :class: note
+      
+      The MicroCloud setup process handles MicroCeph installation. Thus, you do not need to follow the steps on this page.
+
 This guide will show how to install MicroCeph on a single machine, thereby
 creating a single-node cluster.
 

--- a/docs/tutorial/get-started.rst
+++ b/docs/tutorial/get-started.rst
@@ -1,6 +1,15 @@
 Get started
 ===========
 
+.. The note below is only visible when viewed through MicroCloud's docs site:
+   https://documentation.ubuntu.com/microcloud/latest/microceph/
+.. only:: integrated
+
+   .. admonition:: For MicroCloud users
+      :class: note
+      
+      The MicroCloud setup process handles MicroCeph installation and configuration. Thus, you do not need to follow the steps on this page.
+
 This tutorial will guide you through your first steps with MicroCeph. We will deploy a Ceph cluster on a single node using MicroCeph and store a JPEG image in an S3 bucket managed by MicroCeph.
 
 How you'll do It


### PR DESCRIPTION
# Description

The MicroCeph docs set is pulled in as part of the [MicroCloud integrated docs set](https://canonical-microcloud.readthedocs-hosted.com/en/latest/microovn/), which allows the user to switch between the MicroCloud, LXD, MicroCeph, and MicroOVN products from a header menu.

For MicroCloud users, some pages of the other docs sets are not relevant (such as installation docs, which MicroCloud handles). This PR adds a `note`-type annotation to such pages advising users of this, which uses the `only` Sphinx directive to _only_ show those notes when the page is viewed as part of the MicroCloud integrated docs set. It has no effect on the standalone MicroCeph docs set.

## Type of change

Please delete options that are not relevant.

- [X] Documentation update (Doc only change)

## How Has This Been Tested?

I tested manually in local build, both as a standalone docs set and how it's viewed when pulled into a MicroCloud integrated docs set. It behaves as expected: invisible in the standalone, visible in the integrated.
