### PR TITLE
DEMO ONLY: wire faultcat-explore into multi-node-tests CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -431,20 +431,22 @@ jobs:
       - name: Bootstrap
         run: ~/actionutils.sh bootstrap_head public
 
+      # FAULTCAT-DEMO: this step is deliberately disabled (`if: false`)
+      # so the downstream "Verify config" / "Add 2 OSDs" / "Test failure
+      # domain scale up" steps fail naturally on the missing setup. This
+      # exercises explore mode against a real diagnostics_gap-shaped
+      # failure (state expected by a later step was never set up by an
+      # earlier step). Skipping at this point fails the job at minute
+      # ~5-6 instead of minute ~9, so the demo feedback loop is faster.
+      # Restore by removing the `if: false` line before merging.
       - name: Setup cluster
+        if: false
         run: ~/actionutils.sh cluster_nodes public
 
       - name: Verify config
         run: ~/actionutils.sh test_ceph_conf
 
-      # FAULTCAT-DEMO: this step is deliberately disabled (`if: false`)
-      # so the downstream "Test 3 osds present" / "Test crush rules"
-      # steps fail naturally on the missing setup. This exercises
-      # explore mode against a real `diagnostics_gap`-shaped failure
-      # (state expected by a later step was never set up by an earlier
-      # step). Restore by removing the `if: false` line before merging.
       - name: Add 2 OSDs
-        if: false
         run: |
           for c in node-wrk1 node-wrk2 ; do
             ~/actionutils.sh add_osd_to_node $c

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -432,7 +432,14 @@ jobs:
       - name: Verify config
         run: ~/actionutils.sh test_ceph_conf
 
+      # FAULTCAT-DEMO: this step is deliberately disabled (`if: false`)
+      # so the downstream "Test 3 osds present" / "Test crush rules"
+      # steps fail naturally on the missing setup. This exercises
+      # explore mode against a real `diagnostics_gap`-shaped failure
+      # (state expected by a later step was never set up by an earlier
+      # step). Restore by removing the `if: false` line before merging.
       - name: Add 2 OSDs
+        if: false
         run: |
           for c in node-wrk1 node-wrk2 ; do
             ~/actionutils.sh add_osd_to_node $c
@@ -527,6 +534,18 @@ jobs:
         if: failure()
         run: |
           sudo snap logs microceph -n 1000
+
+      # FAULTCAT-DEMO: run faultcat explore against the live failed runner
+      # state, upload scrubbed evidence/findings/suggestions as an
+      # artifact. Remove this step before merging this PR.
+      - name: FAULTCAT-DEMO faultcat explore
+        if: failure()
+        uses: canonical/faultcat/.github/actions/faultcat-explore@feat/explore-mode
+        with:
+          hints: microceph,lxd
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          artifact-name: faultcat-probe-multi-node
+          fail-on-explore-error: "false"
 
   availability-zone-tests:
     name: Availability zone crush rule testing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-microceph:
+    if: false  # FAULTCAT-DEMO: bypass build, multi-node-tests pulls snap from store
     name: Build microceph snap
     runs-on: ubuntu-22.04
     env:
@@ -397,14 +398,11 @@ jobs:
   multi-node-tests:
     name: Multi node testing
     runs-on: ubuntu-22.04
-    needs: build-microceph
+    # FAULTCAT-DEMO: no longer `needs: build-microceph` — we install
+    # the published snap from snapcraft instead, which skips the ~3 min
+    # build step. Restore `needs: build-microceph` and the Download
+    # snap / Install local microceph snap steps before merging.
     steps:
-      - name: Download snap
-        uses: actions/download-artifact@v4
-        with:
-          name: snaps
-          path: /home/runner
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -425,8 +423,11 @@ jobs:
       - name: Create containers with loopback devices
         run: ~/actionutils.sh create_containers public
 
-      - name: Install local microceph snap
-        run: ~/actionutils.sh install_multinode
+      # FAULTCAT-DEMO: was `~/actionutils.sh install_multinode` (local
+      # snap from build-microceph artifact); using the published snap
+      # via install_store to skip the build. Restore before merging.
+      - name: Install microceph snap from store
+        run: ~/actionutils.sh install_store reef/stable
 
       - name: Bootstrap
         run: ~/actionutils.sh bootstrap_head public

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
           retention-days: 5
 
   dsl-functional-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: DSL functional tests
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -92,6 +93,7 @@ jobs:
           lxc storage volume list default || true
 
   api-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: API tests
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -139,6 +141,7 @@ jobs:
           ~/actionutils.sh dump_microceph_debug
 
   static-checks:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Run static checks
     runs-on: ubuntu-24.04
     steps:
@@ -164,6 +167,7 @@ jobs:
           make check-static
 
   unit-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Run Unit tests
     runs-on: ubuntu-24.04
     steps:
