### PR TITLE
fix: prevent enabling snapshot replication on RBD pools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -878,6 +878,9 @@ jobs:
     - name: Enable RBD Mirror Daemon
       run : ~/actionutils.sh remote_enable_rbd_mirror_daemon
 
+    - name: Verify snapshot replication on pool fails
+      run: ~/actionutils.sh remote_verify_snapshot_pool_replication_fails
+
     - name: Configure RBD mirror
       run : ~/actionutils.sh remote_configure_rbd_mirroring
 

--- a/microceph/ceph/replication_rbd.go
+++ b/microceph/ceph/replication_rbd.go
@@ -132,7 +132,11 @@ func (rh *RbdReplicationHandler) EnableHandler(ctx context.Context, args ...any)
 
 	logger.Infof("REPRBD: Local(%s) Remote(%s)", dbRec[0].LocalName, dbRec[0].Name)
 	if rh.Request.ResourceType == types.RbdResourcePool {
-		return handlePoolEnablement(rh, dbRec[0].LocalName, dbRec[0].Name)
+		if rh.Request.ReplicationType == types.RbdReplicationSnapshot {
+			return fmt.Errorf("Snapshot-based replication is only supported for individual RBD images, not pools")
+		} else {
+			return handlePoolEnablement(rh, dbRec[0].LocalName, dbRec[0].Name)
+		}
 	} else if rh.Request.ResourceType == types.RbdResourceImage {
 		return handleImageEnablement(rh, dbRec[0].LocalName, dbRec[0].Name)
 	}

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -1117,6 +1117,16 @@ function test_maintenance_enter_set_noout_stop_osds_and_exit_force() {
     echo "Passed: test running maintenance enter and exit with --set-noout=true --stop-osds=true --force."
 }
 
+# Test that enabling snapshot replication on an RBD pool fails with the correct error message.
+# Usage: remote_verify_snapshot_pool_replication_fails
+function remote_verify_snapshot_pool_replication_fails() {
+    set -eux
+
+    # This function must be called only after the pool has been created (e.g., after bootstrap or before Configure RBD mirror)
+    lxc exec node-wrk0 -- sh -c \
+        '! microceph replication enable rbd pool_one --type snapshot --remote siteb | grep "Snapshot-based replication is only supported for individual RBD images"'
+}
+
 run="${1}"
 shift
 


### PR DESCRIPTION
# Description

This change adds a validation check to prevent users from enabling snapshot-based replication on RBD pools, which is currently unsupported. If a user attempts this, the system now returns a clear and descriptive error message.

This improves user experience by avoiding silent failures and preventing unexpected fallback to journal mode.

Fixes: #547


## Type of change

- ✅ Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

I tested this manually using my local build of MicroCeph (custom snap package) installed in `--devmode` in two clean Multipass VMs:

- **micro01** and **micro02** were set up as separate Ceph clusters using `microceph cluster bootstrap`.
- Fake disks were created using loopback devices on both VMs (`fallocate` + `losetup`) and added using `microceph disk add`.
- The two clusters were linked via exported tokens using `microceph remote import` and `cluster export`.
- On `micro01`, I created a pool (`foo`) and two RBD images (`test`, `test2`).
- Before replication, I confirmed the images had no journaling features via `microceph.rbd info foo/test`.

Then I ran:
```bash
sudo microceph replication enable rbd foo --type snapshot --remote secondary
```
✅ The command failed as expected with the message:

```bash
Error: failed to process enable_replication request for rbd: Snapshot-based replication is only supported for individual RBD images, not pools
```
✅ After the command, `microceph.rbd info foo/test` confirmed that journaling was not silently enabled — verifying the bug is now prevented.
