### PR TITLE
docs: Create redirect for renamed file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -204,7 +204,7 @@ else:
 
 redirects = {
     # The FDE topic was split to a how-to and explanation; explanation topic was renamed
-    'explanation/security/full-disk-encryption": "../../about-fde',
+    'explanation/security/full-disk-encryption': '../../about-fde',
 }
 
 ###########################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -204,7 +204,7 @@ else:
 
 redirects = {
     # The FDE topic was split to a how-to and explanation; explanation topic was renamed
-    'explanation/security/full-disk-encryption': '../../about-fde',
+    'explanation/security/full-disk-encryption': '../../security/about-fde',
 }
 
 ###########################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,8 +202,10 @@ else:
 # NOTE: If undefined, set to None, or empty,
 #       the sphinx_reredirects extension will be disabled.
 
-redirects = {}
-
+redirects = {
+    # The FDE topic was split to a how-to and explanation; explanation topic was renamed
+    'explanation/security/full-disk-encryption": "../../about-fde',
+}
 
 ###########################
 # Link checker exceptions #


### PR DESCRIPTION
# Description

We recently renamed `explanation/security/full-disk-encryption` to `../../about-fde`, and it caused links from MicroCloud to the original page to break. 
This PR creates a redirect so that links to the page from other places, e.g. Microcloud, LXD, etc., don't continue to break. [Microcloud have updated the links](https://github.com/canonical/microcloud/pull/1000) on their end, but it would be helpful for the future, and also for users who might have bookmarked the page.


## Type of change

Delete options that are not relevant.

- Documentation update (change to documentation only)

## How has this been tested?

> [!NOTE]
> All functional changes should accompany corresponding tests (unit tests, functional tests, etc.).

Please describe the addition/modification of tests done to verify this change. Also list any
relevant details for your test configuration.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change