### PR TITLE
fix: prevent using the same name for local alias and remote cluster

### DIFF
--- a/docs/how-to/import-remote-cluster.rst
+++ b/docs/how-to/import-remote-cluster.rst
@@ -26,6 +26,11 @@ At the primary cluster, this token can be imported to create the remote record.
 
    sudo microceph remote import simple eyJmc2lkIjoiN2FiZmMwYmItNjIwNC00M2FmLTg4NDQtMjg3NDg2OGNiYTc0Iiwia2V5cmluZy5jbGllbnQubWFnaWNhbCI6IkFRQ0hJdmRtNG91SUNoQUFraGsvRldCUFI0WXZCRkpzUC92dDZ3PT0iLCJtb24uaG9zdC5zaW1wbGUtcmVpbmRlZXIiOiIxMC40Mi44OC42OSIsInB1YmxpY19uZXR3b3JrIjoiMTAuNDIuODguNjkvMjQifQ== --local-name magical
 
+.. note::
+
+   The value of ``--local-name`` must be different from the remote cluster name (``simple`` in this example).
+   Using the same name for both will result in an error to avoid conflicts during replication.
+
 This will create the required $simple.conf and $simple.keyring files.
 Note: Importing a remote cluster is a uni-directional operation. For symmetric
 relations both clusters should be added as remotes at each other.

--- a/microceph/cmd/microceph/remote_import.go
+++ b/microceph/cmd/microceph/remote_import.go
@@ -39,6 +39,10 @@ func (c *cmdRemoteImport) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please provide a local name using `--local-name` flag")
 	}
 
+	if c.localName == args[0] {
+		return fmt.Errorf("local alias (--local-name) and remote name must be different to avoid site conflicts")
+	}
+
 	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

This PR introduces a validation in the remote import CLI command to prevent users from specifying the same value for the --local-name flag and the remote cluster name (positional argument). This resolves an issue where Ceph replication fails due to duplicate site names during peer bootstrap.

Additionally, the relevant documentation (Import a remote MicroCeph cluster) was updated to include a note that clarifies this requirement for users.

Fixes #559

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

The validation was tested locally by building the microceph binary and running the remote import command with:
- Identical --local-name and remote name: correctly triggers a validation error
- Distinct values: proceeds past validation as expected