### PR TITLE
test: fix flaky multi-node Test crush rules step (pool migration race)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -465,7 +465,10 @@ jobs:
         run: |
           set -uex
           lxc exec node-wrk0 -- sh -c "microceph.ceph osd crush rule ls" | grep -F microceph_auto_host
-          lxc exec node-wrk0 -- sh -c "microceph.ceph osd pool ls detail" | grep -F "crush_rule 2"
+          # Wait for pool migration to crush_rule 2 (host failure domain).
+          # The mgr-created .mgr pool may not yet exist when this step runs,
+          # so a bare `grep crush_rule 2` races against pool creation/migration.
+          lxc exec node-wrk0 -- /mnt/actionutils.sh wait_for_pool_crush_rule 2
 
       - name: Add another OSD
         run: |

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -1264,6 +1264,31 @@ function add_osd_to_node() {
     sleep 1
 }
 
+function wait_for_pool_crush_rule() {
+    # Wait until at least one pool exists on the cluster with the given
+    # crush_rule id. After the failure-domain auto-switch flips the default
+    # crush rule (e.g. osd -> host), the mgr-created .mgr pool may not yet
+    # exist, or pool migration may still be in flight, so an immediate
+    # `ceph osd pool ls detail | grep crush_rule N` race-fails.
+    local rule_id="${1?missing rule id}"
+    local tries="${2:-30}"
+    local out=""
+
+    for ((i=0; i<tries; i++)); do
+        out=$(sudo microceph.ceph osd pool ls detail 2>/dev/null || true)
+        if echo "$out" | grep -qF "crush_rule ${rule_id}"; then
+            echo "Found pool with crush_rule ${rule_id}"
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "No pool reached crush_rule ${rule_id} after ${tries} tries"
+    echo "--- pool ls detail ---"
+    echo "$out"
+    return 1
+}
+
 function wait_for_osds() {
     local expect="${1?missing}"
     local res=0


### PR DESCRIPTION
## Summary

- The `Test crush rules` step in the multi-node CI job races against `.mgr` pool creation / crush-rule migration after the failure-domain auto-switch flips the default rule from `microceph_auto_osd` (id 1) to `microceph_auto_host` (id 2).
- A bare `ceph osd pool ls detail | grep -F "crush_rule 2"` exits 1 when either no pools are listed yet, or the only pool still carries `crush_rule 1`.
- Add `wait_for_pool_crush_rule` helper (30 tries × 2s) and call it from the workflow step. The `microceph_auto_host` rule existence check is unchanged.

## Why this lands now

Observed recent multi-node failures across branches all bottom out on the same step:

- `feat/orchPlus` PR #721 — run 26499172061, step `Test crush rules`, stderr shows `osd pool ls detail` returned no `crush_rule 2`. Cluster state preceding the assertion: `pools: 0 pools, 0 pgs`.
- `megademo-robot` runs 26424267655 and 26418196210 — robot-translated form of the same assertion fails with `STDOUT: : 1 != 0` (grep matched 0 lines).

The mgr daemon creates the `.mgr` pool asynchronously; tests should not assume it exists at any specific tick after the rule switch.

## Test plan

- [ ] CI multi-node job passes on first attempt
- [ ] `Test crush rules` step logs `Found pool with crush_rule 2`
- [ ] No new lint / shell warnings in actionutils.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)