### PR TITLE
fix: auto-detect joiner address from join token peers

### DIFF
--- a/microceph/cmd/microceph/cluster_join.go
+++ b/microceph/cmd/microceph/cluster_join.go
@@ -50,14 +50,26 @@ func (c *cmdClusterJoin) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to retrieve system hostname: %w", err)
 	}
 
+	token := args[0]
+
 	address := c.flagMicroCephIp
 	if address == "" {
-		// Get system address for microcluster join.
-		address = util.NetworkInterfaceAddress()
+		// Pick a local address on the same subnet as a cluster peer,
+		// rather than trusting the first global unicast address on the
+		// host (canonical/microceph#476).
+		var peers []string
+		peers, err = common.JoinTokenPeers(token)
+		if err != nil {
+			return fmt.Errorf("invalid join token: %w", err)
+		}
+
+		address, err = common.Network.FindIpForPeers(peers)
+		if err != nil {
+			return fmt.Errorf("could not auto-detect a local address reachable from cluster peers %v: %w. Pass --microceph-ip explicitly", peers, err)
+		}
 	}
 	address = util.CanonicalNetworkAddress(address, constants.BootstrapPortConst)
 
-	token := args[0]
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 

--- a/microceph/common/join.go
+++ b/microceph/common/join.go
@@ -2,8 +2,33 @@
 package common
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
 	"github.com/canonical/microceph/microceph/logger"
 )
