### PR TITLE
Replaced :doc: with :ref: target for 'Configure cluster network' how-to

### DIFF
--- a/docs/explanation/cluster-configurations.rst
+++ b/docs/explanation/cluster-configurations.rst
@@ -1,3 +1,5 @@
+.. _explanation-cluster-configurations:
+
 ==============================
 Cluster network configurations
 ==============================

--- a/docs/how-to/configure-network-keys.rst
+++ b/docs/how-to/configure-network-keys.rst
@@ -53,5 +53,5 @@ The MicroCeph cluster configuration CLI supports setting, getting, resetting and
    | # | KEY | VALUE |
    +---+-----+-------+
 
-For more explanations and implementation details refer to :doc:`explanation <../explanation/cluster-configurations>`
+For more explanations and implementation details refer to :ref:`explanation-cluster-configurations`.
 


### PR DESCRIPTION
# Description
Replaces the :doc: target in the [Configure cluster network](https://canonical-microceph.readthedocs-hosted.com/latest/how-to/configure-network-keys/) how-to with the rST :ref: role. 

Partially fixes issue #605
Fixes the following issue from the Open Documentation Academy:  https://github.com/canonical/open-documentation-academy/issues/276

## Type of change

- Documentation update (change to documentation only)

## How has this been tested?

I have built the docs locally to make sure it works.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change