### PR TITLE
test: upgrade squid to tentacle

### DIFF
--- a/.github/workflows/s2t-upgrade.yaml
+++ b/.github/workflows/s2t-upgrade.yaml
@@ -44,7 +44,7 @@ jobs:
         for c in node-wrk0 node-wrk1 node-wrk2 ; do
           ~/actionutils.sh add_osd_to_node $c
         done
-        ~/actionutils.sh headexec wait_for_osds 3
+        ~/actionutils.sh headexec wait_for_osds_up_in 3
 
     - name: Enable RGW
       run: ~/actionutils.sh headexec enable_rgw
@@ -56,7 +56,7 @@ jobs:
       run: ~/actionutils.sh refresh_snap tentacle
 
     - name: Wait until 3 OSDs are up
-      run:  ~/actionutils.sh headexec wait_for_osds 3
+      run:  ~/actionutils.sh headexec wait_for_osds_up_in 3
 
     - name: Verify config
       run: ~/actionutils.sh test_ceph_conf

--- a/.github/workflows/s2t-upgrade.yaml
+++ b/.github/workflows/s2t-upgrade.yaml
@@ -1,0 +1,65 @@
+name: Upgrade a s/stable cluster to tentacle/edge
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch: null
+
+jobs:
+  # a2b upgrade implies a/stable -> b/candidate release upgrade.
+  s2t-upgrade-test:
+    name: Test squid/stable to tentacle/edge upgrades
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Copy utils
+      run: cp tests/scripts/actionutils.sh $HOME
+
+    - name: Clear FORWARD firewall rules
+      run: ~/actionutils.sh cleaript
+
+    - name: Free disk
+      run: ~/actionutils.sh free_runner_disk
+
+    - name: Install dependencies
+      run: ~/actionutils.sh setup_lxd
+
+    - name: Create containers with loopback devices
+      run: ~/actionutils.sh create_containers public
+
+    - name: Install squid stable from store
+      run: ~/actionutils.sh install_store squid/stable
+
+    - name: Bootstrap
+      run: ~/actionutils.sh bootstrap_head
+
+    - name: Setup cluster
+      run: ~/actionutils.sh cluster_nodes
+
+    - name: Add 3 OSDs
+      run: |
+        for c in node-wrk0 node-wrk1 node-wrk2 ; do
+          ~/actionutils.sh add_osd_to_node $c
+        done
+        ~/actionutils.sh headexec wait_for_osds 3
+
+    - name: Enable RGW
+      run: ~/actionutils.sh headexec enable_rgw
+
+    - name: Exercise RGW
+      run: ~/actionutils.sh headexec testrgw
+
+    - name: Upgrade to tentacle
+      run: ~/actionutils.sh refresh_snap tentacle
+
+    - name: Wait until 3 OSDs are up
+      run:  ~/actionutils.sh headexec wait_for_osds 3
+
+    - name: Verify config
+      run: ~/actionutils.sh test_ceph_conf
+
+    - name: Exercise RGW again
+      run: ~/actionutils.sh headexec testrgw

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -127,7 +127,7 @@ function test_encrypted_wal_db_startup() {
         --wal-device /dev/sdie --wal-encrypt \
         --db-device /dev/sdif --db-encrypt
 
-    wait_for_osds "${expected_osds}"
+    wait_for_osds_up_in "${expected_osds}"
 
     # Find the OSD ID just created
     local osd_id
@@ -151,7 +151,7 @@ function test_encrypted_wal_db_startup() {
         fi
     done
 
-    wait_for_osds "${expected_osds}" || exit 1
+    wait_for_osds_up_in "${expected_osds}" || exit 1
 }
 
 function add_lvm_vol() {
@@ -1285,6 +1285,43 @@ function wait_for_osds() {
     sudo microceph.ceph -s
     if (( res < expect )); then
         echo "Never reached ${expect} OSDs"
+        return 1
+    fi
+}
+
+function wait_for_osds_up_in() {
+    local expect="${1?missing}"
+    local up_osds=0
+    local in_osds=0
+    local status=""
+    local tries=24
+
+    install_tools
+    for ((i=0; i<tries; i++)); do
+        status=$(sudo microceph.ceph -s -f json 2>/dev/null || true)
+        if [[ -n "$status" ]]; then
+            up_osds=$(jq -r '.osdmap.num_up_osds // 0' <<<"$status" 2>/dev/null || echo 0)
+            in_osds=$(jq -r '.osdmap.num_in_osds // 0' <<<"$status" 2>/dev/null || echo 0)
+        else
+            up_osds=0
+            in_osds=0
+        fi
+
+        [[ "$up_osds" =~ ^[0-9]+$ ]] || up_osds=0
+        [[ "$in_osds" =~ ^[0-9]+$ ]] || in_osds=0
+
+        if (( up_osds >= expect && in_osds >= expect )); then
+            echo "Found >=${expect} OSDs up and in"
+            break
+        else
+            printf '.'
+            sleep 5
+        fi
+    done
+
+    sudo microceph.ceph -s
+    if (( up_osds < expect || in_osds < expect )); then
+        echo "Never reached ${expect} OSDs up and in (up=${up_osds}, in=${in_osds})"
         return 1
     fi
 }


### PR DESCRIPTION
Also add workaround for upstream issue

Upstream tracks https://tracker.ceph.com/issues/70869 which is fixed
but not yet backported to tentacle. This bug causes an OSD crash if
OSDs are restarted that are not yet fully up. Workaround by waiting
for OSDs being "in"