### PR TITLE
ci: Add workflow for tagging stable commit

### DIFF
--- a/.github/workflows/tag-stable-commit.yml
+++ b/.github/workflows/tag-stable-commit.yml
@@ -5,31 +5,39 @@ name: Tag stable MicroCeph commit
 # Controls when the action will run. Workflow runs when there is a new stable channel
 # promoted on Snapcraft
 on:
-# Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch: null
-#  schedule:
-#    - cron: '0 0 * * MON,THU' # Runs biweekly on Tuesdays and Thursdays
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+  # Allow manual trigger from Actions UI
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * MON,THU' # Runs on Tuesdays and Thursdays at midnight UTC
+
 jobs:
   tag-stable-commit:
-   # The type of runner that the job will run on
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed for creating tags
     steps:
-     - name: Checkout repository
-       uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       # Install the MicroCeph snap
-     - name: Install MicroCeph snap
-       run: |
-        sudo snap install microceph
-    # Find the first name under "channels:" that includes "/stable:"
-    # and parse <code name>, <release version> and <commit ID>
-     - name: Extract channel information
-       id: snap
-       uses: actions/github-script@v7
-       with:
-         script: |
-           const { execSync } = require('child_process');
+      - name: Install MicroCeph snap
+        run: |
+          sudo snap install microceph
+
+      # Find the first name under "channels:" that includes "/stable:"
+      # and parse <code name>, <release version> and <commit ID>
+      - name: Extract channel information
+        id: snap
+        uses: actions/github-script@v7
+        with: 
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { execSync } = require('child_process');
             // Run `snap info microceph`
             const info = execSync('snap info microceph', { encoding: 'utf-8' });
             const lines = info.split('\n');
@@ -64,17 +72,17 @@ jobs:
             // Add minimum length requirement to validate output variables          
             if (!codeName || codeName.length < minCodeNameLength) {
               core.setFailed(`Invalid codeName: "${codeName}"`);
-                return;
-                }        
+              return;
+            }        
             if (!version || version.length < minVersionLength) {
               core.setFailed(`Invalid version: "${version}"`);
-                return;
-                }
+              return;
+            }
             if (!commit || commit.length < minCommitLength) {
               core.setFailed(`Invalid commit: "${commit}"`);
-                return;
-                }
-          
+              return;
+            }
+
             core.setOutput('codeName', codeName);
             core.setOutput('version', version);
             core.setOutput('commit', commit);
@@ -83,9 +91,11 @@ jobs:
             core.info(`commit=${commit}`);
 
       # Verify commit exists in the repo and print commit message first line
-     - name: Verify commit exists
-       uses: actions/github-script@v7
-       with: 
+      - name: Verify commit exists
+        id: verify
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const target = '${{ steps.snap.outputs.commit }}'.slice(0, 7);  // 7-char prefix
             core.info(`Looking for a commit starting with "${target}" ...`);
@@ -103,61 +113,63 @@ jobs:
               // Print first line of the commit message
               const firstLine = hit.commit.message.split('\n')[0];
               core.info(`Commit message first line: "${firstLine}"`);
+              core.setOutput('full_sha', hit.sha); // Output full SHA
             } else {
               core.setFailed(`No commit starting with "${target}" found in the repository`);
             }
-     # Create or update tag pointing to the verified commit
-       # If the tag doesn't exist, create it
-       # If the tag exists, but it points to a different commit, update it (move it forward)
-       # If it already exists but points to the correct commit, do nothing     
-     - name: Create or update stable tag for verified commit
-       uses: actions/github-script@v7
-       with:
-         script: |
-           const commitSha = '${{ steps.snap.outputs.commit }}';
-           const codeName = '${{ steps.snap.outputs.codeName }}';
-           const version = '${{ steps.snap.outputs.version }}';
-           const stableTag = `v${version}+${codeName}`;
-           core.info(`Proposed stable tag: ${stableTag}`);
 
-           // Get existing tags
-           const tags = await github.paginate(
-             github.rest.repos.listTags,
-               {
-                 owner: context.repo.owner,
-                 repo: context.repo.repo,
-                 per_page: 100
-               }
+      # Create or update tag pointing to the verified commit
+      # If the tag doesn't exist, create it
+      # If the tag exists, but it points to a different commit, update it (move it forward)
+      # If it already exists but points to the correct commit, do nothing     
+      - name: Create or update stable tag for verified commit
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commitSha = '${{ steps.verify.outputs.full_sha }}';
+            const codeName = '${{ steps.snap.outputs.codeName }}';
+            const version = '${{ steps.snap.outputs.version }}';
+            const stableTag = `v${version}+${codeName}`;
+            core.info(`Proposed stable tag: ${stableTag}`);
+
+            // Get existing tags
+            const tags = await github.paginate(
+              github.rest.repos.listTags,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              }
             );
 
-           const existingTag = tags.find(t => t.name === stableTag);
+            const existingTag = tags.find(t => t.name === stableTag);
 
-             if (existingTag) {
-               core.info(`Tag "${stableTag}" already exists.`);
-             if (existingTag.commit.sha === commitSha) {
-               core.info(`It already points to the correct commit (${commitSha}). Nothing to do.`);
-             return;
-           } else {
-             core.info(`Tag "${stableTag}" points to a different commit (${existingTag.commit.sha}). Updating to ${commitSha}...`);
-             await github.rest.git.updateRef({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               ref: `tags/${stableTag}`,
-               sha: commitSha,
-               force: true
-             });
-             core.info(`Tag "${stableTag}" updated to point to ${commitSha}.`);
-             return;
+            if (existingTag) {
+              core.info(`Tag "${stableTag}" already exists.`);
+              if (existingTag.commit.sha === commitSha) {
+                core.info(`It already points to the correct commit (${commitSha}). Nothing to do.`);
+                return;
+              } else {
+                core.info(`Tag "${stableTag}" points to a different commit (${existingTag.commit.sha}). Updating to ${commitSha}...`);
+                await github.rest.git.updateRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `tags/${stableTag}`,
+                  sha: commitSha,
+                  force: true
+                });
+                core.info(`Tag "${stableTag}" updated to point to ${commitSha}.`);
+                return;
+              }
             }
-           }
 
-           // Create tag if it doesn't exist
-           core.info(`Creating new tag "${stableTag}" pointing to commit ${commitSha}`);
-           await github.rest.git.createRef({
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             ref: `refs/tags/${stableTag}`,
-             sha: commitSha
-           });
-           core.info(`Tag "${stableTag}" created successfully.`);
-  
+            // Create tag if it doesn't exist
+            core.info(`Creating new tag "${stableTag}" pointing to commit ${commitSha}`);
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${stableTag}`,
+              sha: commitSha
+            });
+            core.info(`Tag "${stableTag}" created successfully.`);


### PR DESCRIPTION
# Description

When a MicroCeph snap revision is promoted to stable, the corresponding Git commit is tagged manually.This PR adds a GitHub Actions workflow to help us automate updating Git tags (which we also use for marking our doc versions - and hopefully for release notes using the GitHub release feature). The workflow uses the `github-script` action, and will:
1. Install the MicroCeph snap,
2. Parse the snap info output,
3. Get the latest stable channel,
4. Find its commit ID,
5. Go to the repo and find that commit hash,
6. and tagging it.

 The workflow will run on a regular cadence (twice a week).

## Type of change

Delete options that are not relevant.

- Clean code (code refactor, test updates; does not introduce functional changes)

## How has this been tested?

This workflow hasn't been tested. I am hoping to test it by triggering it manually first, before enabling the `schedule` event and cron expressions.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change