### PR TITLE
doc: Fix RBD client cache docs and command reference

### DIFF
--- a/docs/how-to/rbd-client-cfg.rst
+++ b/docs/how-to/rbd-client-cfg.rst
@@ -1,114 +1,121 @@
-Configure RBD client cache in MicroCeph
-========================================
+===========
+``client``
+===========
 
-MicroCeph supports setting, resetting, and listing client configurations which are exported to ceph.conf and are used by tools like qemu directly for configuring rbd cache. Below are the supported client configurations.
+Manages MicroCeph clients
 
-.. list-table:: Supported Config Keys
-   :widths: 30 70
-   :header-rows: 1
+Usage:
 
-   * - Key
-     - Description
-   * - rbd_cache
-     - Enable caching for RADOS Block Device (RBD).
-   * - rbd_cache_size
-     - The RBD cache size in bytes.
-   * - rbd_cache_writethrough_until_flush
-     - The number of seconds dirty data is in the cache before writeback starts.
-   * - rbd_cache_max_dirty
-     - The dirty limit in bytes at which the cache triggers write-back. If 0, uses write-through caching.
-   * - rbd_cache_target_dirty
-     - The dirty target before the cache begins writing data to the data storage. Does not block writes to the cache.
+.. code-block:: none
 
-1. Supported config keys can be configured using the 'set' command:
+   microceph client [flags]
+   microceph client [command]
 
-  .. code-block:: shell
+Available commands:
 
-    $ sudo microceph client config set rbd_cache true
-    $ sudo microceph client config set rbd_cache false --target alpha
-    $ sudo microceph client config set rbd_cache_size 2048MiB --target beta
+.. code-block:: none
 
-  .. note::
+   config      Manage Ceph Client configs
 
-    Host level configuration changes can be made by passing the relevant hostname as the --target parameter.
+Global options:
 
-2. All the client configs can be queried using the 'list' command.
+.. code-block:: none
 
-  .. code-block:: shell
+   -d, --debug       Show all debug messages
+   -h, --help        Print help
+       --state-dir   Path to store state information
+   -v, --verbose     Show all information messages
+       --version     Print version number
 
-    $ sudo microceph cluster config list
-    +---+----------------+---------+----------+
-    | # |      KEY       |  VALUE  |   HOST   |
-    +---+----------------+---------+----------+
-    | 0 | rbd_cache      | true    | beta     |
-    +---+----------------+---------+----------+
-    | 1 | rbd_cache      | false   | alpha    |
-    +---+----------------+---------+----------+
-    | 2 | rbd_cache_size | 2048MiB | beta     |
-    +---+----------------+---------+----------+
+``config``
+----------
 
-  Similarly, all the client configs of a particular host can be queried using the --target parameter.
+Manages Ceph Client configs.
 
-  .. code-block:: shell
+Usage:
 
-    $ sudo microceph cluster config list --target beta
-    +---+----------------+---------+----------+
-    | # |      KEY       |  VALUE  |   HOST   |
-    +---+----------------+---------+----------+
-    | 0 | rbd_cache      | true    | beta     |
-    +---+----------------+---------+----------+
-    | 1 | rbd_cache_size | 2048MiB | beta     |
-    +---+----------------+---------+----------+
+.. code-block:: none
 
+   microceph client config [flags]
+   microceph client config [command]
 
-3. A particular config key can be queried for using the 'get' command:
+Available Commands:
 
-  .. code-block:: shell
+.. code-block:: none
 
-    $ sudo microceph cluster config list
-    +---+----------------+---------+----------+
-    | # |      KEY       |  VALUE  |   HOST   |
-    +---+----------------+---------+----------+
-    | 0 | rbd_cache      | true    | beta     |
-    +---+----------------+---------+----------+
-    | 1 | rbd_cache      | false   | alpha    |
-    +---+----------------+---------+----------+
+   get         Fetches specified Ceph Client config
+   list        Lists all configured Ceph Client configs
+   reset       Removes specified Ceph Client configs
+   set         Sets specified Ceph Client config
 
-  Similarly, --target parameter can be used with get command to query for a particular config key/hostname pair.
+``config set``
+--------------
 
-  .. code-block:: shell
+Sets specified Ceph Client config
 
