### PR TITLE
Ensure a majority of mon services remain available before entering maintenance mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -509,11 +509,12 @@ jobs:
         ~/actionutils.sh headexec remove_disk osd.4
         ~/actionutils.sh headexec remove_node node-wrk3
 
-        if ~/actionutils.sh headexec "microceph cluster maintenance enter node-wrk1"; then
-          echo "Unexpected to succeed entering maintenance mode with less than 4 nodes"
-          exit 1
-        fi
-        echo "It's expected to fail entering maintenance mode with less than 4 nodes"
+        # this should succeed, because 2/3 remaining nodes is still a majority for quorum
+        ~/actionutils.sh headexec "microceph cluster maintenance enter node-wrk1"
+
+        # TODO: add a regression test here when https://github.com/canonical/microceph/issues/558 is fixed
+
+        ~/actionutils.sh headexec "microceph cluster maintenance exit node-wrk1"
 
     - name: Test force enter and exit maintainenace mode without set noout and stop osd
       run: ~/actionutils.sh test_maintenance_enter_and_exit_force node-wrk1

--- a/docs/explanation/cluster-maintenance.rst
+++ b/docs/explanation/cluster-maintenance.rst
@@ -28,7 +28,7 @@ Enabling maintenance mode
 
 - Check if OSDs on the node are ``ok-to-stop`` to ensure sufficient redundancy to tolerate the loss
   of OSDs on the node.
-- Check if the number of running services is greater than the minimum (3 MON, 1 MDS, 1 MGR)
+- Check if the number of running services is greater than the minimum (majority of MON, 1 MDS, 1 MGR)
   required for quorum.
 - *(Optional)* Apply noout flag to prevent data migration from triggering during the planned
   maintenance slot. (default=True)

--- a/microceph/ceph/maintenance.go
+++ b/microceph/ceph/maintenance.go
@@ -64,7 +64,7 @@ func (m *Maintenance) Enter(req types.MaintenanceRequest) ([]Result, error) {
 	// Preflight checks for entering maintenance mode
 	preflightChecks := []Operation{
 		&CheckOsdOkToStopOps{ClusterOps: m.ClusterOps},
-		&CheckNonOsdSvcEnoughOps{ClusterOps: m.ClusterOps, MinMon: 3, MinMds: 1, MinMgr: 1},
+		&CheckNonOsdSvcEnoughOps{ClusterOps: m.ClusterOps},
 	}
 
 	// Main operations

--- a/microceph/ceph/operations.go
+++ b/microceph/ceph/operations.go
@@ -124,23 +124,21 @@ func (o *CheckNonOsdSvcEnoughOps) Run(name string) error {
 		"mgr": 0,
 		"mds": 0,
 	}
-	totals := map[string]int{
-		"mon": 0,
-		"mgr": 0,
-		"mds": 0,
-	}
+	total_mon_services := 0
 	for _, service := range services {
-		// count the number of each service type remaining when excluding services on this node
+		// do not count the services on this node (these are the services remaining if this node is down)
 		if service.Location != name {
 			remains[service.Service]++
 		}
 
-		// count the total number of each service type
-		totals[service.Service]++
+		// count the total number of mon services, so we can calculate the minimum number of mon services required for quorum
+		if service.Service == "mon" {
+			total_mon_services += 1
+		}
 	}
 
 	// a majority of ceph-mon services must remain active to retain quorum
-	minMon := totals["mon"] / 2 + 1
+	minMon := total_mon_services / 2 + 1
 	// only need one ceph-mds and one ceph-mgr: they operate as one active, the rest in standby
 	minMds := 1
 	minMgr := 1

--- a/microceph/ceph/operations.go
+++ b/microceph/ceph/operations.go
@@ -130,10 +130,12 @@ func (o *CheckNonOsdSvcEnoughOps) Run(name string) error {
 		"mds": 0,
 	}
 	for _, service := range services {
-		// do not count the service on this node
+		// count the number of each service type remaining when excluding services on this node
 		if service.Location != name {
 			remains[service.Service]++
 		}
+
+		// count the total number of each service type
 		totals[service.Service]++
 	}
 


### PR DESCRIPTION
# Description

Previously, the number of mon services was hardcoded to 3 - this means this preflight check only correctly supported clusters of 4-5 mon services. See #534 for more information.

This change dynamically calculates the required number of remaining ceph-mon services to ensure a majority will be available after entering maintenance mode.

Fixes: #534


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Locally, on a 3 node microceph deployment on LXD VMs.

Before:

```
root@microceph-0:~# microceph status
MicroCeph deployment summary:
- microceph-0 (10.180.54.6)
  Services: mds, mgr, mon, osd
  Disks: 3
- microceph-1 (10.180.54.82)
  Services: mds, mgr, mon, osd
  Disks: 3
- microceph-2 (10.180.54.165)
  Services: mds, mgr, mon, osd
  Disks: 3

root@microceph-0:~# microceph cluster maintenance enter microceph-0
Error: failed to enter maintenance mode: error bringing node 'microceph-0' into maintenance: maintenance operations failed: [(need at least 3 mon, 1 mds, and 1 mgr services in the cluster besides those in node 'microceph-0')]
```

After:

```
root@microceph-0:~# microceph cluster maintenance enter microceph-0
Check if osds.[1 2 3] in node 'microceph-0' are ok-to-stop. (succeeded)
Check if there are at least a majority of mon services, 1 mds service, and 1 mgr service in the cluster besides those in node 'microceph-0' (succeeded)
Run `ceph osd set noout`. (succeeded)
Assert osd has 'noout' flag set. (succeeded)
```



## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change [I'm not very familiar with this codebase, and I couldn't find existing tests for maintenance mode]