### PR TITLE
ci: cache snap artifact

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,15 @@ jobs:
           sudo snap install snapcraft --classic
           snap list
 
+      - name: Cache snap artifact
+        id: snap-cache
+        uses: actions/cache@v4
+        with:
+          path: "*.snap"
+          key: snap-${{ hashFiles('snap/**', 'microceph/**', 'microceph-orch/**', 'snapcraft/**', 'patches/**') }}
+
       - name: Build snaps
+        if: steps.snap-cache.outputs.cache-hit != 'true'
         run: snapcraft
 
       - name: Upload snap artifact


### PR DESCRIPTION
# Description

Skip the snapcraft build on CI reruns by caching the built snap if nothing requiring rebuild canged.

Occasionally we rerun CI due to a integration test failure that is just from a flaky test. This change caches the snap that is built for only that existing run leading to about 5 minutes in time being saved on CI re-run. This also avoids lengthy rebuilds on only integration test changes.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Rebuild in CI, uses cached snap.

See example cached build:

https://github.com/johnramsden/microceph/actions/runs/23564743255/job/68613375676

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change