### PR TITLE
Added format flag to cluster list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -872,6 +872,18 @@ jobs:
       - name: Exercise RGW
         run: ~/actionutils.sh testrgw
 
+      - name: Test Cluster List
+        run: |
+           set -uex
+           if ! sudo microceph cluster list | grep -q $HOSTNAME; then
+               echo "Failed: cluster list does not include $HOSTNAME"
+               exit 1
+           fi
+           if ! sudo microceph cluster list -f json | jq '.[]["name"]' | grep -q $HOSTNAME; then
+               echo "Failed: cluster list is improper json"
+               exit 1
+           fi
+
       - name: Bombard MicroCeph with cluster configs
         run: ~/actionutils.sh bombard_rgw_configs
 

--- a/microceph/cmd/microceph/cluster_list.go
+++ b/microceph/cmd/microceph/cluster_list.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/canonical/lxd/shared"
 	lxdCmd "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/lxd/shared/i18n"
 	"github.com/canonical/microcluster/v2/microcluster"
 	"github.com/spf13/cobra"
 )
 
 type cmdClusterList struct {
-	common  *CmdControl
-	cluster *cmdCluster
+	common     *CmdControl
+	cluster    *cmdCluster
+	flagFormat string
 }
 
 func (c *cmdClusterList) Command() *cobra.Command {
@@ -21,6 +23,14 @@ func (c *cmdClusterList) Command() *cobra.Command {
 		Short: "List servers in the cluster",
 		RunE:  c.Run,
 	}
+
+	cmd.Flags().StringVarP(
+		&c.flagFormat,
+		"format",
+		"f",
+		lxdCmd.TableFormatTable,
+		i18n.G("Format (csv|json|table|yaml|compact)")+"``",
+	)
 
 	return cmd
 }
@@ -54,5 +64,5 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 	header := []string{"NAME", "ADDRESS", "ROLE", "FINGERPRINT", "STATUS"}
 	sort.Sort(lxdCmd.SortColumnsNaturally(data))
 
-	return lxdCmd.RenderTable(lxdCmd.TableFormatTable, header, data, clusterMembers)
+	return lxdCmd.RenderTable(c.flagFormat, header, data, clusterMembers)
 }


### PR DESCRIPTION
Uses existing lxdCmd RenderTable options to allow other formatting options while keeping "table" as the default. This will be useful for machine readability of cluster list through formats such as json, allowing easier integration of this command within larger automated workflows.
