### PR TITLE
Fix udevd getstorage race

### DIFF
--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -917,7 +917,21 @@ var storageRetrySleepFunc = time.Sleep
 
 // getStorageWithRetry calls GetStorage() up to 3 times, retrying on any error
 func (m *OSDManager) getStorageWithRetry() (*api.ResourcesStorage, error) {
-	return m.storage.GetStorage()
+	const maxAttempts = 3
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var storage *api.ResourcesStorage
+		storage, err = m.storage.GetStorage()
+		if err == nil {
+			return storage, nil
+		}
+		if attempt < maxAttempts {
+			logger.Warnf("Transient error enumerating storage (attempt %d/%d): %v; retrying",
+				attempt, maxAttempts, err)
+			storageRetrySleepFunc(time.Duration(attempt) * 500 * time.Millisecond)
+		}
+	}
+	return nil, err
 }
 
 func (m *OSDManager) stabilizeDevicePath(data *types.DiskParameter) (*api.ResourcesStorage, error) {
@@ -926,7 +940,7 @@ func (m *OSDManager) stabilizeDevicePath(data *types.DiskParameter) (*api.Resour
 		return nil, nil
 	}
 
-	storage, err := m.storage.GetStorage()
+	storage, err := m.getStorageWithRetry()
 	if err != nil {
 		logger.Errorf("failed to stabilize device path for %s, err %v", data.Path, err)
 		return nil, fmt.Errorf("unable to list system disks: %w", err)
@@ -1358,7 +1372,7 @@ func trueBoolMapKeys(m map[string]bool) []string {
 }
 
 func (m *OSDManager) getStorageAndConfiguredDisks(ctx context.Context) (*api.ResourcesStorage, types.Disks, error) {
-	storage, err := m.storage.GetStorage()
+	storage, err := m.getStorageWithRetry()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get storage resources: %w", err)
 	}

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -910,6 +910,16 @@ func (m *OSDManager) validateAddOSDArgs(data types.DiskParameter, wal *types.Dis
 	return nil
 }
 
+// storageRetrySleepFunc is the sleep function used between GetStorage retry attempts.
+// It is a package-level variable so that tests can replace it with a no-op for fast
+// execution without changing retry logic.
+var storageRetrySleepFunc = time.Sleep
+
+// getStorageWithRetry calls GetStorage() up to 3 times, retrying on any error
+func (m *OSDManager) getStorageWithRetry() (*api.ResourcesStorage, error) {
+	return m.storage.GetStorage()
+}
+
 func (m *OSDManager) stabilizeDevicePath(data *types.DiskParameter) (*api.ResourcesStorage, error) {
 	logger.Infof("Stabilizing device path for %s", data.Path)
 	if data.LoopSize != 0 {

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -1424,3 +1424,56 @@ func (s *osdSuite) TestIsRackDegradeBlockedMoreThan3AZs() {
 	assert.NoError(s.T(), err)
 	assert.False(s.T(), blocked)
 }
+
+// TestGetStorageWithRetry is a regression test for the udevd TOCTOU race in
+// /dev/disk/by-id/. udevd atomically replaces symlinks by writing a .#-prefixed
+// temp entry then renaming it. LXD's GetStorage() can see the .# entry in readdir
+// and then get ENOENT on lstat because the rename completed between the two calls.
+// getStorageWithRetry must absorb that transient error and succeed on the next attempt.
+func (s *osdSuite) TestGetStorageWithRetry() {
+	storageRetrySleepFunc = func(_ time.Duration) {}
+	s.T().Cleanup(func() { storageRetrySleepFunc = time.Sleep })
+
+	osdmgr := NewOSDManager(nil)
+	goodStorage := &api.ResourcesStorage{
+		Disks: []api.ResourcesStorageDisk{{Device: "sda"}},
+	}
+
+	calls := 0
+	mockStorage := mocks.NewStorageInterface(s.T())
+	mockStorage.On("GetStorage").Return(func() (*api.ResourcesStorage, error) {
+		calls++
+		if calls == 1 {
+			// Exact error from the CI failure: udevd renamed .#scsi-... out from
+			// under LXD's EvalSymlinks call.
+			return nil, fmt.Errorf(`Failed to find "/dev/disk/by-id/.#scsi-0QEMU_QEMU_HARDDISK_lxd_microceph--dsl--01d14fb4b757b3ed": lstat /dev/disk/by-id/.#scsi-0QEMU_QEMU_HARDDISK_lxd_microceph--dsl--01d14fb4b757b3ed: no such file or directory`)
+		}
+		return goodStorage, nil
+	})
+	osdmgr.storage = mockStorage
+
+	storage, err := osdmgr.getStorageWithRetry()
+
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), goodStorage, storage)
+	assert.Equal(s.T(), 2, calls)
+}
+
+// TestGetStorageWithRetryExhausted verifies that errors are propagated after all
+// retry attempts are exhausted, and that GetStorage() is called exactly maxAttempts
+// times before giving up.
+func (s *osdSuite) TestGetStorageWithRetryExhausted() {
+	storageRetrySleepFunc = func(_ time.Duration) {}
+	s.T().Cleanup(func() { storageRetrySleepFunc = time.Sleep })
+
+	osdmgr := NewOSDManager(nil)
+	persistentErr := fmt.Errorf("persistent storage error")
+
+	mockStorage := mocks.NewStorageInterface(s.T())
+	mockStorage.On("GetStorage").Return(nil, persistentErr).Times(3)
+	osdmgr.storage = mockStorage
+
+	_, err := osdmgr.getStorageWithRetry()
+
+	require.ErrorIs(s.T(), err, persistentErr)
+}

--- a/microceph/ceph/osd_waldb.go
+++ b/microceph/ceph/osd_waldb.go
@@ -682,7 +682,7 @@ func (m *OSDManager) resolvePartitionStablePath(parentPath string, partition uin
 		}
 	}
 
-	storage, err := m.storage.GetStorage()
+	storage, err := m.getStorageWithRetry()
 	if err == nil {
 		for _, disk := range storage.Disks {
 			if common.GetDevicePath(&disk) != parentPath {
@@ -772,7 +772,7 @@ func (m *OSDManager) executeDSLProvisionPlan(ctx context.Context, plan *dslProvi
 		var generatedAux *generatedAuxDevicesManifest
 		createdAux := false
 
-		dataStorage, err := m.storage.GetStorage()
+		dataStorage, err := m.getStorageWithRetry()
 		if err != nil {
 			logger.Errorf("Unable to list system disks before adding OSD %s: %v", planned.OSDPath, err)
 			resp.Reports = append(resp.Reports, types.DiskAddReport{Path: planned.OSDPath, Report: "Failure", Error: fmt.Sprintf("unable to list system disks: %v", err)})


### PR DESCRIPTION
# Description

Fix transient race with udev.

Fixes #738

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Add unit test mocking transient failure.

## Contributor checklist

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change