### PR TITLE
fix: Remove unnecessary references to client from command

### DIFF
--- a/microceph/cmd/microceph/enable_nfs.go
+++ b/microceph/cmd/microceph/enable_nfs.go
@@ -7,7 +7,6 @@ import (
 	"net"
 
 	"github.com/canonical/microcluster/v2/microcluster"
-	microclusterclient "github.com/canonical/microcluster/v2/client"
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/microceph/microceph/api/types"
@@ -23,7 +22,6 @@ type cmdEnableNFS struct {
 	flagBindPort     uint
 	flagV4MinVersion uint
 	flagTarget       string
-	client           *microclusterclient.Client
 }
 
 func (c *cmdEnableNFS) Command() *cobra.Command {


### PR DESCRIPTION
# Description
Cleans up unnecessary references for NFS

## Type of change

Delete options that are not relevant.
- Clean code (code refactor, test updates; does not introduce functional changes)

## How has this been tested?
Existing CI

## Contributor checklist
- [X] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change