### PR TITLE
Clarify RGW and RADOS terminology in tutorial

### DIFF
--- a/docs/tutorial/get-started.rst
+++ b/docs/tutorial/get-started.rst
@@ -15,6 +15,9 @@ As we progress, you will also interact with your cluster by checking its health,
 
 By the end of this tutorial, after successfully using MicroCeph to store an image, you will have a foundational understanding of how MicroCeph works, and be ready to explore more advanced use cases.
 
+.. note::
+    RGW stands for RADOS GateWay, while RADOS stands for Reliable Autonomic Distributed Object Store (Ceph's core storage layer)
+
 What you'll need
 ----------------
 


### PR DESCRIPTION
Added a note explaining RGW and RADOS terms.

Since this tutorial can take a new user to having a test installation of MicroCeph, it would help knowing what RGW stands for, as the acronym is introduced. Whoever came up with an acronym partly made of another acronym is responsible for the fact that RADOS has to be explained too, consequently. 