### PR TITLE
feat: Add cephfs-mirror to service placement interface

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -832,8 +832,8 @@ jobs:
     - name: Exercise RGW again
       run: ~/actionutils.sh testrgw "newFile"
 
-  replication-tests:
-    name: Test MicroCeph Remote Replication features.
+  rbd-replication-test:
+    name: Test MicroCeph RBD Remote Replication features.
     runs-on: ubuntu-22.04
     needs: build-microceph
     steps:
@@ -876,7 +876,7 @@ jobs:
       run: ~/actionutils.sh remote_perform_remote_ops_check
 
     - name: Enable RBD Mirror Daemon
-      run : ~/actionutils.sh remote_enable_rbd_mirror_daemon
+      run : ~/actionutils.sh remote_enable_mirror_daemon "rbd-mirror"
 
     - name: Verify snapshot replication on pool fails
       run: ~/actionutils.sh remote_verify_snapshot_pool_replication_fails
@@ -898,6 +898,62 @@ jobs:
 
     - name: Verify Remote removal
       run: ~/actionutils.sh remote_remove_and_verify
+
+  cephfs-replication-test:
+    name: Test MicroCeph Cephfs Remote Replication features.
+    runs-on: ubuntu-24.04
+    needs: build-microceph
+    steps:
+    - name: Download snap
+      uses: actions/download-artifact@v4
+      with:
+        name: snaps
+        path: /home/runner
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Copy utils
+      run: cp tests/scripts/actionutils.sh $HOME
+
+    - name: Clear FORWARD firewall rules
+      run: ~/actionutils.sh cleaript
+
+    - name: Free disk
+      run: ~/actionutils.sh free_runner_disk
+
+    - name: Install dependencies
+      run: ~/actionutils.sh setup_lxd
+
+    - name: Create virtual machines with block devices
+      run: ~/actionutils.sh create_vms 4
+
+    - name: Bootstrap
+      run: ~/actionutils.sh remote_simple_bootstrap_two_sites
+
+    - name: Exchange Cluster tokens
+      run: ~/actionutils.sh remote_exchange_site_tokens
+
+    - name: Verify Remote authentication
+      run: ~/actionutils.sh remote_perform_remote_ops_check
+
+    - name: Enable Cephfs Mirror Daemon
+      run : ~/actionutils.sh remote_enable_mirror_daemon "cephfs-mirror"
+
+    - name: Install ceph-common
+      run : ~/actionutils.sh remote_install_ceph_common
+
+    - name: Configure CephFS mirror
+      run : ~/actionutils.sh remote_configure_cephfs_mirroring
+
+    - name: Perform IO and Wait for CephFS mirror to sync directories
+      run : ~/actionutils.sh remote_wait_cephfs_for_secondary_to_sync 40
+
+    - name: Verify Data integrity
+      run : ~/actionutils.sh remote_verify_cephfs_mirroring
+
+    - name: Disable Cephfs Mirror daemons
+      run : ~/actionutils.sh remote_enable_mirror_daemon "cephfs-mirror"
 
   nfs-test:
     name: Test MicroCeph NFS feature

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -925,8 +925,11 @@ jobs:
     - name: Install dependencies
       run: ~/actionutils.sh setup_lxd
 
-    - name: Create virtual machines with block devices
-      run: ~/actionutils.sh create_vms 4
+    - name: Create containers with loopback devices
+      run: ~/actionutils.sh create_containers public
+
+    - name: Install local microceph snap
+      run: ~/actionutils.sh install_multinode
 
     - name: Bootstrap
       run: ~/actionutils.sh remote_simple_bootstrap_two_sites
@@ -940,8 +943,8 @@ jobs:
     - name: Enable Cephfs Mirror Daemon
       run : ~/actionutils.sh remote_enable_mirror_daemon "cephfs-mirror"
 
-    - name: Install ceph-common
-      run : ~/actionutils.sh remote_install_ceph_common
+    - name: Install ceph-common on host
+      run : sudo apt install ceph-common -y
 
     - name: Configure CephFS mirror
       run : ~/actionutils.sh remote_configure_cephfs_mirroring
@@ -953,7 +956,7 @@ jobs:
       run : ~/actionutils.sh remote_verify_cephfs_mirroring
 
     - name: Disable Cephfs Mirror daemons
-      run : ~/actionutils.sh remote_enable_mirror_daemon "cephfs-mirror"
+      run : ~/actionutils.sh remote_disable_mirror_daemon "cephfs-mirror"
 
   nfs-test:
     name: Test MicroCeph NFS feature

