### PR TITLE
Ensure a majority of mon services remain available before entering maintenance mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -498,9 +498,6 @@ jobs:
     - name: Setup cluster
       run: ~/actionutils.sh cluster_nodes internal
 
-    - name: Enable one extra ceph mon for redundancy
-      run: ~/actionutils.sh nodeexec node-wrk3 enable_mon
-
     - name: Add and wait for OSDs
       run: |
         set -uex
@@ -526,17 +523,34 @@ jobs:
     - name: Test enter and exit maintainenace mode with set noout and stop osd
       run: ~/actionutils.sh test_maintenance_enter_set_noout_stop_osds_and_exit node-wrk1
 
-    - name: Scale down the cluster to 3 nodes
+    - name: Scale down the cluster to 3 nodes and stop 1 mon
       run: |
         set -uex
+        # reduce to 3 node cluster
         ~/actionutils.sh headexec remove_disk osd.4
         ~/actionutils.sh headexec remove_node node-wrk3
 
+        # reduce to only 2 active mons in a 3 node cluster
+        ~/actionutils.sh nodeexec node-wrk2 disable_mon
+        # wait for the cluster to report warning
+        for i in {0..100}; do
+            if ~/actionutils.sh headexec "microceph.ceph health | grep quorum" ; then
+              echo "Waiting for the cluster to be out of quorum..."
+              exit 0
+            fi
+            sleep 1
+        done
+
+        echo "Did not reach cluster warning state when there is only 2 out of 3 active mons"
+        exit 1
+
+    - name: Test not enough active mons for quorum
+      run: |
+        set -uex
         if ~/actionutils.sh headexec "microceph cluster maintenance enter node-wrk1"; then
-          echo "Unexpected to succeed entering maintenance mode with less than 4 nodes"
+          echo "Unexpected to succeed entering maintenance mode with 2 out of 3 mons active"
           exit 1
         fi
-        echo "It's expected to fail entering maintenance mode with less than 4 nodes"
 
     - name: Test force enter and exit maintainenace mode without set noout and stop osd
       run: ~/actionutils.sh test_maintenance_enter_and_exit_force node-wrk1

--- a/docs/explanation/cluster-maintenance.rst
+++ b/docs/explanation/cluster-maintenance.rst
@@ -28,7 +28,7 @@ Enabling maintenance mode
 
 - Check if OSDs on the node are ``ok-to-stop`` to ensure sufficient redundancy to tolerate the loss
   of OSDs on the node.
-- Check if the number of running services is greater than the minimum (3 MON, 1 MDS, 1 MGR)
+- Check if the number of running services is greater than the minimum (majority of MON, 1 MDS, 1 MGR)
   required for quorum.
 - *(Optional)* Apply noout flag to prevent data migration from triggering during the planned
   maintenance slot. (default=True)

--- a/microceph/ceph/maintenance.go
+++ b/microceph/ceph/maintenance.go
@@ -64,7 +64,7 @@ func (m *Maintenance) Enter(req types.MaintenanceRequest) ([]Result, error) {
 	// Preflight checks for entering maintenance mode
 	preflightChecks := []Operation{
 		&CheckOsdOkToStopOps{ClusterOps: m.ClusterOps},
-		&CheckNonOsdSvcEnoughOps{ClusterOps: m.ClusterOps, MinMon: 3, MinMds: 1, MinMgr: 1},
+		&CheckNonOsdSvcEnoughOps{ClusterOps: m.ClusterOps},
 	}
 
 	// Main operations

--- a/microceph/ceph/manager.go
+++ b/microceph/ceph/manager.go
@@ -3,6 +3,10 @@ package ceph
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microceph/microceph/common"
+	"github.com/tidwall/gjson"
 )
 
 func bootstrapMgr(hostname string, path string) error {
@@ -22,4 +26,24 @@ func bootstrapMgr(hostname string, path string) error {
 	}
 
 	return nil
+}
+
+func getActiveMgrs() ([]string, error) {
+	output, err := common.ProcessExec.RunCommand("ceph", "mgr", "dump", "-f", "json")
+	if err != nil {
+		logger.Errorf("Failed fetching Mgr dump: %v", err)
+		return nil, err
+	}
+
+	logger.Debugf("Mgr Dump:\n%s", output)
+
+	// Get the active mgr services.
+	activeMgrs := []string{}
+	result := gjson.Get(output, "standbys.#.name")
+	for _, name := range result.Array() {
+		activeMgrs = append(activeMgrs, name.String())
+	}
+	activeMgrs = append(activeMgrs, gjson.Get(output, "active_name").String())
+
+	return activeMgrs, nil
 }

--- a/microceph/ceph/metadata.go
+++ b/microceph/ceph/metadata.go
@@ -3,6 +3,10 @@ package ceph
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microceph/microceph/common"
+	"github.com/tidwall/gjson"
 )
 
 func bootstrapMds(hostname string, path string) error {
@@ -23,4 +27,23 @@ func bootstrapMds(hostname string, path string) error {
 	}
 
 	return nil
+}
+
+func getActiveMdss() ([]string, error) {
+	output, err := common.ProcessExec.RunCommand("ceph", "fs", "status", "-f", "json")
+	if err != nil {
+		logger.Errorf("Failed fetching fs status: %v", err)
+		return nil, err
+	}
+
+	logger.Debugf("Fs Status:\n%s", output)
+
+	// Get the active mds services.
+	activeMdss := []string{}
+	result := gjson.Get(output, "mdsmap.#.name")
+	for _, name := range result.Array() {
+		activeMdss = append(activeMdss, name.String())
+	}
+
+	return activeMdss, nil
 }

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -210,6 +210,13 @@ function enable_mon() {
     sudo microceph enable mon
 }
 
+function disable_mon() {
+    # Support disable mon properly. Also see issue
+    # https://github.com/canonical/microceph/issues/512
+    set -x
+    sudo snap stop microceph.mon --disable
+}
+
 function enable_rgw_ssl() {
     set -x
     # Generate the SSL material


### PR DESCRIPTION
# Description

Supersede #557 (the author of that PR is on a long break) 

Fixes: https://github.com/canonical/microceph/issues/534

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Clean code (code refactor, test updates)
- Documentation update (change to documentation

## How has this been tested?

Locally, on a 3 node microceph deployment on LXD VMs.

Before
```
root@microceph-0:~# microceph status
MicroCeph deployment summary:
- microceph-0 (10.180.54.6)
  Services: mds, mgr, mon, osd
  Disks: 3
- microceph-1 (10.180.54.82)
  Services: mds, mgr, mon, osd
  Disks: 3
- microceph-2 (10.180.54.165)
  Services: mds, mgr, mon, osd
  Disks: 3

root@microceph-0:~# microceph cluster maintenance enter microceph-0
Error: failed to enter maintenance mode: error bringing node 'microceph-0' into maintenance: maintenance operations failed: [(need at least 3 mon, 1 mds, and 1 mgr services in the cluster besides those in node 'microceph-0')]
```

After
```
root@microceph-0:~# microceph cluster maintenance enter microceph-0
Check if osds.[1 2 3] in node 'microceph-0' are ok-to-stop. (succeeded)
Check if there are at least a majority of mon services, 1 mds service, and 1 mgr service in the cluster besides those in node 'microceph-0' (succeeded)
Run `ceph osd set noout`. (succeeded)
Assert osd has 'noout' flag set. (succeeded)
```
## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change