### PR TITLE
Add our product page to header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "",
+    "product_page": "microceph.com",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # To add a tag image, uncomment and update as needed.


### PR DESCRIPTION
# Description

The docs starter pack gives us an option to include our product page in the header of of our docs site. We agreed as a team to point to microceph.com because it's more of a homepage, and it's suitable for a broader audience - including for marketing reasons, which are not satisfied by our docs site.

## Type of change

- Documentation update (change to documentation only)

## How has this been tested?

- I have built the docs locally to make sure it works.

## Contributor checklist

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change