@@ -189,6 +193,7 @@ jobs:
           make check-unit
 
   single-system-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Single node with encryption
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -544,10 +549,12 @@ jobs:
         with:
           hints: microceph,lxd
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          faultcat-ref: feat/explore-mode
           artifact-name: faultcat-probe-multi-node
           fail-on-explore-error: "false"
 
   availability-zone-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Availability zone crush rule testing
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -597,6 +604,7 @@ jobs:
           done
 
   multi-node-tests-with-custom-microceph-ip:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Multi node testing with custom microceph IP
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -654,6 +662,7 @@ jobs:
           sudo snap logs microceph -n 1000
 
   test-sequential-mon-host-refresh:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Regression test for sequential join mon host refresh (issue #556)
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -700,6 +709,7 @@ jobs:
           done
 
   test-maintenance-modes:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test maintenance mode
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -800,6 +810,7 @@ jobs:
         run: ~/actionutils.sh test_maintenance_enter_set_noout_stop_osds_and_exit_force node-wrk1
 
   loop-file-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test with loopback file OSDs
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -855,6 +866,7 @@ jobs:
           sudo snap logs microceph -n 1000
 
   wal-db-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test WAL/DB device usage
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -926,6 +938,7 @@ jobs:
           sudo snap logs microceph -n 1000
 
   upgrade-reef-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test reef upgrades
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -1002,6 +1015,7 @@ jobs:
         uses: lhotari/action-upterm@v1
 
   cluster-tests:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test MicroCeph Cluster features.
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -1063,6 +1077,7 @@ jobs:
         run: ~/actionutils.sh testrgw "newFile"
 
   rbd-replication-test:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test MicroCeph RBD Remote Replication features.
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -1132,6 +1147,7 @@ jobs:
         run: ~/actionutils.sh remote_remove_and_verify
 
   cephfs-replication-test:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test MicroCeph Cephfs Remote Replication features.
     runs-on: ubuntu-24.04
     needs: build-microceph
@@ -1197,6 +1213,7 @@ jobs:
         run: ~/actionutils.sh remote_disable_mirror_daemon "cephfs-mirror"
 
   nfs-test:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test MicroCeph NFS feature
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -1268,6 +1285,7 @@ jobs:
         run: ~/actionutils.sh disable_nfs foo
 
   nfs-multinode-test:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Test MicroCeph NFS feature (multinode)
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -1388,6 +1406,7 @@ jobs:
         run: ~/actionutils.sh test_v2_all_nodes
 
   wiping-test:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Verify pristineness and wiping
     runs-on: ubuntu-22.04
     needs: build-microceph
@@ -1413,6 +1432,7 @@ jobs:
         run: ~/actionutils.sh verify_pristine_check
 
   cephadm-adopt-test:
+    if: false  # FAULTCAT-DEMO: disabled to speed up explore-mode demo cycle
     name: Adopt test with cephadm
     runs-on: ubuntu-24.04
     needs: build-microceph

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -548,6 +548,7 @@ jobs:
       # artifact. Remove this step before merging this PR.
       - name: FAULTCAT-DEMO faultcat explore
         if: failure()
+        timeout-minutes: 6
         uses: canonical/faultcat/.github/actions/faultcat-explore@feat/explore-mode
         with:
           hints: microceph,lxd


### PR DESCRIPTION
> ⚠️ **Do NOT merge.** This PR exists to exercise [canonical/faultcat](https://github.com/canonical/faultcat) PR #8 (`feat/explore-mode`) end-to-end against a real failing microceph CI job. Both demo changes are tagged `FAULTCAT-DEMO` so they can be ripped out cleanly. The PR is opened as a **draft** to make the do-not-merge status visible.

## What this PR does

1. Disables the **"Add 2 OSDs"** step in the **multi-node-tests** job with `if: false`. The downstream "Test 3 osds present" / "Test crush rules" steps then fail naturally on the missing setup — this is a real `diagnostics_gap` shape: state that a later step expects was never set up by an earlier step.

2. Adds a new step right after the existing **"Print logs for failure"** step:

   ```yaml
   - name: FAULTCAT-DEMO faultcat explore
     if: failure()
     uses: canonical/faultcat/.github/actions/faultcat-explore@feat/explore-mode
     with:
       hints: microceph,lxd
       openrouter-api-key: \${{ secrets.OPENROUTER_API_KEY }}
       artifact-name: faultcat-probe-multi-node
       fail-on-explore-error: "false"
   ```

   The composite action installs `@earendil-works/pi-coding-agent`, faultcat, drives Pi (fast tier, DeepSeek V3 via OpenRouter) to inspect the live failed multi-node test environment read-only, validates the output against the same `evidence_bundle.v1` / `findings.v1` / `suggestions.v1` schemas as faultcat M1, scrubs secrets from the entire output tree, and uploads it as a `faultcat-probe-multi-node` artifact.

## What I want to learn from this CI run

- Does the composite action install cleanly on the `ubuntu-22.04` runner used by `multi-node-tests`?
- Does Pi correctly identify the missing-OSDs cause from live `microceph status` / `ceph -s` / `snap.microceph.osd` logs, or does it get distracted?
- Is the resulting artifact actually safe to publish on the public repo (scrubber output looks clean)?
- Are the three baseline skills (`microceph`, `lxd`, `_default`) tight enough that Pi stays focused, or does it bloat?

## Prerequisite

`OPENROUTER_API_KEY` needs to be set as a repo secret in `canonical/microceph`. The action reads `\${{ secrets.OPENROUTER_API_KEY }}` — if the secret is missing, the action will run but Pi will return empty content (no fallback model in this first cut). I have not added that secret; would appreciate you doing so before kicking the workflow, or letting me know and I'll keep the PR in draft until it's in place.

## When this PR is no longer needed

After the explore action has been observed working over a few real CI failures, a follow-up PR can add the `if: failure()` step into more (or all) integration test jobs as a permanent hook. This PR's role ends as soon as we have evidence the action behaves correctly.

## Test plan
- [ ] CI fails as expected in the "Test 3 osds present" step (missing OSDs)
- [ ] The `FAULTCAT-DEMO faultcat explore` step runs to completion (does not fail the job either way thanks to `fail-on-explore-error: false`)
- [ ] `faultcat-probe-multi-node` artifact appears on the workflow run
- [ ] Downloaded artifact contains a scrubbed `evidence.yaml`, `findings.yaml`, `suggestions.yaml` whose content reflects the missing-OSDs failure shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)