+
+// JoinTokenPeers returns the cluster member addresses embedded in a
+// microcluster join token (base64-encoded JSON).
+func JoinTokenPeers(token string) ([]string, error) {
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return nil, fmt.Errorf("decode token: %w", err)
+	}
+
+	var payload struct {
+		JoinAddresses []string `json:"join_addresses"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("parse token: %w", err)
+	}
+
+	if len(payload.JoinAddresses) == 0 {
+		return nil, fmt.Errorf("token contains no join addresses")
+	}
+	return payload.JoinAddresses, nil
+}
 
 // JoinConfig holds all additional parameters that could be provided to the join API/CLI command.
 type JoinConfig struct {

--- a/microceph/common/join_test.go
+++ b/microceph/common/join_test.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type JoinSuite struct {
+	suite.Suite
+}
+
+func TestJoinSuite(t *testing.T) {
+	suite.Run(t, new(JoinSuite))
+}
+
+// makeToken builds a base64-encoded join-token blob with the given addresses.
+func makeToken(joinAddrsJSON string) string {
+	body := `{"secret":"s","fingerprint":"f","join_addresses":` + joinAddrsJSON + `}`
+	return base64.StdEncoding.EncodeToString([]byte(body))
+}
+
+func (s *JoinSuite) TestJoinTokenPeers_IPv4() {
+	tok := makeToken(`["192.168.1.10:7443","192.168.1.11:7443"]`)
+
+	peers, err := JoinTokenPeers(tok)
+	s.Require().NoError(err)
+	s.Equal([]string{"192.168.1.10:7443", "192.168.1.11:7443"}, peers)
+}
+
+func (s *JoinSuite) TestJoinTokenPeers_IPv6() {
+	tok := makeToken(`["[2001:db8::10]:7443"]`)
+
+	peers, err := JoinTokenPeers(tok)
+	s.Require().NoError(err)
+	s.Equal([]string{"[2001:db8::10]:7443"}, peers)
+}
+
+func (s *JoinSuite) TestJoinTokenPeers_InvalidBase64() {
+	_, err := JoinTokenPeers("!!!not-base64!!!")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "decode token")
+}
+
+func (s *JoinSuite) TestJoinTokenPeers_InvalidJSON() {
+	tok := base64.StdEncoding.EncodeToString([]byte("{not json"))
+
+	_, err := JoinTokenPeers(tok)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "parse token")
+}
+
+func (s *JoinSuite) TestJoinTokenPeers_EmptyAddresses() {
+	tok := makeToken(`[]`)
+
+	_, err := JoinTokenPeers(tok)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no join addresses")
+}
+
+func (s *JoinSuite) TestJoinTokenPeers_MissingField() {
+	tok := base64.StdEncoding.EncodeToString([]byte(`{"secret":"s"}`))
+
+	_, err := JoinTokenPeers(tok)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no join addresses")
+}

--- a/microceph/common/network.go
+++ b/microceph/common/network.go
@@ -12,85 +12,88 @@ type NetworkIntf interface {
 	FindIpOnSubnet(subnet string) (string, error)
 	FindNetworkAddress(address string) (string, error)
 	IsIpOnSubnet(address string, subnet string) bool
+	FindIpForPeers(peers []string) (string, error)
 }
 
-type networkImpl struct{}
+// cidrLister returns the host's interface addresses. Injectable for tests.
+type cidrLister func() ([]*net.IPNet, error)
 
-// FindIpOnSubnet scans the host's network interfaces to check if an IP is available
-// for the provided subnet. It returns the FIRST found IP address or an empty string
-// in case of errors.
-func (nwi networkImpl) FindIpOnSubnet(subnet string) (string, error) {
+// hostCIDRs is the production cidrLister, backed by net.Interfaces.
+func hostCIDRs() ([]*net.IPNet, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	var cidrs []*net.IPNet
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			logger.Warnf("error fetching addresses for interface %s: %v", iface.Name, err)
+			continue
+		}
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			cidrs = append(cidrs, ipNet)
+		}
+	}
+	return cidrs, nil
+}
+
+type networkImpl struct {
+	lister cidrLister
+}
+
+// FindIpOnSubnet returns the first local interface address that lies within
+// the given CIDR.
+func (nwi *networkImpl) FindIpOnSubnet(subnet string) (string, error) {
 	subnet = strings.TrimSpace(subnet)
 	_, sn, err := net.ParseCIDR(subnet)
 	if err != nil {
 		return "", err
 	}
 
-	ifaces, err := net.Interfaces()
+	cidrs, err := nwi.lister()
 	if err != nil {
 		return "", err
 	}
 
-	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			logger.Warnf("error fetching network interfaces: %v", err)
+	for _, ipNet := range cidrs {
+		if !ipNet.IP.IsGlobalUnicast() {
+			continue
 		}
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
-			}
-
-			if !ipNet.IP.IsGlobalUnicast() {
-				continue
-			}
-
-			if sn.Contains(ipNet.IP) {
-				return ipNet.IP.String(), nil
-			}
+		if sn.Contains(ipNet.IP) {
+			return ipNet.IP.String(), nil
 		}
 	}
 	return "", fmt.Errorf("no IP belongs to provided subnet %s", subnet)
 }
 
-// FindNetworkAddress locates the provided IP address on host's network interfaces.
-// It returns the containing subnet address on success or an empty string on failure.
-func (nwi networkImpl) FindNetworkAddress(address string) (string, error) {
+// FindNetworkAddress returns the local CIDR that owns the given IP.
+func (nwi *networkImpl) FindNetworkAddress(address string) (string, error) {
 	nw := []string{}
 	address = strings.TrimSpace(address)
 
-	// Parse provided address.
 	monIP := net.ParseIP(address)
 	if monIP == nil {
 		return "", fmt.Errorf("provided address %s is invalid", address)
 	}
 
-	ifaces, err := net.Interfaces()
+	cidrs, err := nwi.lister()
 	if err != nil {
 		return "", err
 	}
 
-	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			logger.Warnf("error fetching network interfaces: %v", err)
+	for _, ipNet := range cidrs {
+		if !ipNet.IP.IsGlobalUnicast() {
+			continue
 		}
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
-			}
-
-			if !ipNet.IP.IsGlobalUnicast() {
-				continue
-			}
-
-			// record for reporting
-			nw = append(nw, addr.String())
-			if ipNet.IP.Equal(monIP) {
-				return addr.String(), nil
-			}
+		nw = append(nw, ipNet.String())
+		if ipNet.IP.Equal(monIP) {
+			return ipNet.String(), nil
 		}
 	}
 
@@ -98,7 +101,7 @@ func (nwi networkImpl) FindNetworkAddress(address string) (string, error) {
 }
 
 // IsIpOnSubnet checks if the provided ip address is on the provided subnet.
-func (nwi networkImpl) IsIpOnSubnet(address string, subnet string) bool {
+func (nwi *networkImpl) IsIpOnSubnet(address string, subnet string) bool {
 	address = strings.TrimSpace(address)
 	subnet = strings.TrimSpace(subnet)
 
@@ -115,4 +118,57 @@ func (nwi networkImpl) IsIpOnSubnet(address string, subnet string) bool {
 	return sn.Contains(ip)
 }
 
-var Network NetworkIntf = networkImpl{}
+// FindIpForPeers returns the first local interface address whose subnet
+// contains any of the supplied peers. Each peer may be a bare IP or an
+// "ip:port" / "[ipv6]:port" pair (the form carried in a join token).
+func (nwi *networkImpl) FindIpForPeers(peers []string) (string, error) {
+	if len(peers) == 0 {
+		return "", fmt.Errorf("no peer addresses supplied")
+	}
+
+	peerIPs := make([]net.IP, 0, len(peers))
+	for _, peer := range peers {
+		ip, err := parsePeerIP(peer)
+		if err != nil {
+			return "", fmt.Errorf("invalid peer address %q: %w", peer, err)
+		}
+		peerIPs = append(peerIPs, ip)
+	}
+
+	cidrs, err := nwi.lister()
+	if err != nil {
+		return "", err
+	}
+
+	for _, ipNet := range cidrs {
+		if !ipNet.IP.IsGlobalUnicast() {
+			continue
+		}
+		for _, peerIP := range peerIPs {
+			if ipNet.Contains(peerIP) {
+				return ipNet.IP.String(), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no local interface shares a subnet with any of the cluster peers %v", peers)
+}
+
+// parsePeerIP extracts the IP from a bare-IP or "ip:port" string.
+func parsePeerIP(peer string) (net.IP, error) {
+	peer = strings.TrimSpace(peer)
+	if ip := net.ParseIP(peer); ip != nil {
+		return ip, nil
+	}
+	host, _, err := net.SplitHostPort(peer)
+	if err != nil {
+		return nil, err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, fmt.Errorf("not an IP address")
+	}
+	return ip, nil
+}
+
+var Network NetworkIntf = &networkImpl{lister: hostCIDRs}

--- a/microceph/common/network_test.go
+++ b/microceph/common/network_test.go
@@ -1,0 +1,187 @@
+package common
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type NetworkSuite struct {
+	suite.Suite
+}
+
+func TestNetworkSuite(t *testing.T) {
+	suite.Run(t, new(NetworkSuite))
+}
+
+// mustCIDR parses a CIDR string and panics on error.
+func mustCIDR(s string) *net.IPNet {
+	ip, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	ipNet.IP = ip // keep host bits, mirroring net.Interfaces output
+	return ipNet
+}
+
+func staticLister(cidrs ...*net.IPNet) cidrLister {
+	return func() ([]*net.IPNet, error) { return cidrs, nil }
+}
+
+func errLister(msg string) cidrLister {
+	return func() ([]*net.IPNet, error) { return nil, errors.New(msg) }
+}
+
+// --- FindIpForPeers ---
+
+// Reproduces canonical/microceph#476: pick eth0, not the docker bridge.
+func (s *NetworkSuite) TestFindIpForPeers_PicksMatchingSubnet() {
+	nw := &networkImpl{
+		lister: staticLister(
+			mustCIDR("172.17.0.1/16"),   // docker0
+			mustCIDR("192.168.1.50/24"), // eth0
+		),
+	}
+
+	ip, err := nw.FindIpForPeers([]string{"192.168.1.10:7443"})
+	s.Require().NoError(err)
+	s.Equal("192.168.1.50", ip)
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_BarePeerAddress() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("10.0.0.5/24"))}
+
+	ip, err := nw.FindIpForPeers([]string{"10.0.0.42"})
+	s.Require().NoError(err)
+	s.Equal("10.0.0.5", ip)
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_IPv6() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("2001:db8::5/64"))}
+
+	ip, err := nw.FindIpForPeers([]string{"[2001:db8::10]:7443"})
+	s.Require().NoError(err)
+	s.Equal("2001:db8::5", ip)
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_MultiplePeersOneMatches() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	ip, err := nw.FindIpForPeers([]string{
+		"10.99.0.1:7443",    // unreachable
+		"192.168.1.10:7443", // reachable
+	})
+	s.Require().NoError(err)
+	s.Equal("192.168.1.50", ip)
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_NoMatch() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("172.17.0.1/16"))}
+
+	_, err := nw.FindIpForPeers([]string{"192.168.1.10:7443"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no local interface shares a subnet")
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_SkipsNonGlobalUnicast() {
+	nw := &networkImpl{
+		lister: staticLister(
+			mustCIDR("169.254.1.5/16"),  // link-local, skipped
+			mustCIDR("192.168.1.50/24"), // matches
+		),
+	}
+
+	ip, err := nw.FindIpForPeers([]string{"192.168.1.10:7443"})
+	s.Require().NoError(err)
+	s.Equal("192.168.1.50", ip)
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_EmptyPeers() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	_, err := nw.FindIpForPeers(nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no peer addresses supplied")
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_InvalidPeer() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	_, err := nw.FindIpForPeers([]string{"not-an-address"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "invalid peer address")
+}
+
+func (s *NetworkSuite) TestFindIpForPeers_ListerError() {
+	nw := &networkImpl{lister: errLister("boom")}
+
+	_, err := nw.FindIpForPeers([]string{"192.168.1.10:7443"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "boom")
+}
+
+// --- FindIpOnSubnet ---
+
+func (s *NetworkSuite) TestFindIpOnSubnet_Match() {
+	nw := &networkImpl{
+		lister: staticLister(
+			mustCIDR("172.17.0.1/16"),
+			mustCIDR("192.168.1.50/24"),
+		),
+	}
+
+	ip, err := nw.FindIpOnSubnet("192.168.1.0/24")
+	s.Require().NoError(err)
+	s.Equal("192.168.1.50", ip)
+}
+
+func (s *NetworkSuite) TestFindIpOnSubnet_NoMatch() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("172.17.0.1/16"))}
+
+	_, err := nw.FindIpOnSubnet("192.168.1.0/24")
+	s.Require().Error(err)
+}
+
+func (s *NetworkSuite) TestFindIpOnSubnet_InvalidCIDR() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	_, err := nw.FindIpOnSubnet("garbage")
+	s.Require().Error(err)
+}
+
+// --- FindNetworkAddress ---
+
+func (s *NetworkSuite) TestFindNetworkAddress_Match() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	cidr, err := nw.FindNetworkAddress("192.168.1.50")
+	s.Require().NoError(err)
+	s.Equal("192.168.1.50/24", cidr)
+}
+
+func (s *NetworkSuite) TestFindNetworkAddress_NotPresent() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	_, err := nw.FindNetworkAddress("10.0.0.1")
+	s.Require().Error(err)
+}
+
+func (s *NetworkSuite) TestFindNetworkAddress_InvalidIP() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	_, err := nw.FindNetworkAddress("garbage")
+	s.Require().Error(err)
+}
+
+// --- IsIpOnSubnet ---
+
+func (s *NetworkSuite) TestIsIpOnSubnet() {
+	nw := &networkImpl{}
+
+	s.True(nw.IsIpOnSubnet("192.168.1.10", "192.168.1.0/24"))
+	s.False(nw.IsIpOnSubnet("10.0.0.1", "192.168.1.0/24"))
+	s.False(nw.IsIpOnSubnet("garbage", "192.168.1.0/24"))
+	s.False(nw.IsIpOnSubnet("192.168.1.10", "garbage"))
+}

--- a/microceph/mocks/NetworkIntf.go
+++ b/microceph/mocks/NetworkIntf.go
@@ -57,6 +57,30 @@ func (_m *NetworkIntf) FindNetworkAddress(address string) (string, error) {
 	return r0, r1
 }
 
+// FindIpForPeers provides a mock function with given fields: peers
+func (_m *NetworkIntf) FindIpForPeers(peers []string) (string, error) {
+	ret := _m.Called(peers)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]string) (string, error)); ok {
+		return rf(peers)
+	}
+	if rf, ok := ret.Get(0).(func([]string) string); ok {
+		r0 = rf(peers)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = rf(peers)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsIpOnSubnet provides a mock function with given fields: address, subnet
 func (_m *NetworkIntf) IsIpOnSubnet(address string, subnet string) bool {
 	ret := _m.Called(address, subnet)


### PR DESCRIPTION
## Summary
- `microceph cluster join` falls back to lxd's `util.NetworkInterfaceAddress()` when `--microceph-ip` is unset, returning the first global unicast address from `net.Interfaces()` — typically a docker/lxd bridge, not the cluster network. The joiner advertises an unreachable address, raft membership stalls, and the user sees `Failed to join cluster: Ready dqlite: context deadline exceeded`.
- Decode the `join_addresses` already carried in the join token and pick a local interface address whose subnet contains at least one peer. If nothing matches, error out clearly and ask for `--microceph-ip` explicitly instead of silently picking the wrong address.
- Refactors `common/network.go` behind an injectable `cidrLister` seam so all four `NetworkIntf` methods share a single `net.Interfaces()` walk and are unit-testable for the first time. Adds 22 unit tests across `common/network_test.go` and `common/join_test.go`.

Fixes #476.

## Out of scope
- The interactive `init.go` flow still uses `NetworkInterfaceAddress()` because it asks for the address before the token; needs prompt reordering.
- The 5-minute outer ctx in `cluster_join.go` vs the 30-second inner `dqlite.Ready` deadline in microcluster — the visible deadline lies to the user. Likely needs an upstream microcluster change.

## Test plan
- [x] `go test ./common/...` — 24/24 pass (16 new network tests + 6 new token tests + 4 pre-existing storage tests, no regressions)
- [x] `go test ./ceph/... ./cmd/microcephd/...` — pass (verifies the value→pointer receiver change in `networkImpl` doesn't break other call sites)
- [x] `go vet ./common/... ./mocks/... ./cmd/microceph/...` — clean
