### PR TITLE
feat: Add log rotation of logs/ dir via logrotate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1239,6 +1239,9 @@ jobs:
 
           sudo umount /mnt/nfs
 
+      - name: Test log rotation
+        run: ~/actionutils.sh test_log_rotation
+
       - name: Test stale run dir migration (NFS)
         run: ~/actionutils.sh test_nfs_stale_run_dir_migration
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,6 +164,12 @@ apps:
       - network
       - network-bind
       - process-control
+  log-rotate:
+    command: commands/log-rotate.start
+    daemon: oneshot
+    timer: "00:02,06:04,12:07,18:03"
+    after:
+      - daemon
   # Commands
   ceph:
     command: commands/ceph
@@ -457,11 +463,28 @@ parts:
       - lib/*/liburcu-bp.so*
       - lib/*/libwbclient.so*
 
+  logrotate:
+    plugin: nil
+    stage-packages:
+      - logrotate
+    organize:
+      usr/sbin/: bin/
+      usr/lib/: lib/
+    stage:
+      - -etc/logrotate.conf
+    prime:
+      - bin/logrotate
+      - lib/*/libacl.so*
+      - lib/*/libpopt.so*
+      - lib/*/libselinux.so*
+      - lib/*/libpcre2-8.so*
+
   strip:
     after:
       - ceph
       - dqlite
       - microceph
+      - logrotate
     plugin: nil
     override-prime: |
       set -x
@@ -474,3 +497,6 @@ parts:
   wrappers:
     plugin: dump
     source: snapcraft/
+    permissions:
+      - path: etc/logrotate.conf
+        mode: "0644"

--- a/snapcraft/commands/log-rotate.start
+++ b/snapcraft/commands/log-rotate.start
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Ensure the state file is created with 600 so logrotate does not warn that
+# it is world-readable and skip lock acquisition.
+umask 077
+
+exec "${SNAP}/bin/logrotate" \
+    "${SNAP}/etc/logrotate.conf" \
+    -s "${SNAP_COMMON}/logrotate.status"

--- a/snapcraft/etc/logrotate.conf
+++ b/snapcraft/etc/logrotate.conf
@@ -1,0 +1,11 @@
+/var/snap/microceph/common/logs/*.log
+/var/snap/microceph/common/logs/ganesha/*.log
+{
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -2390,6 +2390,75 @@ function test_nfs_stale_run_dir_migration() {
     echo "NFS stale run dir migration: PASS"
 }
 
+# test_log_rotation verifies that the log-rotate snap service rotates both Ceph
+# daemon logs and the Ganesha log under $SNAP_COMMON/logs/. NFS must already be
+# enabled before calling this function so that ganesha.log exists.
+function test_log_rotation() {
+    set -eux
+
+    local logs_dir="/var/snap/microceph/common/logs"
+
+    # Wait for Ganesha log to appear (NFS must be enabled by caller).
+    for i in $(seq 1 30); do
+        if [ -f "${logs_dir}/ganesha/ganesha.log" ]; then
+            break
+        fi
+        if [[ $i -eq 30 ]]; then
+            echo "FAIL: Ganesha log not found after 30s"
+            exit 1
+        fi
+        sleep 1
+    done
+
+    # Verify a ceph-mon log exists.
+    ls "${logs_dir}"/ceph-mon.*.log
+
+    # Wait 1 minute for daemons to write log content.
+    sleep 60
+
+    # Show the systemd timer unit and status so CI output captures the
+    # configured schedule and last/next trigger times.
+    echo "--- snap.microceph.log-rotate.timer ---"
+    cat /etc/systemd/system/snap.microceph.log-rotate.timer || true
+    systemctl status snap.microceph.log-rotate.timer || true
+
+    # Show log file sizes so CI output captures whether files are empty.
+    echo "--- log file sizes before rotation ---"
+    ls -la "${logs_dir}"/*.log || true
+    ls -la "${logs_dir}/ganesha"/*.log || true
+
+    # Backdate the state file to yesterday so the daily check is satisfied.
+    # Without this, logrotate falls back to the log file's mtime, which is
+    # always today because Ceph daemons are continuously appending.
+    # Log file names include the hostname (e.g. ceph-mon.<hostname>.log) so
+    # discover them dynamically rather than hardcoding.
+    local yesterday
+    yesterday=$(date -d "yesterday" "+%Y-%-m-%-d-0:0:0")
+    {
+        echo "logrotate state -- version 2"
+        for f in "${logs_dir}"/*.log "${logs_dir}"/ganesha/*.log; do
+            [ -f "${f}" ] && echo "\"${f}\" ${yesterday}"
+        done
+    } | sudo tee /var/snap/microceph/common/logrotate.status > /dev/null
+    sudo chmod 600 /var/snap/microceph/common/logrotate.status
+
+    sudo snap run microceph.log-rotate
+
+    # Show resulting directory state before asserting.
+    echo "--- log directory after rotation ---"
+    ls -la "${logs_dir}"/ || true
+    ls -la "${logs_dir}/ganesha"/ || true
+
+    # Verify at least one rotated backup exists for both daemon and ganesha logs.
+    ls "${logs_dir}"/ceph-mon.*.log.1
+    ls "${logs_dir}/ganesha/ganesha.log.1"
+
+    # Original files must still exist, truncated in-place by copytruncate.
+    test -f "${logs_dir}/ganesha/ganesha.log"
+
+    echo "test_log_rotation: PASS"
+}
+
 run="${1}"
 shift
 


### PR DESCRIPTION
# Description

Address the missing log rotation for files in `$SNAP_COMMON/logs/`. Add logrotate with a timer that will trigger every 6 hours. Rotation will only happen once daily but the timer triggers every 6 hours in case one of the rotations was missed due to the service being off.

Fixes #163

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

* Added integration testing verifying rotation occurs

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change