### PR TITLE
Encryption supported Check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,13 @@ jobs:
           ~/actionutils.sh hurl tests/hurl/services-mon.hurl
           ~/actionutils.sh hurl tests/hurl/maintenance-put-failed.hurl
           ~/actionutils.sh hurl tests/hurl/disks-list.hurl
+          ~/actionutils.sh hurl tests/hurl/disks-encryption-support-unsupported.hurl
+
+      - name: API disk encryption-support (supported)
+        run: |
+          sudo snap connect microceph:dm-crypt
+          sudo modprobe dm_crypt
+          ~/actionutils.sh hurl tests/hurl/disks-encryption-support-supported.hurl
 
       - name: API disk Hurl testing with discoverable devices
         run: |

--- a/docs/snap/explanation/security/cryptographic-approaches.rst
+++ b/docs/snap/explanation/security/cryptographic-approaches.rst
@@ -83,7 +83,7 @@ Data at rest
 MicroCeph offers full disk encryption (FDE) for Object Storage Daemons (OSDs), activated when adding disks. Note that this disk encryption
 only pertains to user data managed in Ceph, and not encryption of the cluster data (such as administrative data, 
 logs, etc.).
-To use FDE, users must first connect the ``dm-crypt`` plug for MicroCeph (it is not auto-connected).
+To use FDE, the ``dm-crypt`` plug for MicroCeph must be connected. This plug auto-connects when MicroCeph is installed from the Snap Store; for locally-built or ``--dangerous`` installs it must be connected manually.
 When FDE is requested, MicroCeph generates a random key and stores it in the Ceph Monitor (MON). This key is then used to setup
 Linux Unified Key Setup (LUKS) via ``cryptsetup``, using ``cipher AES-XTS-plain64`` and ``SHA256`` hashing, with a 256-bit keysize.
 

--- a/docs/snap/how-to/enable-fde.rst
+++ b/docs/snap/how-to/enable-fde.rst
@@ -18,12 +18,14 @@ To use FDE, the following prerequisites must be met:
 - The installed snapd daemon version must be >= 2.59.1
 - The `dm-crypt kernel module`_ must be available. Note that some cloud-optimised kernels
   do not ship dm-crypt by default. Check by running ``sudo modinfo dm-crypt``
-- The :external+snapcraft:ref:`snap dm-crypt plug <interfaces-dm-crypt-interface>` has to be connected, and ``microceph.daemon`` subsequently restarted:
+- The :external+snapcraft:ref:`snap dm-crypt plug <interfaces-dm-crypt-interface>` has to be connected. When MicroCeph is installed from the Snap Store this plug auto-connects, so no action is needed. For locally-built or ``--dangerous`` installs, connect it manually and restart ``microceph.daemon``:
 
   .. code-block:: none
 
      sudo snap connect microceph:dm-crypt
      sudo snap restart microceph.daemon
+
+  You can confirm all prerequisites are met by running ``sudo microceph disk encryption-support``.
 
 
 Enable FDE

--- a/docs/snap/reference/commands/disk.rst
+++ b/docs/snap/reference/commands/disk.rst
@@ -207,8 +207,10 @@ Usage:
 
 .. note::
 
-   To enable encryption support, connect the snap interface and load the
-   kernel module:
+   When MicroCeph is installed from the Snap Store, the ``dm-crypt``
+   interface auto-connects, so no manual ``snap connect`` is required.
+   For locally-built or ``--dangerous`` installs, connect the snap
+   interface and load the kernel module manually:
 
    .. code-block:: bash
 

--- a/docs/snap/reference/commands/disk.rst
+++ b/docs/snap/reference/commands/disk.rst
@@ -16,9 +16,10 @@ Available commands:
 
 .. code-block:: none
 
-   add         Add a Ceph disk (OSD)
-   list        List servers in the cluster
-   remove      Remove a Ceph disk (OSD)
+   add                  Add a Ceph disk (OSD)
+   encryption-support   Check if disk encryption is supported
+   list                 List servers in the cluster
+   remove               Remove a Ceph disk (OSD)
 
 Global flags:
 
