### PR TITLE
fix: purgeOSD retries on any transient failure, not just EBUSY exit code

### DIFF
--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -1894,26 +1894,14 @@ func (m *OSDManager) purgeOSD(osd int64) error {
 	for i := 0; i < retries; i++ {
 		err = m.doPurge(osd)
 		if err == nil {
-			// Success: break the retry loop
 			break
 		}
-		// we're getting a RunError from common.ProcessExec.RunCommand, and it
-		// wraps the original exit error if there's one
-		exitError, ok := err.(shared.RunError).Unwrap().(*exec.ExitError)
-		if !ok {
-			// not an exit error, abort and bubble up the error
-			logger.Warnf("Purge failed with non-exit error: %v", err)
-			break
-		}
-		if syscall.Errno(exitError.ExitCode()) != syscall.EBUSY {
-			// not a busy error, abort and bubble up the error
-			logger.Warnf("Purge failed with unexpected exit error: %v", exitError)
-			break
-		}
-		// purge failed with EBUSY - retry after a delay, and make delay exponential
-		logger.Infof("Purge failed %v, retrying in %v", err, backoff)
+		// Retry on any failure: the OSD process may still be shutting down
+		// when purge is attempted, causing transient errors. ceph CLI exits
+		// with 1 (not errno 16) in these cases.
+		logger.Infof("Purge attempt %d failed: %v, retrying in %v", i+1, err, backoff)
 		backoff = time.Duration(math.Pow(2, float64(i))) * time.Millisecond * 100
-		time.Sleep(backoff)
+		purgeRetrySleepFunc(backoff)
 	}
 
 	if err != nil {
@@ -2309,6 +2297,9 @@ var (
 	osdKillPollInterval     = 250 * time.Millisecond
 	osdPresenceRetryWindow  = 5 * time.Second
 	osdPresencePollInterval = 250 * time.Millisecond
+	// purgeRetrySleepFunc is the sleep function used between purgeOSD retry attempts.
+	// Replaced in tests to avoid slow backoff delays.
+	purgeRetrySleepFunc = time.Sleep
 )
 
 func isExitCode(err error, code int) bool {

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -981,6 +981,35 @@ func (s *osdSuite) TestDoPurge() {
 	assert.Error(s.T(), err)
 }
 
+// TestPurgeOSD tests purgeOSD retry logic.
+func (s *osdSuite) TestPurgeOSD() {
+	origSleep := purgeRetrySleepFunc
+	purgeRetrySleepFunc = func(_ time.Duration) {}
+	s.T().Cleanup(func() { purgeRetrySleepFunc = origSleep })
+
+	osdmgr := NewOSDManager(nil)
+	r := mocks.NewRunner(s.T())
+	osdmgr.runner = r
+
+	// Succeeds on first attempt.
+	r.On("RunCommand", "ceph", "osd", "purge", "osd.0", "--yes-i-really-mean-it").Return("", nil).Once()
+	err := osdmgr.purgeOSD(0)
+	assert.NoError(s.T(), err)
+
+	// Fails transiently then succeeds — retry must fire regardless of error type.
+	r.On("RunCommand", "ceph", "osd", "purge", "osd.1", "--yes-i-really-mean-it").Return("", fmt.Errorf("exit status 1")).Once()
+	r.On("RunCommand", "ceph", "osd", "purge", "osd.1", "--yes-i-really-mean-it").Return("", nil).Once()
+	err = osdmgr.purgeOSD(1)
+	assert.NoError(s.T(), err)
+
+	// Exhausts all retries and returns error.
+	for range 10 {
+		r.On("RunCommand", "ceph", "osd", "purge", "osd.2", "--yes-i-really-mean-it").Return("", fmt.Errorf("exit status 1")).Once()
+	}
+	err = osdmgr.purgeOSD(2)
+	assert.Error(s.T(), err)
+}
+
 // TestTestSafeStop tests OSD safe stop check
 func (s *osdSuite) TestTestSafeStop() {
 	osdmgr := NewOSDManager(nil)


### PR DESCRIPTION
## Summary

- `purgeOSD` had a dead retry loop: it checked `syscall.Errno(exitError.ExitCode()) != syscall.EBUSY` to decide whether to retry, but `ceph osd purge` exits with code 1 on failure, not the errno value 16 (EBUSY). Every failure hit the "unexpected exit error" break and retried zero times.
- Fix: retry on any failure from `doPurge`, matching the existing `wipeDevice` pattern. The OSD process may still be shutting down when purge is attempted, causing transient errors.
- Add `purgeRetrySleepFunc` injectable variable (per AGENTS.md `Func` suffix convention) to allow test-time sleep suppression.
- Add `TestPurgeOSD` covering success-on-first-try, transient-failure-then-success, and retry exhaustion.

## Test Plan

- [x] `go test ./ceph/... -run TestOSD -count=1` passes
- [x] `TestPurgeOSD` covers all three cases
- [ ] Integration: `test_dsl_api_disk_hurl` OSD purge race no longer flaky