### PR TITLE
ci: don't put a default epic

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -16,7 +16,7 @@ settings:
   add_gh_comment: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: CEPH-972
+  #epic_key: CEPH-972
 
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug


### PR DESCRIPTION
In the interest of more transparent bug tracking don't lump all bugs under the same parent epic anymore.