@@ -183,6 +184,36 @@ Limitations:
 - ``--wal-encrypt`` and ``--wal-wipe`` require ``--wal-match`` when using DSL-based selection.
 - ``--db-encrypt`` and ``--db-wipe`` require ``--db-match`` when using DSL-based selection.
 - ``--wal-match`` and ``--db-match`` must resolve to disjoint device sets.
+
+
+``encryption-support``
+----------------------
+
+Checks whether dm-crypt disk encryption is supported on this node. Exits
+with a non-zero status and prints the reason if encryption is not available.
+Exits zero and prints a confirmation message if all prerequisites are met.
+
+Encryption requires:
+
+- The ``dm-crypt`` snap interface to be connected.
+- The ``dm_crypt`` kernel module to be loaded.
+- The ``/dev/mapper/control`` device to be present.
+
+Usage:
+
+.. code-block:: none
+
+   microceph disk encryption-support
+
+.. note::
+
+   To enable encryption support, connect the snap interface and load the
+   kernel module:
+
+   .. code-block:: bash
+
+      sudo snap connect microceph:dm-crypt
+      sudo modprobe dm_crypt
 
 
 ``list``

--- a/microceph/api/disks.go
+++ b/microceph/api/disks.go
@@ -38,6 +38,13 @@ var disksDelCmd = mcTypes.Endpoint{
 	Delete: mcTypes.EndpointAction{Handler: cmdDisksDelete, ProxyTarget: true},
 }
 
+// /1.0/disks/encryption-support endpoint.
+var disksEncryptionSupportCmd = mcTypes.Endpoint{
+	Path: "disks/encryption-support",
+
+	Get: mcTypes.EndpointAction{Handler: cmdDisksEncryptionSupport, ProxyTarget: true},
+}
+
 var mu sync.Mutex
 
 func cmdDisksGet(s mcTypes.State, r *http.Request) mcTypes.Response {
@@ -266,6 +273,20 @@ func cmdDisksDelete(s mcTypes.State, r *http.Request) mcTypes.Response {
 	}
 
 	return mcTypes.EmptySyncResponse
+}
+
+// cmdDisksEncryptionSupport is the handler for GET /1.0/disks/encryption-support.
+func cmdDisksEncryptionSupport(s mcTypes.State, r *http.Request) mcTypes.Response {
+	var resp types.DisksEncryptionSupportResponse
+
+	m := ceph.NewOSDManager(s)
+	err := m.CheckEncryptSupport()
+	if err != nil {
+		resp.ReasonUnsupported = err.Error()
+	}
+	resp.Supported = err == nil
+
+	return mcTypes.SyncResponse(true, resp)
 }
 
 // parseAndPatchDiskPostParams parses/patches Disk add command parameters

