### PR TITLE
chore: Pinned Dqlite dependency to 1.18.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -277,47 +277,31 @@ parts:
       - share/ceph
 
   dqlite:
-    after:
-      - raft
     source: https://github.com/canonical/dqlite
     source-type: git
     source-depth: 1
+    source-tag: v1.18.0
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
+      - --enable-build-raft
     stage-packages:
       - libuv1
       - libsqlite3-0
+      - liblz4-1
     build-packages:
+      - make
       - libuv1-dev
+      - liblz4-dev
       - libsqlite3-dev
       - pkg-config
     organize:
       usr/lib/: lib/
     prime:
       - lib/libdqlite*so*
-      - lib/*/libuv*
-
-  raft:
-    source: https://github.com/canonical/raft
-    source-type: git
-    source-depth: 1
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=
-    stage-packages:
-      - libuv1
-      - liblz4-1
-    build-packages:
-      - libuv1-dev
-      - liblz4-dev
-      - pkg-config
-    organize:
-      usr/lib/: lib/
-    prime:
       - lib/libraft*so*
-      - lib/*/libuv.so*
-
+      - lib/*/libuv*so*
+  
   microceph:
     source: microceph/
     after:
@@ -368,7 +352,6 @@ parts:
     after:
       - ceph
       - dqlite
-      - raft
       - microceph
     plugin: nil
     override-prime: |


### PR DESCRIPTION
# Description

Pins Dqlite dependency to v1.18.0

If it fixes a reported issue, mention it here, i.e.:
Fixes #<issue-number>

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Existing CI

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change