### PR TITLE
fix: Resolve no disks present add all error

### DIFF
--- a/microceph/api/disks.go
+++ b/microceph/api/disks.go
@@ -172,14 +172,20 @@ func parseAndPatchDiskPostParams(rb io.ReadCloser) (types.DisksPost, error) {
 	logger.Debugf("CmdDiskPost Req Body: %v", buf)
 
 	diskPath := gjson.Get(buf, "path")
-	if !diskPath.IsArray() {
+	if diskPath.IsArray() {
+		// use unpatched buffer if client is using Batch Disk params.
+		patchedBody = buf
+	} else if diskPath.Exists() && diskPath.String() != "" {
 		patchedBody, err = sjson.Set(buf, "path", []string{diskPath.String()})
 		if err != nil {
 			return types.DisksPost{}, err
 		}
 	} else {
-		// use unpatched buffer if client is using Batch Disk params.
-		patchedBody = buf
+		// Empty or nonexistent path, return empty
+		patchedBody, err = sjson.Set(buf, "path", []string{})
+		if err != nil {
+			return types.DisksPost{}, err
+		}
 	}
 
 	logger.Debugf("CmdDiskPost Patched Body: %v", patchedBody)

--- a/microceph/api/disks_test.go
+++ b/microceph/api/disks_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAndPatchDiskPostParams(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		expectedPaths []string
+		description   string
+	}{
+		{
+			name:          "legacy single string path",
+			body:          `{"path":"/dev/sdb","wipe":false,"encrypt":false}`,
+			expectedPaths: []string{"/dev/sdb"},
+			description:   "Legacy clients send path as a single string; should be wrapped into an array",
+		},
+		{
+			name:          "current array of paths",
+			body:          `{"path":["/dev/sdb","/dev/sdc"],"wipe":false,"encrypt":false}`,
+			expectedPaths: []string{"/dev/sdb", "/dev/sdc"},
+			description:   "Current clients send path as an array; should be preserved as-is",
+		},
+		{
+			name:          "current single element array",
+			body:          `{"path":["/dev/sdb"],"wipe":false,"encrypt":false}`,
+			expectedPaths: []string{"/dev/sdb"},
+			description:   "Current clients with a single disk send a one-element array",
+		},
+		{
+			name:          "empty array (no available disks)",
+			body:          `{"path":[],"wipe":false,"encrypt":false}`,
+			expectedPaths: []string{},
+			description:   "Empty array from --all-available with no free disks should stay empty",
+		},
+		{
+			name:          "null path field",
+			body:          `{"path":null,"wipe":false,"encrypt":false}`,
+			expectedPaths: []string{},
+			description:   "Null path should result in empty path slice, not [\"\"]",
+		},
+		{
+			name:          "missing path field",
+			body:          `{"wipe":false,"encrypt":false}`,
+			expectedPaths: []string{},
+			description:   "Missing path should result in empty path slice, not [\"\"]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := io.NopCloser(strings.NewReader(tt.body))
+			result, err := parseAndPatchDiskPostParams(reader)
+			require.NoError(t, err, tt.description)
+
+			assert.Equal(t, tt.expectedPaths, result.Path, tt.description)
+		})
+	}
+}

--- a/microceph/cmd/microceph/disk_add.go
+++ b/microceph/cmd/microceph/disk_add.go
@@ -111,6 +111,11 @@ func (c *cmdDiskAdd) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		if len(disks) == 0 {
+			fmt.Println("No available disks found on this system.")
+			return nil
+		}
+
 		// Prepare Batch arguments
 		for _, disk := range disks {
 			req.Path = append(req.Path, disk.Path)


### PR DESCRIPTION
# Description

When a user tries to add all disks and there are none present, print a nice message instead of erroring out with a confusing message.

Change the underlying code that does parsing to parse "" or nil into an empty array instead of an array element with an empty string.

Add appropriate tests to confirm the expected behavior.

Fixes #639

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Added a unit test that is fed into the parser, the parser should behave accordingly if it is past no disks, or empty or nil disks. 

Confirm it returns the expected empty array when there are no disks instead of [""]

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change