### PR TITLE
feat: expose useful tools

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -187,6 +187,17 @@ apps:
     command: commands/rados
     plugs:
       - network
+  ceph-bluestore-tool:
+    command: commands/ceph-bluestore-tool
+    plugs:
+      - mount-observe
+      - block-devices
+      - hardware-observe
+  ceph-authtool:
+    command: commands/ceph-authtool
+    plugs:
+      - home
+
 
 parts:
   microceph-orch:

--- a/snapcraft/commands/ceph-authtool
+++ b/snapcraft/commands/ceph-authtool
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "${SNAP}/bin/ceph-authtool" "$@"

--- a/snapcraft/commands/ceph-bluestore-tool
+++ b/snapcraft/commands/ceph-bluestore-tool
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "${SNAP}/bin/ceph-bluestore-tool" "$@"


### PR DESCRIPTION
# Description

Expose the ceph-bluestore-tool for manipulating disk devices and the ceph-authtool for keyring files

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Manual testing, as we're only exposing existing upstream tools

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change