-    $ sudo microceph cluster config rbd_cache --target alpha
-    +---+----------------+---------+----------+
-    | # |      KEY       |  VALUE  |   HOST   |
-    +---+----------------+---------+----------+
-    | 0 | rbd_cache      | false   | alpha    |
-    +---+----------------+---------+----------+
+Usage:
 
+.. code-block:: none
 
-4. Resetting a config key (i.e. removing the configured key/value) can performed using the 'reset' command:
+   microceph client config set <Key> <Value> [flags]
 
-  .. code-block:: shell
+Flags:
 
-   $ sudo microceph cluster config reset rbd_cache_size
-   $ sudo microceph cluster config list
-    +---+----------------+---------+----------+
-    | # |      KEY       |  VALUE  |   HOST   |
-    +---+----------------+---------+----------+
-    | 0 | rbd_cache      | true    | beta     |
-    +---+----------------+---------+----------+
-    | 1 | rbd_cache      | false   | alpha    |
-    +---+----------------+---------+----------+
+.. code-block:: none
 
-  This operation can also be performed for a specific host as follows:
+   --target string   Specify a microceph node the provided config should be applied to. (default "*")
+   --wait            Wait for configs to propagate across the cluster. (default true)
 
-  .. code-block:: shell
+``config get``
+--------------
 
-   $ sudo microceph cluster config reset rbd_cache --target alpha
-   $ sudo microceph cluster config list
-    +---+----------------+---------+----------+
-    | # |      KEY       |  VALUE  |   HOST   |
-    +---+----------------+---------+----------+
-    | 0 | rbd_cache      | true    | beta     |
-    +---+----------------+---------+----------+
+Fetches specified Ceph Client config
+
+Usage:
+
+.. code-block:: none
+
+   microceph client config get <key> [flags]
+
+Flags:
+
+.. code-block:: none
+
+   --target string   Specify a microceph node the provided config should be applied to. (default "*")
+
+``config list``
+---------------
+
+Lists all configured Ceph Client configs
+
+Usage:
+
+.. code-block:: none
+
+   microceph client config list [flags]
+
+Flags:
+
+.. code-block:: none
+
+   --target string   Specify a microceph node the provided config should be applied to. (default "*")
+
+``config reset``
+----------------
+
+Removes specified Ceph Client configs
+
+Usage:
+
+.. code-block:: none
+
+   microceph client config reset <key> [flags]
+
+Flags:
+
+.. code-block:: none
+
+   --target string          Specify a microceph node the provided config should be applied to. (default "*")
+   --wait                   Wait for required ceph services to restart post config reset. (default true)
+   --yes-i-really-mean-it   Force microceph to reset all client config records for given key.
 

--- a/docs/reference/commands/client.rst
+++ b/docs/reference/commands/client.rst
@@ -30,14 +30,14 @@ Global options:
 ``config``
 ----------
 
-Manages Ceph Cluster configs.
+Manages Ceph Client configs.
 
 Usage:
 
 .. code-block:: none
 
-   microceph cluster config [flags]
-   microceph cluster config [command]
+   microceph client config [flags]
+   microceph client config [command]
 
 Available Commands:
 


### PR DESCRIPTION
# Description

Clarify that RBD client cache settings are client-level and should be listed with `microceph client config list`, not `microceph cluster config list`.

- Update `docs/how-to/rbd-client-cfg.rst` to consistently document `microceph client config {set|get|list|reset}` usage, flags, and global options. Remove outdated examples that used `cluster config` for client settings.
- Fix `docs/reference/commands/client.rst` to reference `client` (not `cluster`) and correct usage examples.

Motivation/context:
- Users following the how-to were checking `cluster config list` and not seeing their RBD client cache config, causing confusion. This aligns the how-to and reference with the CLI and avoids mixed “cluster vs client” terminology.
- Related issue: https://github.com/canonical/microceph/issues/592

Dependencies: None

Fixes #592

## Type of change

- [x] Documentation update (change to documentation only)

## How has this been tested?

Docs-only change.

- Built docs locally; build succeeded with no errors:
  ```bash
  make -C docs html
  ```
- Optionally verified CLI help output matches the docs:
  ```bash
  microceph client --help
  microceph client config --help
  microceph client config list --help
  ```

## Contributor checklist

- [x] self-reviewed the changes in this PR
- [x] checked and updated relevant documentation
- [x] release notes: N/A (docs-only, no functional change)
- [x] tests: N/A (docs-only)