--- a/microceph/api/servers.go
+++ b/microceph/api/servers.go
@@ -15,6 +15,7 @@ var Servers = map[string]mcTypes.Server{
 				PathPrefix: types.ExtendedPathPrefix,
 				Endpoints: []mcTypes.Endpoint{
 					disksCmd,
+					disksEncryptionSupportCmd,
 					disksDelCmd,
 					resourcesCmd,
 					servicesCmd,

--- a/microceph/api/types/disks.go
+++ b/microceph/api/types/disks.go
@@ -83,6 +83,12 @@ type DisksDelete struct {
 	Timeout                int64 `json:"timeout" yaml:"timeout"`
 }
 
+// DisksEncryptionSupportResponse is the response body for GET /1.0/disks/encryption-support.
+type DisksEncryptionSupportResponse struct {
+	Supported         bool   `json:"supported" yaml:"supported"`
+	ReasonUnsupported string `json:"reason_unsupported,omitempty" yaml:"reason_unsupported,omitempty"`
+}
+
 // Disks is a slice of disks
 type Disks []Disk
 

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -152,7 +152,7 @@ func (m *OSDManager) prepareDisk(disk *types.DiskParameter, suffix string, osdPa
 		}
 	}
 	if disk.Encrypt {
-		err := m.checkEncryptSupport()
+		err := m.CheckEncryptSupport()
 		if err != nil {
 			return fmt.Errorf("encryption unsupported on this machine: %w", err)
 		}
@@ -301,12 +301,12 @@ Verify your version of snapd by running "snap version"
 	return fmt.Sprintf("/dev/mapper/luksosd%s-%d", suffix, osdID), nil
 }
 
-// checkEncryptSupport checks if the kernel supports encryption.
+// CheckEncryptSupport checks if the kernel supports encryption.
 // Checks performed:
 // - Check if the kernel module is loaded.
 // - Check if we have a mapper control file.
 // - Check if we can access /run
-func (m *OSDManager) checkEncryptSupport() error {
+func (m *OSDManager) CheckEncryptSupport() error {
 	// Check if we have a mapper
 	_, err := m.fs.Stat("/dev/mapper/control")
 	if err != nil {

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -786,7 +786,7 @@ func (s *osdSuite) TestCheckEncryptSupport() {
 	defer func() { common.ProcessExec = originalProcessExec }()
 
 	// Test missing /dev/mapper/control
-	err := osdmgr.checkEncryptSupport()
+	err := osdmgr.CheckEncryptSupport()
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "missing /dev/mapper/control")
 
@@ -800,7 +800,7 @@ func (s *osdSuite) TestCheckEncryptSupport() {
 	r.On("RunCommand", "snapctl", "is-connected", "dm-crypt").Return("", fmt.Errorf("not connected")).Once()
 
 	// Test dm-crypt interface not connected
-	err = osdmgr.checkEncryptSupport()
+	err = osdmgr.CheckEncryptSupport()
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "dm-crypt interface")
 
@@ -808,7 +808,7 @@ func (s *osdSuite) TestCheckEncryptSupport() {
 	r.On("RunCommand", "snapctl", "is-connected", "dm-crypt").Return("", nil).Once()
 
 	// Test missing dm_crypt module
-	err = osdmgr.checkEncryptSupport()
+	err = osdmgr.CheckEncryptSupport()
 	assert.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "missing dm_crypt module")
 
@@ -822,7 +822,7 @@ func (s *osdSuite) TestCheckEncryptSupport() {
 	// Test successful encryption support check, need /run directory
 	err = fs.MkdirAll("/run", 0755)
 	assert.NoError(s.T(), err)
-	err = osdmgr.checkEncryptSupport()
+	err = osdmgr.CheckEncryptSupport()
 	assert.NoError(s.T(), err)
 }
 

--- a/microceph/client/disks.go
+++ b/microceph/client/disks.go
@@ -93,3 +93,25 @@ func RemoveDisk(ctx context.Context, c mcTypes.Client, data *types.DisksDelete) 
 	}
 	return nil
 }
+
+// GetEncryptionSupport returns whether or not encryption is supported
+// and an optional reason why.
+func GetEncryptionSupport(ctx context.Context, c mcTypes.Client) (bool, string, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	supported := types.DisksEncryptionSupportResponse{}
+
+	err := c.Query(
+		queryCtx,
+		"GET",
+		types.ExtendedPathPrefix,
+		&api.NewURL().Path("disks", "encryption-support").URL,
+		nil,
+		&supported)
+	if err != nil {
+		return false, "", err
+	}
+
+	return supported.Supported, supported.ReasonUnsupported, nil
+}

--- a/microceph/cmd/microceph/disk.go
+++ b/microceph/cmd/microceph/disk.go
@@ -26,6 +26,10 @@ func (c *cmdDisk) Command() *cobra.Command {
 	diskRemoveCmd := cmdDiskRemove{common: c.common, disk: c}
 	cmd.AddCommand(diskRemoveCmd.Command())
 
+	// EncryptionSupported
+	encryptionSupportCmd := cmdDiskEncryptionSupport{common: c.common, disk: c}
+	cmd.AddCommand(encryptionSupportCmd.Command())
+
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }

--- a/microceph/cmd/microceph/disk_encryption_support.go
+++ b/microceph/cmd/microceph/disk_encryption_support.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/microcluster/v3/microcluster"
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/microceph/microceph/client"
+)
+
+var getEncryptionSupportFunc = func(ctx context.Context, stateDir string) (bool, string, error) {
+	m, err := microcluster.App(microcluster.Args{StateDir: stateDir})
+	if err != nil {
+		return false, "", err
+	}
+	cli, err := m.LocalClient()
+	if err != nil {
+		return false, "", err
+	}
+	return client.GetEncryptionSupport(ctx, cli)
+}
+
+type cmdDiskEncryptionSupport struct {
+	common *CmdControl
+	disk   *cmdDisk
+}
+
+func (c *cmdDiskEncryptionSupport) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "encryption-support",
+		Short: "Check if disk encryption is supported. Exits non-zero with reason if not.",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdDiskEncryptionSupport) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	supported, reason, err := getEncryptionSupportFunc(context.Background(), c.common.FlagStateDir)
+	if err != nil {
+		return err
+	}
+
+	if !supported {
+		return fmt.Errorf("%s", reason)
+	}
+
+	fmt.Println("Encryption supported.")
+	return nil
+}

