### PR TITLE
Fixes RBD Replication status command

### DIFF
--- a/microceph/cmd/microceph/replication_status.go
+++ b/microceph/cmd/microceph/replication_status.go
@@ -40,7 +40,7 @@ type cmdReplicationStatusRbd struct {
 
 func (c *cmdReplicationStatusRbd) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <resource>",
+		Use:   "rbd <resource>",
 		Short: "Show RBD resource (Pool or Image) replication status",
 		RunE:  c.Run,
 	}

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -296,6 +296,8 @@ function remote_verify_rbd_mirroring() {
     lxc exec node-wrk1 -- sh -c "sudo microceph replication list rbd" | grep "pool_one.*image_two"
     lxc exec node-wrk2 -- sh -c "sudo microceph replication list rbd" | grep "pool_two.*image_one"
     lxc exec node-wrk3 -- sh -c "sudo microceph replication list rbd" | grep "pool_two.*image_two"
+
+    lxc exec node-wrk0 -- sh -c "sudo microceph replication status rbd --json"
 }
 
 function remote_failover_to_siteb() {


### PR DESCRIPTION
# Description

Fix incorrect status command keyword for RBD resources

Fixes #548 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Contributor's Checklist

Please check that you have:

- [X] self-reviewed the code in this PR.
- [X] added tests to verify effectiveness of this change.
