### PR TITLE
fix: Add content attributes for content plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,12 +20,14 @@ plugs:
 slots:
   ceph-logs:
     interface: content
+    content: logs
     source:
       read:
         - "$SNAP_COMMON/logs"
 
   ceph-conf:
     interface: content
+    content: ceph-conf
     source:
       read:
         - "$SNAP_DATA/conf"


### PR DESCRIPTION
Adds missing content attributes to the content interface to enable otel-collector connection.

```
ubuntu@test:~$ sudo snap connect opentelemetry-collector:logs microceph:ceph-logs
error: cannot perform the following tasks:
- Connect opentelemetry-collector:logs to microceph:ceph-logs (connection not allowed by slot rule of interface "content")
ubuntu@test:~$ sudo snap refresh microceph --channel latest/edge/test
microceph (edge/test) 19.2.1+snapcd512a17d5 from Canonical✓ refreshed
ubuntu@test:~$ sudo snap connect opentelemetry-collector:logs microceph:ceph-logs
ubuntu@test:~$
```