--- a/microceph/cmd/microceph/disk_encryption_support_test.go
+++ b/microceph/cmd/microceph/disk_encryption_support_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmdDiskEncryptionSupportUnsupported(t *testing.T) {
+	orig := getEncryptionSupportFunc
+	defer func() { getEncryptionSupportFunc = orig }()
+	getEncryptionSupportFunc = func(_ context.Context, _ string) (bool, string, error) {
+		return false, "missing dm_crypt module", nil
+	}
+
+	cmd := &cmdDiskEncryptionSupport{common: &CmdControl{}}
+	err := cmd.Run(nil, []string{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing dm_crypt module")
+}
+
+func TestCmdDiskEncryptionSupportSupported(t *testing.T) {
+	orig := getEncryptionSupportFunc
+	defer func() { getEncryptionSupportFunc = orig }()
+	getEncryptionSupportFunc = func(_ context.Context, _ string) (bool, string, error) {
+		return true, "", nil
+	}
+
+	cmd := &cmdDiskEncryptionSupport{common: &CmdControl{}}
+	var err error
+	out := captureStdout(t, func() {
+		err = cmd.Run(nil, []string{})
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, out, "Encryption supported.")
+}
+
+func TestCmdDiskEncryptionSupportTransportError(t *testing.T) {
+	orig := getEncryptionSupportFunc
+	defer func() { getEncryptionSupportFunc = orig }()
+	getEncryptionSupportFunc = func(_ context.Context, _ string) (bool, string, error) {
+		return false, "", fmt.Errorf("connection refused")
+	}
+
+	cmd := &cmdDiskEncryptionSupport{common: &CmdControl{}}
+	err := cmd.Run(nil, []string{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "connection refused")
+}

--- a/tests/hurl/disks-encryption-support-supported.hurl
+++ b/tests/hurl/disks-encryption-support-supported.hurl
@@ -1,0 +1,5 @@
+GET http://localhost/1.0/disks/encryption-support
+HTTP 200
+[Asserts]
+jsonpath "$.metadata.supported" == true
+jsonpath "$.metadata.reason_unsupported" not exists

--- a/tests/hurl/disks-encryption-support-unsupported.hurl
+++ b/tests/hurl/disks-encryption-support-unsupported.hurl
@@ -1,0 +1,5 @@
+GET http://localhost/1.0/disks/encryption-support
+HTTP 200
+[Asserts]
+jsonpath "$.metadata.supported" == false
+jsonpath "$.metadata.reason_unsupported" exists


### PR DESCRIPTION
# Description

Add a check to notify if encryption is supported:

`/1.0/disks/encryption-support`

```
{
    "supported": bool,
    "reason": string | omit
}
```

Add cli subcommand:

```
microceph disk encryption-support
```

Shows:

Reason if unsupported and returns nonzero

otherwise

"Encryption supported"

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

* Test supported/unsupported paths in cli (unit) & api (hurl)

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change