### PR TITLE
refactor: move subprocess to common package

### DIFF
--- a/microceph/ceph/bootstrap_test.go
+++ b/microceph/ceph/bootstrap_test.go
@@ -104,7 +104,7 @@ func (s *bootstrapSuite) TestBootstrap() {
 	addEnableMsgr2Expectations(r)
 	addNetworkExpectationsBootstrap(nw, s.TestStateInterface)
 
-	processExec = r
+	common.ProcessExec = r
 	common.Network = nw
 
 	err := Bootstrap(context.Background(), s.TestStateInterface, common.BootstrapConfig{MonIp: "1.1.1.1", PublicNet: "1.1.1.1/24"})
@@ -121,7 +121,7 @@ func (s *bootstrapSuite) TestBootstrapDataPrep() {
 
 	addNetworkExpectations(nw, s.TestStateInterface)
 
-	processExec = r
+	common.ProcessExec = r
 	common.Network = nw
 
 	// Case 1. Only mon-ip is provided.

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -145,7 +145,7 @@ func GetConfigItem(c types.Config) (types.Configs, error) {
 	}
 
 	ret[0].Key = c.Key
-	ret[0].Value, err = processExec.RunCommand("ceph", args...)
+	ret[0].Value, err = common.ProcessExec.RunCommand("ceph", args...)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func RemoveConfigItem(c types.Config) error {
 		c.Key,
 	}
 
-	_, err = processExec.RunCommand("ceph", args...)
+	_, err = common.ProcessExec.RunCommand("ceph", args...)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func ListConfigs() (types.Configs, error) {
 		"json-pretty",
 	}
 
-	output, err := processExec.RunCommand("ceph", args...)
+	output, err := common.ProcessExec.RunCommand("ceph", args...)
 	if err != nil {
 		return configs, err
 	}
@@ -217,7 +217,7 @@ func setConfigItem(c types.Config) error {
 		"json-pretty",
 	}
 
-	_, err := processExec.RunCommand("ceph", args...)
+	_, err := common.ProcessExec.RunCommand("ceph", args...)
 	if err != nil {
 		return err
 	}

--- a/microceph/ceph/config_test.go
+++ b/microceph/ceph/config_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"encoding/json"
+	"github.com/canonical/microceph/microceph/common"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/tests"
@@ -51,7 +52,7 @@ func (s *configSuite) TestSetConfig() {
 
 	r := mocks.NewRunner(s.T())
 	addConfigSetExpectations(r, t.Key, t.Value)
-	processExec = r
+	common.ProcessExec = r
 
 	err := SetConfigItem(t)
 	assert.NoError(s.T(), err)
@@ -69,7 +70,7 @@ func (s *configSuite) TestSetROConfigBypassChecks() {
 
 	r := mocks.NewRunner(s.T())
 	addConfigSetExpectations(r, t.Key, t.Value)
-	processExec = r
+	common.ProcessExec = r
 
 	err := SetConfigItemUnsafe(t)
 	assert.NoError(s.T(), err)
@@ -87,7 +88,7 @@ func (s *configSuite) TestGetConfig() {
 
 	r := mocks.NewRunner(s.T())
 	addConfigOpExpectations(r, "get", "mon", t.Key, t.Value)
-	processExec = r
+	common.ProcessExec = r
 
 	_, err := GetConfigItem(t)
 	assert.NoError(s.T(), err)
@@ -105,7 +106,7 @@ func (s *configSuite) TestResetConfig() {
 
 	r := mocks.NewRunner(s.T())
 	addConfigOpExpectations(r, "rm", "global", t.Key, t.Value)
-	processExec = r
+	common.ProcessExec = r
 
 	err := RemoveConfigItem(t)
 	assert.NoError(s.T(), err)
@@ -116,7 +117,7 @@ func (s *configSuite) TestListConfig() {
 
 	r := mocks.NewRunner(s.T())
 	addListConfigExpectations(r, t.Key, t.Value)
-	processExec = r
+	common.ProcessExec = r
 
 	configs, err := ListConfigs()
 	assert.NoError(s.T(), err)

--- a/microceph/ceph/crush.go
+++ b/microceph/ceph/crush.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"strings"
 
 	"github.com/canonical/microceph/microceph/api/types"
@@ -12,7 +13,7 @@ import (
 
 // addCrushRule creates a new default crush rule with a given name and failure domain
 func addCrushRule(name string, failureDomain string) error {
-	_, err := processExec.RunCommand("ceph", "osd", "crush", "rule", "create-replicated", name, "default", failureDomain)
+	_, err := common.ProcessExec.RunCommand("ceph", "osd", "crush", "rule", "create-replicated", name, "default", failureDomain)
 	if err != nil {
 		return err
 	}
@@ -22,7 +23,7 @@ func addCrushRule(name string, failureDomain string) error {
 
 // listCrushRules returns a list of crush rule names
 func listCrushRules() ([]string, error) {
-	output, err := processExec.RunCommand("ceph", "osd", "crush", "rule", "ls")
+	output, err := common.ProcessExec.RunCommand("ceph", "osd", "crush", "rule", "ls")
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func haveCrushRule(name string) bool {
 
 // getCrushRuleID returns the id of a crush rule with the given name
 func getCrushRuleID(name string) (string, error) {
-	output, err := processExec.RunCommand("ceph", "osd", "crush", "rule", "dump", name)
+	output, err := common.ProcessExec.RunCommand("ceph", "osd", "crush", "rule", "dump", name)
 	if err != nil {
 		return "", err
 	}
@@ -77,7 +78,7 @@ func getPoolsForDomain(domain string) ([]string, error) {
 		return nil, err
 	}
 
-	output, err := processExec.RunCommand("ceph", "osd", "pool", "ls", "detail", "--format=json")
+	output, err := common.ProcessExec.RunCommand("ceph", "osd", "pool", "ls", "detail", "--format=json")
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func getPoolsForDomain(domain string) ([]string, error) {
 
 // setPoolCrushRule sets the crush rule for a given pool
 func setPoolCrushRule(pool string, rule string) error {
-	_, err := processExec.RunCommand("ceph", "osd", "pool", "set", pool, "crush_rule", rule)
+	_, err := common.ProcessExec.RunCommand("ceph", "osd", "pool", "set", pool, "crush_rule", rule)
 	if err != nil {
 		return err
 	}

--- a/microceph/ceph/keyring.go
+++ b/microceph/ceph/keyring.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"bufio"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"strings"
 )
@@ -23,7 +24,7 @@ func genKeyring(path, name string, caps ...[]string) error {
 		args = append(args, "--cap", capability[0], capability[1])
 	}
 
-	_, err := processExec.RunCommand("ceph-authtool", args...)
+	_, err := common.ProcessExec.RunCommand("ceph-authtool", args...)
 	if err != nil {
 		return err
 	}
@@ -38,7 +39,7 @@ func importKeyring(path string, source string) error {
 		source,
 	}
 
-	_, err := processExec.RunCommand("ceph-authtool", args...)
+	_, err := common.ProcessExec.RunCommand("ceph-authtool", args...)
 	if err != nil {
 		return err
 	}

--- a/microceph/ceph/keyring_test.go
+++ b/microceph/ceph/keyring_test.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"github.com/canonical/microceph/microceph/common"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/mocks"
@@ -31,7 +32,7 @@ func (ks *KeyringSuite) TestClientKeyringCreation() {
 		"ceph", "auth", "get-or-create", "client.RemoteName"}...).Return("ok", nil).Once()
 	r.On("RunCommand", []interface{}{
 		"ceph", "auth", "print-key", "client.RemoteName"}...).Return("ABCD", nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Method call
 	clientKey, err := CreateClientKey("RemoteName")
@@ -46,7 +47,7 @@ func (ks *KeyringSuite) TestClientKeyringDelete() {
 	// mocks and expectations
 	r.On("RunCommand", []interface{}{
 		"ceph", "auth", "del", "client.RemoteName"}...).Return("ok", nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Method call
 	err := DeleteClientKey("RemoteName")

--- a/microceph/ceph/monitor.go
+++ b/microceph/ceph/monitor.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"fmt"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 )
@@ -14,7 +15,7 @@ func genMonmap(path string, fsid string) error {
 		path,
 	}
 
-	_, err := processExec.RunCommand("monmaptool", args...)
+	_, err := common.ProcessExec.RunCommand("monmaptool", args...)
 	if err != nil {
 		return err
 	}
@@ -30,7 +31,7 @@ func addMonmap(path string, name string, address string) error {
 		path,
 	}
 
-	_, err := processExec.RunCommand("monmaptool", args...)
+	_, err := common.ProcessExec.RunCommand("monmaptool", args...)
 	if err != nil {
 		return err
 	}
@@ -47,7 +48,7 @@ func bootstrapMon(hostname string, path string, monmap string, keyring string) e
 		"--keyring", keyring,
 	}
 
-	_, err := processExec.RunCommand("ceph-mon", args...)
+	_, err := common.ProcessExec.RunCommand("ceph-mon", args...)
 	if err != nil {
 		return err
 	}

--- a/microceph/ceph/nfs.go
+++ b/microceph/ceph/nfs.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -300,5 +301,5 @@ func removeNodeFromSharedGraceMgmtDb(cephConfPath, clusterID, userID, node strin
 
 // ganeshaRadosGraceRun runs the ganesha-rados-grace command with the given arguments.
 func ganeshaRadosGraceRun(args ...string) (string, error) {
-	return processExec.RunCommand("ganesha-rados-grace", args...)
+	return common.ProcessExec.RunCommand("ganesha-rados-grace", args...)
 }

--- a/microceph/ceph/nfs_test.go
+++ b/microceph/ceph/nfs_test.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,8 +73,8 @@ func (s *NFSSuite) TestEnableNFS() {
 	// startNFS call
 	r.On("RunCommand", "snapctl", "start", "microceph.nfs", "--enable").Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	nfs := &NFSServicePlacement{
 		ClusterID:    clusterID,
@@ -199,8 +200,8 @@ func (s *NFSSuite) TestDisableNFS() {
 	clientUser := fmt.Sprintf("client.%s", userID)
 	r.On("RunCommand", "ceph", "auth", "del", clientUser).Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err = DisableNFS(ctx, s.TestStateInterface, clusterID)
@@ -217,8 +218,8 @@ func (s *NFSSuite) TestStartNFS() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "snapctl", "start", "microceph.nfs", "--enable").Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := startNFS()
@@ -229,8 +230,8 @@ func (s *NFSSuite) TestStopNFS() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "snapctl", "stop", "microceph.nfs", "--disable").Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := stopNFS()
@@ -244,8 +245,8 @@ func (s *NFSSuite) TestCreateNFSKeyring() {
 	// mocks and expectations
 	r.On("RunCommand", []interface{}{"ceph", "auth", "get-or-create", "client.lish", "mon", "allow r", "osd", "allow rw pool=.nfs namespace=foo", "-o", keyringPath}...).Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := createNFSKeyring(s.Tmp, "foo", "lish")
@@ -262,8 +263,8 @@ func (s *NFSSuite) TestEnsureNFSPoolFailPool() {
 	r.On("RunCommand", []interface{}{
 		"rados", "ls", "--pool", ".nfs", "--all", "--create"}...).Return("", expectedErr).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := ensureNFSPool(clusterID)
@@ -284,8 +285,8 @@ func (s *NFSSuite) TestEnsureNFSPoolFailEnable() {
 	r.On("RunCommand", []interface{}{
 		"ceph", "osd", "pool", "application", "enable", ".nfs", "nfs"}...).Return("", expectedErr).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := ensureNFSPool(clusterID)
@@ -309,8 +310,8 @@ func (s *NFSSuite) TestEnsureNFSPoolFailCreateObj() {
 	r.On("RunCommand", []interface{}{
 		"rados", "create", "--pool", ".nfs", "-N", clusterID, obj}...).Return("", expectedErr).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := ensureNFSPool(clusterID)
@@ -334,8 +335,8 @@ func (s *NFSSuite) TestEnsureNFSPool() {
 	r.On("RunCommand", []interface{}{
 		"rados", "create", "--pool", ".nfs", "-N", clusterID, obj}...).Return("", existsErr).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := ensureNFSPool(clusterID)
@@ -359,8 +360,8 @@ func (s *NFSSuite) TestAddNodeToSharedGraceMgmtDb() {
 	r.On("RunCommand", []interface{}{
 		"ganesha-rados-grace", "--cephconf", cephconf, "--pool", ".nfs", "--ns", clusterID, "--userid", userID, "add", node2}...).Return("", expectedErr).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := addNodeToSharedGraceMgmtDb(cephconf, clusterID, userID, node)
@@ -389,8 +390,8 @@ func (s *NFSSuite) TestRemoveNodeFromSharedGraceMgmtDb() {
 	r.On("RunCommand", []interface{}{
 		"ganesha-rados-grace", "--cephconf", cephconf, "--pool", ".nfs", "--ns", clusterID, "--userid", userID, "remove", node2}...).Return("", expectedErr).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// function call
 	err := removeNodeFromSharedGraceMgmtDb(cephconf, clusterID, userID, node)

--- a/microceph/ceph/operations_test.go
+++ b/microceph/ceph/operations_test.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/database"
@@ -46,8 +47,8 @@ func (s *operationsSuite) TestCheckOsdOkToStopOpsTrue() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "ok-to-stop", "osd.1").Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// osd.1 in microceph-0 is okay to stop
 	ops := CheckOsdOkToStopOps{ClusterOps: ClusterOps{nil, context.Background()}}
@@ -75,8 +76,8 @@ func (s *operationsSuite) TestCheckOsdOkToStopOpsFalse() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "ok-to-stop", "osd.1").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// osd.1 in microceph-0 is not okay to stop
 	ops := CheckOsdOkToStopOps{ClusterOps: ClusterOps{nil, context.Background()}}
@@ -101,8 +102,8 @@ func (s *operationsSuite) TestSetNooutOpsOkay() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "set", "noout").Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := SetNooutOps{}
 	err := ops.Run("microceph-0")
@@ -113,8 +114,8 @@ func (s *operationsSuite) TestSetNooutOpsFail() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "set", "noout").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := SetNooutOps{}
 	err := ops.Run("microceph-0")
@@ -125,8 +126,8 @@ func (s *operationsSuite) TestAssertNooutFlagSetOpsTrue() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "dump").Return("flags noout", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := AssertNooutFlagSetOps{}
 	err := ops.Run("microceph-0")
@@ -137,8 +138,8 @@ func (s *operationsSuite) TestAssertNooutFlagSetOpsFalse() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "dump").Return("flags", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := AssertNooutFlagSetOps{}
 	err := ops.Run("microceph-0")
@@ -149,8 +150,8 @@ func (s *operationsSuite) TestAssertNooutFlagSetOpsError() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "dump").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := AssertNooutFlagSetOps{}
 	err := ops.Run("microceph-0")
@@ -161,8 +162,8 @@ func (s *operationsSuite) TestAssertNooutFlagUnsetOpsTrue() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "dump").Return("flags", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := AssertNooutFlagUnsetOps{}
 	err := ops.Run("microceph-0")
@@ -173,8 +174,8 @@ func (s *operationsSuite) TestAssertNooutFlagUnsetOpsFalse() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "dump").Return("flags noout", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := AssertNooutFlagUnsetOps{}
 	err := ops.Run("microceph-0")
@@ -185,8 +186,8 @@ func (s *operationsSuite) TestAssertNooutFlagUnsetOpsError() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "dump").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := AssertNooutFlagUnsetOps{}
 	err := ops.Run("microceph-0")
@@ -197,8 +198,8 @@ func (s *operationsSuite) TestStopOsdOpsOkay() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "snapctl", "stop", "microceph.osd", "--disable").Return("okay", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := StopOsdOps{ClusterOps: ClusterOps{nil, context.Background()}}
 	err := ops.Run("microceph-0")
@@ -209,8 +210,8 @@ func (s *operationsSuite) TestStopOsdOpsFail() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "snapctl", "stop", "microceph.osd", "--disable").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := StopOsdOps{ClusterOps: ClusterOps{nil, context.Background()}}
 	err := ops.Run("microceph-0")
@@ -221,8 +222,8 @@ func (s *operationsSuite) TestStartOsdOpsOkay() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "snapctl", "start", "microceph.osd", "--enable").Return("okay", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := StartOsdOps{ClusterOps: ClusterOps{nil, context.Background()}}
 	err := ops.Run("microceph-0")
@@ -235,8 +236,8 @@ func (s *operationsSuite) TestStartOsdOpsFail() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "snapctl", "start", "microceph.osd", "--enable").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := StartOsdOps{ClusterOps: ClusterOps{nil, context.Background()}}
 	err := ops.Run("microceph-0")
@@ -247,8 +248,8 @@ func (s *operationsSuite) TestUnSetNooutOpsOkay() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "unset", "noout").Return("ok", nil).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := UnsetNooutOps{}
 	err := ops.Run("microceph-0")
@@ -259,8 +260,8 @@ func (s *operationsSuite) TestUnSetNooutOpsFail() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "osd", "unset", "noout").Return("fail", fmt.Errorf("some reasons")).Once()
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	ops := UnsetNooutOps{}
 	err := ops.Run("microceph-0")

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -75,11 +75,10 @@ func (f SharedFileStater) GetFileStat(path string) (uid int, gid int, major uint
 	return shared.GetFileStat(path)
 }
 
-
 // OSDManager handles OSD operations. It holds the state, a runner for executing commands and a filesystem interface.
 type OSDManager struct {
 	state        state.State
-	runner       Runner
+	runner       common.Runner
 	fs           afero.Fs
 	storage      interfaces.StorageInterface
 	validator    PathValidator
@@ -87,12 +86,11 @@ type OSDManager struct {
 	fileStater   FileStater
 }
 
-
 // NewOSDManager returns a new OSD manager instance.
 func NewOSDManager(s state.State) *OSDManager {
 	return &OSDManager{
 		state:        s,
-		runner:       processExec,
+		runner:       common.ProcessExec,
 		fs:           afero.NewOsFs(),
 		storage:      StorageImpl{},
 		validator:    SharedPathValidator{},
@@ -1022,7 +1020,7 @@ func (m *OSDManager) purgeOSD(osd int64) error {
 			// Success: break the retry loop
 			break
 		}
-		// we're getting a RunError from processExec.RunCommand, and it
+		// we're getting a RunError from ProcessExec.RunCommand, and it
 		// wraps the original exit error if there's one
 		exitError, ok := err.(shared.RunError).Unwrap().(*exec.ExitError)
 		if !ok {
@@ -1242,7 +1240,7 @@ func setOsdNooutFlag(set bool) error {
 		command = "unset"
 	}
 
-	_, err := processExec.RunCommand("ceph", "osd", command, "noout")
+	_, err := common.ProcessExec.RunCommand("ceph", "osd", command, "noout")
 	if err != nil {
 		logger.Errorf("failed to %s noout flag: %v", command, err)
 		return fmt.Errorf("failed to %s noout flag: %w", command, err)
@@ -1251,7 +1249,7 @@ func setOsdNooutFlag(set bool) error {
 }
 
 func isOsdNooutSet() (bool, error) {
-	output, err := processExec.RunCommand("ceph", "osd", "dump")
+	output, err := common.ProcessExec.RunCommand("ceph", "osd", "dump")
 	if err != nil {
 		logger.Errorf("failed to dump osd info: %v", err)
 		return false, fmt.Errorf("failed to dump osd info: %w", err)
@@ -1381,7 +1379,7 @@ func (m *OSDManager) killOSD(osd int64) error {
 
 func SetReplicationFactor(pools []string, size int64) error {
 	ssize := fmt.Sprintf("%d", size)
-	_, err := processExec.RunCommand("ceph", "config", "set", "global",
+	_, err := common.ProcessExec.RunCommand("ceph", "config", "set", "global",
 		"osd_pool_default_size", ssize)
 	if err != nil {
 		return fmt.Errorf("failed to set pool size default: %w", err)
@@ -1392,7 +1390,7 @@ func SetReplicationFactor(pools []string, size int64) error {
 		allowSizeOne = "false"
 	}
 
-	_, err = processExec.RunCommand("ceph", "config", "set", "global",
+	_, err = common.ProcessExec.RunCommand("ceph", "config", "set", "global",
 		"mon_allow_pool_size_one", allowSizeOne)
 	if err != nil {
 		return fmt.Errorf("failed to set size one pool config option: %w", err)
@@ -1400,7 +1398,7 @@ func SetReplicationFactor(pools []string, size int64) error {
 
 	if len(pools) == 1 && pools[0] == "*" {
 		// Apply setting to all existing pools.
-		out, err := processExec.RunCommand("ceph", "osd", "pool", "ls", "--format", "json")
+		out, err := common.ProcessExec.RunCommand("ceph", "osd", "pool", "ls", "--format", "json")
 		if err != nil {
 			return fmt.Errorf("failed to list pools: %w", err)
 		}
@@ -1417,7 +1415,7 @@ func SetReplicationFactor(pools []string, size int64) error {
 			continue
 		}
 
-		_, err := processExec.RunCommand("ceph", "osd", "pool", "set", pool, "size", ssize, "--yes-i-really-mean-it")
+		_, err := common.ProcessExec.RunCommand("ceph", "osd", "pool", "set", pool, "size", ssize, "--yes-i-really-mean-it")
 		if err != nil {
 			return fmt.Errorf("failed to set pool size for %s: %w", pool, err)
 		}
@@ -1428,7 +1426,7 @@ func SetReplicationFactor(pools []string, size int64) error {
 
 // GetOSDPools returns a list of OSD Pools and their configurations.
 func GetOSDPools() ([]types.Pool, error) {
-	out, err := processExec.RunCommand("ceph", "osd", "pool", "ls", "--format", "json")
+	out, err := common.ProcessExec.RunCommand("ceph", "osd", "pool", "ls", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pools: %w", err)
 	}
@@ -1441,7 +1439,7 @@ func GetOSDPools() ([]types.Pool, error) {
 
 	pools := make([]types.Pool, 0, len(poolNames))
 	for _, name := range poolNames {
-		out, err := processExec.RunCommand("ceph", "osd", "pool", "get", name, "all", "--format", "json")
+		out, err := common.ProcessExec.RunCommand("ceph", "osd", "pool", "get", name, "all", "--format", "json")
 		if err != nil {
 			return nil, fmt.Errorf("Failed to fetch configuration for OSD pool %q: %w", name, err)
 		}
@@ -1470,7 +1468,7 @@ type CephPool struct {
 func ListPools(application string) []CephPool {
 	args := []string{"osd", "pool", "ls", "detail", "--format", "json"}
 
-	output, err := processExec.RunCommand("ceph", args...)
+	output, err := common.ProcessExec.RunCommand("ceph", args...)
 	if err != nil {
 		return []CephPool{}
 	}

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"path/filepath"
 	"testing"
 
@@ -236,7 +237,7 @@ func (s *osdSuite) TestSwitchHostFailureDomain() {
 	// set pool crush rule
 	addOsdPoolSetExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	mgr := NewOSDManager(nil)
 	mgr.fs = afero.NewMemMapFs()
@@ -267,7 +268,7 @@ func (s *osdSuite) TestUpdateFailureDomain() {
 	// set pool crush rule
 	addOsdPoolSetExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	c := mocks.NewMemberCounterInterface(s.T())
 	c.On("Count", mock.Anything).Return(3, nil).Once()
@@ -290,7 +291,7 @@ func (s *osdSuite) TestHaveOSDInCeph() {
 	addOsdTreeExpectations(r)
 	addOsdTreeExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	mgr := NewOSDManager(nil)
 	mgr.runner = r
@@ -311,8 +312,8 @@ func (s *osdSuite) TestSetOsdStateOkay() {
 	addSetOsdStateUpExpectations(r)
 	addSetOsdStateDownExpectations(r)
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	err := SetOsdState(true)
 	assert.NoError(s.T(), err)
@@ -327,8 +328,8 @@ func (s *osdSuite) TestSetOsdStateFail() {
 	addSetOsdStateUpFailedExpectations(r)
 	addSetOsdStateDownFailedExpectations(r)
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	err := SetOsdState(true)
 	assert.Error(s.T(), err)
@@ -343,8 +344,8 @@ func (s *osdSuite) TestSetOsdNooutFlagOkay() {
 	addOsdtNooutFlagTrueExpectations(r)
 	addOsdtNooutFlagFalseExpectations(r)
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	err := setOsdNooutFlag(true)
 	assert.NoError(s.T(), err)
@@ -358,8 +359,8 @@ func (s *osdSuite) TestSetOsdNooutFlagFail() {
 	r := mocks.NewRunner(s.T())
 	addOsdtNooutFlagFailedExpectations(r)
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	err := setOsdNooutFlag(true)
 	assert.Error(s.T(), err)
@@ -371,8 +372,8 @@ func (s *osdSuite) TestIsOsdNooutSetOkay() {
 	addIsOsdNooutSetTrueExpections(r)
 	addIsOsdNooutSetFalseExpections(r)
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// noout is set
 	set, err := isOsdNooutSet()
@@ -390,8 +391,8 @@ func (s *osdSuite) TestIsOsdNooutSetFail() {
 	r := mocks.NewRunner(s.T())
 	addIsOsdNooutSetFailedExpections(r)
 
-	// patch processExec
-	processExec = r
+	// patch ProcessExec
+	common.ProcessExec = r
 
 	// error running ceph osd dump
 	set, err := isOsdNooutSet()
@@ -728,11 +729,11 @@ func (s *osdSuite) TestCheckEncryptSupport() {
 	fs := afero.NewMemMapFs()
 	osdmgr.fs = fs
 
-	// Mock the processExec for isIntfConnected calls
+	// Mock the ProcessExec for isIntfConnected calls
 	r := mocks.NewRunner(s.T())
-	originalProcessExec := processExec
-	processExec = r
-	defer func() { processExec = originalProcessExec }()
+	originalProcessExec := common.ProcessExec
+	common.ProcessExec = r
+	defer func() { common.ProcessExec = originalProcessExec }()
 
 	// Test missing /dev/mapper/control
 	err := osdmgr.checkEncryptSupport()

--- a/microceph/ceph/rbd_mirror.go
+++ b/microceph/ceph/rbd_mirror.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +33,7 @@ func GetRbdMirrorPoolInfo(pool string, cluster string, client string) (RbdReplic
 	// add --cluster and --id args
 	args = appendRemoteClusterArgs(args, cluster, client)
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Warnf("REPRBD: failed pool info operation on res(%s): %v", pool, err)
 		return RbdReplicationPoolInfo{Mode: types.RbdResourceDisabled}, nil
@@ -67,7 +68,7 @@ func populatePoolStatus(status string) (RbdReplicationPoolStatus, error) {
 func GetRbdMirrorPoolStatus(pool string, cluster string, client string) (RbdReplicationPoolStatus, error) {
 	args := []string{"mirror", "pool", "status", pool, "--format", "json"}
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Warnf("failed pool status operation on res(%s): %v", pool, err)
 		return RbdReplicationPoolStatus{State: StateDisabledReplication}, nil
@@ -103,7 +104,7 @@ func GetRbdMirrorVerbosePoolStatus(pool string, cluster string, client string) (
 	args := []string{"mirror", "pool", "status", pool, "--verbose", "--format", "json"}
 
 	// Get verbose pool status
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Warnf("REPRBD: failed verbose pool status operation on res(%s): %v", pool, err)
 		return RbdReplicationVerbosePoolStatus{Summary: RbdReplicationPoolStatus{State: StateDisabledReplication}}, nil
@@ -150,7 +151,7 @@ func GetRbdMirrorImageStatus(pool string, image string, cluster string, client s
 	response := RbdReplicationImageStatus{}
 	args := []string{"mirror", "image", "status", resource, "--format", "json"}
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Warnf("failed image status operation on res(%s): %v", resource, err)
 		return RbdReplicationImageStatus{State: StateDisabledReplication}, nil
@@ -349,7 +350,7 @@ func configurePoolMirroring(pool string, mode types.RbdResourceType, localName s
 	// add --cluster and --id args
 	args = appendRemoteClusterArgs(args, remoteName, localName)
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return fmt.Errorf("failed to execute rbd command: %v", err)
@@ -372,7 +373,7 @@ func configureImageMirroring(req types.RbdReplicationRequest) error {
 		args = []string{"mirror", "image", "enable", fmt.Sprintf("%s/%s", pool, image), string(mode)}
 	}
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return fmt.Errorf("failed to configure rbd image feature: %v", err)
@@ -430,7 +431,7 @@ func listSnapshotSchedule(pool string, image string) ([]byte, error) {
 		args = append(args, image)
 	}
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return []byte(""), err
@@ -445,7 +446,7 @@ func listAllImagesInPool(pool string, localName string, remoteName string) []str
 	// add --cluster and --id args
 	args = appendRemoteClusterArgs(args, remoteName, localName)
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		return []string{}
 	}
@@ -483,7 +484,7 @@ func configureSnapshotSchedule(pool string, image string, schedule string, start
 		}
 	}
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return err
@@ -496,7 +497,7 @@ func configureSnapshotSchedule(pool string, image string, schedule string, start
 func createSnapshot(pool string, image string) error {
 	args := []string{"mirror", "image", "snapshot", fmt.Sprintf("%s/%s", pool, image)}
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return err
@@ -510,7 +511,7 @@ func configureImageFeatures(pool string, image string, op string, feature string
 	// op is enable or disable
 	args := []string{"feature", op, fmt.Sprintf("%s/%s", pool, image), feature}
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return fmt.Errorf("failed to configure rbd image feature: %v", err)
@@ -547,7 +548,7 @@ func flagImageForResync(poolName string, imageName string) error {
 		"mirror", "image", "resync", fmt.Sprintf("%s/%s", poolName, imageName),
 	}
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		return err
 	}
@@ -566,7 +567,7 @@ func peerBootstrapCreate(pool string, client string, cluster string) (string, er
 		args = appendRemoteClusterArgs(args, cluster, client)
 	}
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return "", fmt.Errorf("failed to bootstrap peer token: %v", err)
@@ -592,7 +593,7 @@ func peerBootstrapImport(pool string, client string, cluster string) error {
 		args = appendRemoteClusterArgs(args, cluster, client)
 	}
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return fmt.Errorf("failed to import peer bootstrap token: %v", err)
@@ -610,7 +611,7 @@ func peerRemove(pool string, peerId string, localName string, remoteName string)
 	// add --cluster and --id args
 	args = appendRemoteClusterArgs(args, remoteName, localName)
 
-	_, err := processExec.RunCommand("rbd", args...)
+	_, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		logger.Errorf("REPRBD: %s", err.Error())
 		return fmt.Errorf("failed to remove peer(%s) for pool(%s): %v", peerId, pool, err)
@@ -631,7 +632,7 @@ func promotePool(poolName string, isForce bool, remoteName string, localName str
 	// add --cluster and --id args
 	args = appendRemoteClusterArgs(args, remoteName, localName)
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		return fmt.Errorf("failed to promote pool(%s): %v", poolName, err)
 	}
@@ -648,7 +649,7 @@ func demotePool(poolName string, remoteName string, localName string) error {
 	// add --cluster and --id args
 	args = appendRemoteClusterArgs(args, remoteName, localName)
 
-	output, err := processExec.RunCommand("rbd", args...)
+	output, err := common.ProcessExec.RunCommand("rbd", args...)
 	if err != nil {
 		return fmt.Errorf("failed to promote pool(%s): %v", poolName, err)
 	}

--- a/microceph/ceph/rbd_mirror_test.go
+++ b/microceph/ceph/rbd_mirror_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"testing"
 
@@ -34,7 +35,7 @@ func (ks *RbdMirrorSuite) TestVerbosePoolStatus() {
 	// mocks and expectations
 	r.On("RunCommand", []interface{}{
 		"rbd", "mirror", "pool", "status", "pool", "--verbose", "--format", "json"}...).Return(string(output), nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Method call
 	resp, err := GetRbdMirrorVerbosePoolStatus("pool", "", "")
@@ -50,7 +51,7 @@ func (ks *RbdMirrorSuite) TestPoolStatus() {
 	// mocks and expectations
 	r.On("RunCommand", []interface{}{
 		"rbd", "mirror", "pool", "status", "pool", "--format", "json"}...).Return(string(output), nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Method call
 	resp, err := GetRbdMirrorPoolStatus("pool", "", "")
@@ -68,7 +69,7 @@ func (ks *RbdMirrorSuite) TestImageStatus() {
 	// mocks and expectations
 	r.On("RunCommand", []interface{}{
 		"rbd", "mirror", "image", "status", "pool/image_one", "--format", "json"}...).Return(string(output), nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Method call
 	resp, err := GetRbdMirrorImageStatus("pool", "image_one", "", "")
@@ -85,7 +86,7 @@ func (ks *RbdMirrorSuite) TestPoolInfo() {
 	// mocks and expectations
 	r.On("RunCommand", []interface{}{
 		"rbd", "mirror", "pool", "info", "pool", "--format", "json"}...).Return(string(output), nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Method call
 	resp, err := GetRbdMirrorPoolInfo("pool", "", "")
@@ -103,7 +104,7 @@ func (ks *RbdMirrorSuite) TestPromotePoolOnSecondary() {
 		"rbd", "mirror", "pool", "promote", "pool"}...).Return("", fmt.Errorf("%s", string(output))).Once()
 	r.On("RunCommand", []interface{}{
 		"rbd", "mirror", "pool", "promote", "pool", "--force"}...).Return("ok", nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Test stardard promotion.
 	err := handlePoolPromotion("pool", false)
@@ -127,7 +128,7 @@ func (ks *RbdMirrorSuite) TestDemotePoolOnSecondary() {
 		"rbd", "mirror", "image", "resync", "pool/image_one"}...).Return("ok", nil).Once()
 	r.On("RunCommand", []interface{}{
 		"rbd", "mirror", "image", "resync", "pool/image_two"}...).Return("ok", nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	// Test stardard promotion.
 	err := handlePoolDemotion("pool")

--- a/microceph/ceph/rgw_test.go
+++ b/microceph/ceph/rgw_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"context"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,7 +64,7 @@ func (s *rgwSuite) TestEnableRGW() {
 
 	addRGWEnableExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := EnableRGW(s.TestStateInterface, 8081, 443, "", "", []string{"10.1.1.1", "10.2.2.2"})
 
@@ -79,7 +80,7 @@ func (s *rgwSuite) TestEnableRGW() {
 func (s *rgwSuite) TestEnableRGWWithInvalidSSLCertificate() {
 	r := mocks.NewRunner(s.T())
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := EnableRGW(s.TestStateInterface, 80, 443, "invalid-certificate", validSSLPrivateKey, []string{"10.1.1.1", "10.2.2.2"})
 
@@ -95,7 +96,7 @@ func (s *rgwSuite) TestEnableRGWWithInvalidSSLCertificate() {
 func (s *rgwSuite) TestEnableRGWWithInvalidSSLPrivateKey() {
 	r := mocks.NewRunner(s.T())
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := EnableRGW(s.TestStateInterface, 80, 443, validSSLCertificate, "invalid-private-key", []string{"10.1.1.1", "10.2.2.2"})
 
@@ -113,7 +114,7 @@ func (s *rgwSuite) TestEnableRGWWithMissingSSLCertificate() {
 
 	addRGWEnableExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := EnableRGW(s.TestStateInterface, 0, 443, "", validSSLPrivateKey, []string{"10.1.1.1", "10.2.2.2"})
 
@@ -130,7 +131,7 @@ func (s *rgwSuite) TestEnableRGWWithMissingSSLPrivateKey() {
 
 	addRGWEnableExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := EnableRGW(s.TestStateInterface, 0, 443, validSSLCertificate, "", []string{"10.1.1.1", "10.2.2.2"})
 
@@ -147,7 +148,7 @@ func (s *rgwSuite) TestEnableRGWWithSSL() {
 
 	addRGWEnableExpectations(r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := EnableRGW(s.TestStateInterface, 8081, 443, validSSLCertificate, validSSLPrivateKey, []string{"10.1.1.1", "10.2.2.2"})
 
@@ -165,7 +166,7 @@ func (s *rgwSuite) TestDisableRGW() {
 
 	addStopRGWExpectations(s, r)
 
-	processExec = r
+	common.ProcessExec = r
 
 	err := DisableRGW(context.Background(), s.TestStateInterface)
 

--- a/microceph/ceph/run.go
+++ b/microceph/ceph/run.go
@@ -1,9 +1,11 @@
 package ceph
 
+import "github.com/canonical/microceph/microceph/common"
+
 func cephRun(args ...string) (string, error) {
-	return processExec.RunCommand("ceph", args...)
+	return common.ProcessExec.RunCommand("ceph", args...)
 }
 
 func radosRun(args ...string) (string, error) {
-	return processExec.RunCommand("rados", args...)
+	return common.ProcessExec.RunCommand("rados", args...)
 }

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -122,7 +122,7 @@ func getUpRgws() (common.Set, error) {
 
 func getMons() (common.Set, error) {
 	retval := common.Set{}
-	output, err := processExec.RunCommand("ceph", "mon", "dump", "-f", "json-pretty")
+	output, err := common.ProcessExec.RunCommand("ceph", "mon", "dump", "-f", "json-pretty")
 	if err != nil {
 		logger.Errorf("Failed fetching Mon dump: %v", err)
 		return nil, err
@@ -140,7 +140,7 @@ func getMons() (common.Set, error) {
 
 func getUpOsds() (common.Set, error) {
 	retval := common.Set{}
-	output, err := processExec.RunCommand("ceph", "osd", "dump", "-f", "json-pretty")
+	output, err := common.ProcessExec.RunCommand("ceph", "osd", "dump", "-f", "json-pretty")
 	if err != nil {
 		logger.Errorf("Failed fetching OSD dump: %v", err)
 		return nil, err

--- a/microceph/ceph/services_placement_test.go
+++ b/microceph/ceph/services_placement_test.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"context"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/tests"
@@ -84,7 +85,7 @@ func (s *servicesPlacementSuite) TestHospitalityCheckFailure() {
 	service := "rgw"
 
 	r := mocks.NewRunner(s.T())
-	processExec = r
+	common.ProcessExec = r
 	addSnapServiceActiveExpectations(r, service, "active", nil)
 
 	payload := types.EnableService{

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -3,6 +3,7 @@ package ceph
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,7 +80,7 @@ func (s *servicesSuite) TestRestartServiceWorkerSuccess() {
 	addMonDumpExpectations(r)
 	addOsdDumpExpectations(r)
 	addServiceRestartExpectations(r, ts)
-	processExec = r
+	common.ProcessExec = r
 
 	services := types.Services{
 		types.Service{Service: "mon", Location: "foohost"},

--- a/microceph/ceph/snap.go
+++ b/microceph/ceph/snap.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"strings"
 
 	"github.com/canonical/lxd/shared/logger"
@@ -14,7 +15,7 @@ func isIntfConnected(name string) bool {
 		name,
 	}
 
-	_, err := processExec.RunCommand("snapctl", args...)
+	_, err := common.ProcessExec.RunCommand("snapctl", args...)
 	if err != nil { // Non-zero return code when connection not present.
 		logger.Errorf("Failure: check is-connected %s: %v", name, err)
 		return false
@@ -35,7 +36,7 @@ func snapStart(service string, enable bool) error {
 		args = append(args, "--enable")
 	}
 
-	_, err := processExec.RunCommand("snapctl", args...)
+	_, err := common.ProcessExec.RunCommand("snapctl", args...)
 	if err != nil {
 		return err
 	}
@@ -54,7 +55,7 @@ func snapStop(service string, disable bool) error {
 		args = append(args, "--disable")
 	}
 
-	_, err := processExec.RunCommand("snapctl", args...)
+	_, err := common.ProcessExec.RunCommand("snapctl", args...)
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func snapRestart(service string, isReload bool) error {
 
 	args = append(args, fmt.Sprintf("microceph.%s", service))
 
-	_, err := processExec.RunCommand("snapctl", args...)
+	_, err := common.ProcessExec.RunCommand("snapctl", args...)
 	if err != nil {
 		return err
 	}
@@ -89,7 +90,7 @@ func snapCheckActive(service string) error {
 		fmt.Sprintf("microceph.%s", service),
 	}
 
-	out, err := processExec.RunCommand("snapctl", args...)
+	out, err := common.ProcessExec.RunCommand("snapctl", args...)
 	if err != nil {
 		return err
 	}

--- a/microceph/ceph/start.go
+++ b/microceph/ceph/start.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/canonical/microceph/microceph/common"
 	"reflect"
 	"strings"
 	"time"
@@ -26,7 +27,7 @@ type cephVersion struct {
 
 // getCurrentVersion extracts the version codename from the 'ceph -v' output
 func getCurrentVersion() (string, error) {
-	output, err := processExec.RunCommand("ceph", "-v")
+	output, err := common.ProcessExec.RunCommand("ceph", "-v")
 	if err != nil {
 		return "", fmt.Errorf("failed to get ceph version: %w", err)
 	}
@@ -49,7 +50,7 @@ func checkVersions() (bool, error) {
 	)
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		out, err := processExec.RunCommand("ceph", "versions")
+		out, err := common.ProcessExec.RunCommand("ceph", "versions")
 		if err != nil {
 			return false, fmt.Errorf("failed to get Ceph versions: %w", err)
 		}
@@ -83,7 +84,7 @@ func checkVersions() (bool, error) {
 }
 
 func osdReleaseRequired(version string) (bool, error) {
-	out, err := processExec.RunCommand("ceph", "osd", "dump", "-f", "json")
+	out, err := common.ProcessExec.RunCommand("ceph", "osd", "dump", "-f", "json")
 	if err != nil {
 		return false, fmt.Errorf("failed to get OSD dump: %w", err)
 	}
@@ -103,7 +104,7 @@ func osdReleaseRequired(version string) (bool, error) {
 }
 
 func updateOSDRelease(version string) error {
-	_, err := processExec.RunCommand("ceph", "osd", "require-osd-release",
+	_, err := common.ProcessExec.RunCommand("ceph", "osd", "require-osd-release",
 		version, "--yes-i-really-mean-it")
 	if err != nil {
 		return fmt.Errorf("failed to update OSD release version: %w", err)

--- a/microceph/ceph/start_test.go
+++ b/microceph/ceph/start_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"errors"
+	"github.com/canonical/microceph/microceph/common"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/mocks"
@@ -51,7 +52,7 @@ func (s *startSuite) TestStartOSDReleaseUpdate() {
 	r := mocks.NewRunner(s.T())
 
 	addExpected(r)
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.NoError(s.T(), err)
@@ -62,7 +63,7 @@ func (s *startSuite) TestInvalidVersionString() {
 	r := mocks.NewRunner(s.T())
 	// only expect the version command, others shouldnt be reached
 	r.On("RunCommand", "ceph", "-v").Return("invalid version", nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.Error(s.T(), err)
@@ -86,7 +87,7 @@ func (s *startSuite) TestMultipleVersionsPresent() {
 
 	r.On("RunCommand", "ceph", "-v").Return(version, nil).Once()
 	r.On("RunCommand", "ceph", "versions").Return(versionsJson, nil).Times(10)
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.NoError(s.T(), err)
@@ -107,7 +108,7 @@ func (s *startSuite) TestNoOSDVersions() {
 
 	r.On("RunCommand", "ceph", "-v").Return(version, nil).Once()
 	r.On("RunCommand", "ceph", "versions").Return(versionsJson, nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.NoError(s.T(), err) // no OSD versions, so no update required
@@ -133,7 +134,7 @@ func (s *startSuite) TestOSDReleaseUpToDate() {
 	r.On("RunCommand", "ceph", "-v").Return(version, nil).Once()
 	r.On("RunCommand", "ceph", "versions").Return(versionsJson, nil).Once()
 	r.On("RunCommand", "ceph", "osd", "dump", "-f", "json").Return(osdDump, nil).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.NoError(s.T(), err)
@@ -161,7 +162,7 @@ func (s *startSuite) TestOSDReleaseUpdateFails() {
 	r.On("RunCommand", "ceph", "osd", "dump", "-f", "json").Return(osdDump, nil).Once()
 	r.On("RunCommand", "ceph", "osd", "require-osd-release", "squid", "--yes-i-really-mean-it").
 		Return("", errors.New("update failed")).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.Error(s.T(), err)
@@ -172,7 +173,7 @@ func (s *startSuite) TestOSDReleaseUpdateFails() {
 func (s *startSuite) TestCephVersionCommandFails() {
 	r := mocks.NewRunner(s.T())
 	r.On("RunCommand", "ceph", "-v").Return("", errors.New("command failed")).Once()
-	processExec = r
+	common.ProcessExec = r
 
 	err := PostRefresh()
 	assert.Error(s.T(), err)

--- a/microceph/common/subprocess.go
+++ b/microceph/common/subprocess.go
@@ -1,4 +1,4 @@
-package ceph
+package common
 
 import (
 	"context"
@@ -26,4 +26,4 @@ func (c RunnerImpl) RunCommandContext(ctx context.Context, name string, arg ...s
 
 // Singleton runner: make this patch-able for testing purposes.
 // By default executes via shared.RunCommand()
-var processExec Runner = RunnerImpl{}
+var ProcessExec Runner = RunnerImpl{}


### PR DESCRIPTION
# Description

Refactor: move subprocess up to the common package which other packages rely on, make process runner var public

## Type of change

- Clean code (code refactor, test updates; does not introduce functional changes)

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
