### PR TITLE
fix: Resolve loop device unexpected behaviour

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -89,8 +89,14 @@ sudo snap install --dangerous microceph_*.snap
 # Locally built snaps do no auto-connect the available plugs on install, they can be connected manually using;
 sudo snap connect microceph:block-devices
 sudo snap connect microceph:hardware-observe
+sudo snap connect microceph:mount-observe
+sudo snap connect microceph:load-rbd
+sudo snap connect microceph:microceph-support
+sudo snap connect microceph:network-bind
+sudo snap connect microceph:process-control
 sudo snap connect microceph:dm-crypt
 sudo snap restart microceph.daemon
+
 ```
 
 ## 👍 Unit-Testing
@@ -102,6 +108,7 @@ The MicroCeph [Makefile](/microceph/Makefile) has targets for running unit tests
 sudo apt install gcc make shellcheck
 
 # Add libdqlite-dev, required for building microceph
+# you may need a specific version such as libdqlite1.17-dev
 sudo add-apt-repository ppa:dqlite/dev -y
 sudo apt install -y libdqlite-dev
 

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -944,6 +944,11 @@ func (s *osdSuite) TestValidateAddOSDArgs() {
 	err := osdmgr.validateAddOSDArgs(data, nil, nil)
 	assert.NoError(s.T(), err)
 
+	// Test valid loopback
+	loopDataValid := types.DiskParameter{Path: "loop,4G,3"}
+	err = osdmgr.validateAddOSDArgs(loopDataValid, nil, nil)
+	assert.NoError(s.T(), err)
+
 	// Test loopback with WAL, should fail as we req. a real block device
 	loopData := types.DiskParameter{LoopSize: 1024}
 	wal := &types.DiskParameter{Path: "/dev/wal"}
@@ -956,6 +961,12 @@ func (s *osdSuite) TestValidateAddOSDArgs() {
 	err = osdmgr.validateAddOSDArgs(loopData, nil, db)
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "loopback and WAL/DB are mutually exclusive")
+
+	// Test loopback with encryption (should fail)
+	loopDataInvalid := types.DiskParameter{Path: "loop,4G,3", Encrypt: true}
+	err = osdmgr.validateAddOSDArgs(loopDataInvalid, nil, nil)
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "encryption is not supported on loop devices")
 }
 
 // TestIsPristineDisk tests pristine disk checking
@@ -986,4 +997,3 @@ func (s *osdSuite) TestIsPristineDisk() {
 	assert.False(s.T(), isPristine)
 	assert.Contains(s.T(), err.Error(), "permission denied")
 }
-

--- a/microceph/cmd/microceph/disk_add.go
+++ b/microceph/cmd/microceph/disk_add.go
@@ -119,18 +119,16 @@ func (c *cmdDiskAdd) Run(cmd *cobra.Command, args []string) error {
 		// Pass space separated params as disk paths.
 		req.Path = args
 
-		if !strings.HasPrefix(req.Path[0], constants.LoopSpecId) {
-			if c.walDevice != "" {
-				req.WALDev = &c.walDevice
-				req.WALWipe = c.walWipe
-				req.WALEncrypt = c.walEncrypt
-			}
+		if c.walDevice != "" {
+			req.WALDev = &c.walDevice
+			req.WALWipe = c.walWipe
+			req.WALEncrypt = c.walEncrypt
+		}
 
-			if c.dbDevice != "" {
-				req.DBDev = &c.dbDevice
-				req.DBWipe = c.dbWipe
-				req.DBEncrypt = c.dbEncrypt
-			}
+		if c.dbDevice != "" {
+			req.DBDev = &c.dbDevice
+			req.DBWipe = c.dbWipe
+			req.DBEncrypt = c.dbEncrypt
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes #674

Loop devices can exhibit unexpected behavior where they are passed encrypt/wal/db flags but it does nothing. FDE/WAL/DB is intended for production usage, so we do not support it on loop devices, but the user experience should be better in case they are trying to test encryption on loop devices and wondering why it's not working.

Fix silent failures when adding loop-backed OSDs:
  - Error on --encrypt with loop devices instead of silently ignoring it
  - Fix missing encryptDevice error handling (err was not assigned)
  - Apply validateAddOSDArgs to single-disk bulk path which previously skipped validation
  - Consolidate loop device detection into isLoopDevice helper
  - Pass WAL/DB through to add disk so we can validate and not ignore WAL/DB
  - Amend old docs

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Clean code (code refactor, test updates; does not introduce functional changes)

## How has this been tested?

* Unit tests adjusted to test WAL/DB/encrypt

Manual test commands:

    sudo microceph cluster bootstrap

    # Should error: encryption on loop device
    sudo microceph disk add loop,4G,3 --encrypt

Validation Error found
Error: encryption is not supported on loop devices

    # Should error: loop device with WAL
    sudo microceph disk add loop,4G,3 --wal-device /dev/sdx

Validation Error found
Error: WAL/DB is not supported on loop devices

    # Should error: loop device with DB
    sudo microceph disk add loop,4G,3 --db-device /dev/sdx

Validation Error found
Error: WAL/DB is not supported on loop devices

    # Should succeed: loop device without encrypt/WAL/DB
    sudo microceph disk add loop,1G,3

```
+-----------+---------+
|   PATH    | STATUS  |
+-----------+---------+
| loop,1G,3 | Success |
+-----------+---------+
```

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change