--- a/microceph/api/servers.go
+++ b/microceph/api/servers.go
@@ -27,6 +27,7 @@ var Servers = map[string]rest.Server{
 					poolsOpCmd,
 					rgwServiceCmd,
 					rbdMirroServiceCmd,
+					fsMirroServiceCmd,
 					poolsCmd,
 					clientCmd,
 					clientConfigsCmd,

--- a/microceph/api/services.go
+++ b/microceph/api/services.go
@@ -80,6 +80,11 @@ var rbdMirroServiceCmd = rest.Endpoint{
 	Put:    rest.EndpointAction{Handler: cmdEnableServicePut, ProxyTarget: true},
 	Delete: rest.EndpointAction{Handler: cmdDeleteService, ProxyTarget: true},
 }
+var fsMirroServiceCmd = rest.Endpoint{
+	Path:   "services/cephfs-mirror",
+	Put:    rest.EndpointAction{Handler: cmdEnableServicePut, ProxyTarget: true},
+	Delete: rest.EndpointAction{Handler: cmdDeleteService, ProxyTarget: true},
+}
 
 // cmdMonGet returns the mon service status.
 func cmdMonGet(s state.State, r *http.Request) response.Response {
@@ -159,7 +164,7 @@ func cmdRestartServicePost(s state.State, r *http.Request) response.Response {
 // cmdDeleteService handles service deletion.
 func cmdDeleteService(s state.State, r *http.Request) response.Response {
 	which := path.Base(r.URL.Path)
-	_, ok := ceph.GetConfigTableServiceSet()[which]
+	_, ok := ceph.GetServicePlacementTable()[which]
 	if !ok {
 		err := fmt.Errorf("%s is not a valid ceph service", which)
 		logger.Errorf("%v", err)

--- a/microceph/ceph/fs_mirror.go
+++ b/microceph/ceph/fs_mirror.go
@@ -1,0 +1,29 @@
+package ceph
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/canonical/lxd/shared/logger"
+)
+
+func bootstrapFsMirror(hostname string, path string) error {
+	args := []string{
+		"auth",
+		"get-or-create",
+		fmt.Sprintf("client.cephfs-mirror.%s", hostname),
+		"mds", "allow r",
+		"mgr", "allow r",
+		"mon", "profile cephfs-mirror",
+		"osd", "allow rw tag cephfs metadata=*, allow r tag cephfs data=*",
+		"-o", filepath.Join(path, "keyring"),
+	}
+
+	_, err := cephRun(args...)
+	if err != nil {
+		logger.Errorf("failed to bootstrap cephfs-mirror daemon: %s", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/microceph/ceph/services_placement.go
+++ b/microceph/ceph/services_placement.go
@@ -26,12 +26,13 @@ type PlacementIntf interface {
 
 func GetServicePlacementTable() map[string](PlacementIntf) {
 	return map[string](PlacementIntf){
-		"mon":        &MonServicePlacement{"mon"},
-		"mgr":        &GenericServicePlacement{"mgr"},
-		"mds":        &GenericServicePlacement{"mds"},
-		"nfs":        &NFSServicePlacement{},
-		"rgw":        &RgwServicePlacement{},
-		"rbd-mirror": &ClientServicePlacement{"rbd-mirror"},
+		"mon":           &MonServicePlacement{"mon"},
+		"mgr":           &GenericServicePlacement{"mgr"},
+		"mds":           &GenericServicePlacement{"mds"},
+		"nfs":           &NFSServicePlacement{},
+		"rgw":           &RgwServicePlacement{},
+		"rbd-mirror":    &ClientServicePlacement{"rbd-mirror"},
+		"cephfs-mirror": &ClientServicePlacement{"cephfs-mirror"},
 	}
 }
 

--- a/microceph/ceph/services_placement_generic.go
+++ b/microceph/ceph/services_placement_generic.go
@@ -18,10 +18,11 @@ import (
 // Maps the addService function to respective services.
 func GetServiceKeyringTable() map[string](func(string, string) error) {
 	return map[string](func(string, string) error){
-		"mon":        joinMon,
-		"mgr":        bootstrapMgr,
-		"mds":        bootstrapMds,
-		"rbd-mirror": bootstrapRbdMirror,
+		"mon":           joinMon,
+		"mgr":           bootstrapMgr,
+		"mds":           bootstrapMds,
+		"rbd-mirror":    bootstrapRbdMirror,
+		"cephfs-mirror": bootstrapFsMirror,
 		// Add more services here, for using the generic Interface implementation.
 	}
 }

--- a/microceph/cmd/microceph/disable.go
+++ b/microceph/cmd/microceph/disable.go
@@ -22,6 +22,10 @@ func (c *cmdDisable) Command() *cobra.Command {
 	disableRGWCmd := cmdDisableRGW{common: c.common}
 	cmd.AddCommand(disableRGWCmd.Command())
 
+	// Disable cephfs-mirror
+	disableCephfsMirror := cmdDisableCephFSMirror{common: c.common}
+	cmd.AddCommand(disableCephfsMirror.Command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }

--- a/microceph/cmd/microceph/disable_cephfs_mirror.go
+++ b/microceph/cmd/microceph/disable_cephfs_mirror.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+
+	"github.com/canonical/microcluster/v2/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microceph/microceph/client"
+)
+
+type cmdDisableCephFSMirror struct {
+	common     *CmdControl
+	flagTarget string
+}
+
+func (c *cmdDisableCephFSMirror) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cephfs-mirror",
+		Short: "Disable the CephFSMirror service",
+		RunE:  c.Run,
+	}
+	cmd.PersistentFlags().StringVar(&c.flagTarget, "target", "", "Server hostname (default: this server)")
+	return cmd
+}
+
+// Run handles the disable cephfs-mirror command.
+func (c *cmdDisableCephFSMirror) Run(cmd *cobra.Command, args []string) error {
+
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteService(context.Background(), cli, c.flagTarget, "cephfs-mirror")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/microceph/cmd/microceph/enable.go
+++ b/microceph/cmd/microceph/enable.go
@@ -21,6 +21,7 @@ func (c *cmdEnable) Command() *cobra.Command {
 	enableMdsCmd := cmdEnableMDS{common: c.common}
 	enableNFSCmd := cmdEnableNFS{common: c.common}
 	enableRbdMirrorCmd := cmdEnableRBDMirror{common: c.common}
+	enableFsMirrorCmd := cmdEnableFsMirror{common: c.common}
 
 	cmd.AddCommand(enableRGWCmd.Command())
 	cmd.AddCommand(enableMonCmd.Command())
@@ -28,6 +29,7 @@ func (c *cmdEnable) Command() *cobra.Command {
 	cmd.AddCommand(enableMdsCmd.Command())
 	cmd.AddCommand(enableNFSCmd.Command())
 	cmd.AddCommand(enableRbdMirrorCmd.Command())
+	cmd.AddCommand(enableFsMirrorCmd.Command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs

--- a/microceph/cmd/microceph/enable_cephfs_mirror.go
+++ b/microceph/cmd/microceph/enable_cephfs_mirror.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+
+	"github.com/canonical/microcluster/v2/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/client"
+)
+
+type cmdEnableFsMirror struct {
+	common     *CmdControl
+	wait       bool
+	flagTarget string
+}
+
+func (c *cmdEnableFsMirror) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cephfs-mirror [--target <server>] [--wait <bool>]",
+		Short: "Enable the CephFS Mirror service on the --target server (default: this server)",
+		RunE:  c.Run,
+	}
+	cmd.PersistentFlags().StringVar(&c.flagTarget, "target", "", "Server hostname (default: this server)")
+	cmd.Flags().BoolVar(&c.wait, "wait", true, "Wait for cephfs-mirror service to be up.")
+	return cmd
+}
+
+// Run handles the enable mon command.
+func (c *cmdEnableFsMirror) Run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+	cli = cli.UseTarget(c.flagTarget)
+	req := &types.EnableService{
+		Name:    "cephfs-mirror",
+		Wait:    c.wait,
+		Payload: "",
+	}
+
+	err = client.SendServicePlacementReq(context.Background(), cli, req, c.flagTarget)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -148,6 +148,16 @@ apps:
       - network
       - network-bind
       - process-control
+  "cephfs-mirror":
+    command: commands/cephfs-mirror.start
+    daemon: simple
+    install-mode: disable
+    after:
+      - daemon
+    plugs:
+      - network
+      - network-bind
+      - process-control
   # Commands
   ceph:
     command: commands/ceph
@@ -214,6 +224,7 @@ parts:
       - ceph-osd
       - radosgw
       - rbd-mirror
+      - cephfs-mirror
       # Utilities
       - coreutils
       - uuid-runtime
@@ -240,6 +251,7 @@ parts:
       - bin/radosgw
       - bin/radosgw-admin
       - bin/rbd-mirror
+      - bin/cephfs-mirror
       - bin/truncate
       - bin/uuidgen
       - lib/*/ceph

--- a/snapcraft/commands/cephfs-mirror.start
+++ b/snapcraft/commands/cephfs-mirror.start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. "${SNAP}/commands/common"
+
+limits
+
+exec cephfs-mirror -f --cluster ceph --id "cephfs-mirror.$(hostname)"


### PR DESCRIPTION
# Description

Adds cephfs-mirror daemon to the service placement interface

## Type of change
- New feature (non-breaking change which adds functionality)
- Documentation update (change to documentation only)

## How has this been tested?
 - Added a functional test

## Contributor checklist

- [X] self-reviewed the code in this PR
- [X] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change