### PR TITLE
test: fix flaky upgrade and adopt CI tests

### DIFF
--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -1004,11 +1004,13 @@ function upgrade_multinode() {
     for container in node-wrk0 node-wrk1 node-wrk2 node-wrk3 ; do
         lxc exec $container -- sh -c "sudo snap install --dangerous /mnt/microceph_*.snap"
         lxc exec $container -- sh -c "snap connect microceph:block-devices ; snap connect microceph:hardware-observe ; snap connect microceph:mount-observe"
-        sleep 5
+        # Give the snap services time to (re)start before polling.
+        sleep 15
         expect=3
-        for i in $(seq 1 20); do
-            res=$( ( lxc exec $container -- sh -c "microceph.ceph osd status" | fgrep -c "exists,up" ) )
-            if [[ $res -eq $expect ]] ; then
+        for i in $(seq 1 30); do
+            # osd status may fail while daemons are restarting; default res=0.
+            res=$(lxc exec $container -- sh -c "microceph.ceph osd status 2>/dev/null | fgrep -c 'exists,up'" 2>/dev/null || echo 0)
+            if [[ "${res}" -eq $expect ]] ; then
                 echo "Found ${expect} osd up"
                 break
             else
@@ -1016,8 +1018,8 @@ function upgrade_multinode() {
                 sleep 10
             fi
         done
-        res=$( ( lxc exec $container -- sh -c "microceph.ceph osd status" | fgrep -c "exists,up" ) )
-        if [[ $res -ne $expect ]] ; then
+        res=$(lxc exec $container -- sh -c "microceph.ceph osd status 2>/dev/null | fgrep -c 'exists,up'" 2>/dev/null || echo 0)
+        if [[ "${res}" -ne $expect ]] ; then
             echo "Expected $expect OSD up, got $res"
             lxc exec $container -- sh -c "microceph.ceph -s"
             exit 1

--- a/tests/scripts/adoptutils.sh
+++ b/tests/scripts/adoptutils.sh
@@ -123,7 +123,7 @@ function wait_for_active_mds() {
   while true; do
     active=$(lxc exec "$container" -- bash -c \
       "sudo microceph.ceph fs status ${fs} --format json 2>/dev/null \
-       | python3 -c \"import sys,json; d=json.load(sys.stdin); print(len([r for r in d.get('mdsmap',[]) if r.get('state')=='active']))\" 2>/dev/null || echo 0")
+       | jq '[.mdsmap[]? | select(.state // \"\" | contains(\"active\"))] | length' 2>/dev/null || echo 0")
     if [[ "${active:-0}" -ge 1 ]]; then
       echo "MDS active on ${fs} in ${container}"
       return 0

--- a/tests/scripts/adoptutils.sh
+++ b/tests/scripts/adoptutils.sh
@@ -114,6 +114,30 @@ function exchange_adopt_remote_tokens() {
   lxc exec $sec_name -- sh -c "microceph remote import sitea $primary_token --local-name=$sec_name"
 }
 
+function wait_for_active_mds() {
+  # Poll until the given fs has at least one active MDS rank.
+  # Usage: wait_for_active_mds <container> <fs_name> [timeout_seconds]
+  local container=$1 fs=$2 timeout=${3:-120}
+  local deadline=$(( $(date +%s) + timeout ))
+  echo "Waiting for active MDS on ${fs} in ${container}..."
+  while true; do
+    active=$(lxc exec "$container" -- bash -c \
+      "sudo microceph.ceph fs status ${fs} --format json 2>/dev/null \
+       | python3 -c \"import sys,json; d=json.load(sys.stdin); print(len([r for r in d.get('mdsmap',[]) if r.get('state')=='active']))\" 2>/dev/null || echo 0")
+    if [[ "${active:-0}" -ge 1 ]]; then
+      echo "MDS active on ${fs} in ${container}"
+      return 0
+    fi
+    if [[ $(date +%s) -ge $deadline ]]; then
+      echo "Timed out waiting for active MDS on ${fs} in ${container}"
+      lxc exec "$container" -- bash -c "sudo microceph.ceph fs status ${fs}" || true
+      return 1
+    fi
+    echo -n '.'
+    sleep 5
+  done
+}
+
 function remote_enable_fs_rep() {
   set -eux
   pri_name=$1
@@ -124,6 +148,9 @@ function remote_enable_fs_rep() {
   lxc exec $pri_name -- bash -c "sudo microceph enable cephfs-mirror"
   lxc exec $pri_name -- bash -c "sudo microceph.ceph fs volume create vol"
   lxc exec $pri_name -- bash -c "sudo microceph.ceph mgr module enable mirroring"
+  # Wait for MDS to become active before enabling mirroring; the
+  # 'fs snapshot mirror enable' command hangs if no MDS rank is up yet.
+  wait_for_active_mds "$pri_name" "vol"
   lxc exec $pri_name -- bash -c "sudo microceph.ceph fs snapshot mirror enable vol"
 
   # Secondary
@@ -131,6 +158,8 @@ function remote_enable_fs_rep() {
   lxc exec $sec_name -- bash -c "sudo microceph enable cephfs-mirror"
   lxc exec $sec_name -- bash -c "sudo microceph.ceph fs volume create vol"
   lxc exec $sec_name -- bash -c "sudo microceph.ceph mgr module enable mirroring"
+  # Same wait for secondary.
+  wait_for_active_mds "$sec_name" "vol"
   lxc exec $sec_name -- bash -c "sudo microceph.ceph fs snapshot mirror enable vol"
 }
 


### PR DESCRIPTION
upgrade_multinode (actionutils.sh):
- bump initial sleep 5→15s: snap services need more time after install before the OSD poll loop starts
- increase poll attempts 20→30 (total window 5+200s → 15+300s)
- guard fgrep exit code: osd status can fail while daemons restart, leaving res empty and breaking integer comparison; default to 0

remote_enable_fs_rep (adoptutils.sh):
- add wait_for_active_mds() helper: polls 'ceph fs status' until at least one MDS rank is active (120s timeout)
- call it before 'ceph fs snapshot mirror enable vol' on both primary and secondary; the command hangs indefinitely when no MDS rank is up and the mirroring module has just been enabled asynchronously
