### PR TITLE
ceph: treat already-removed partition entry as cleaned on WAL/DB cleanup

### DIFF
--- a/microceph/ceph/osd_waldb.go
+++ b/microceph/ceph/osd_waldb.go
@@ -582,6 +582,11 @@ func (m *OSDManager) deletePartition(parentPath string, partition uint64) error 
 	partitionRange := fmt.Sprintf("%d:%d", partition, partition)
 	_, err = m.runner.RunCommand("partx", "-d", "--nr", partitionRange, parentPath)
 	if err != nil {
+		_, resolveErr := m.resolvePartitionStablePath(parentPath, partition)
+		if resolveErr != nil {
+			logger.Infof("Kernel partition entry %d on %s already removed, treating as cleaned", partition, parentPath)
+			return nil
+		}
 		return fmt.Errorf("failed to remove kernel partition entry %d on %s: %w", partition, parentPath, err)
 	}
 

--- a/microceph/ceph/osd_waldb_test.go
+++ b/microceph/ceph/osd_waldb_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -804,6 +805,43 @@ func TestExecuteDSLProvisionPlanCleansCreatedAuxOnPartitionCreationFailure(t *te
 	assert.Equal(t, "Failure", resp.Reports[0].Report)
 	assert.Contains(t, resp.Reports[0].Error, assert.AnError.Error())
 	assert.Empty(t, resp.Warnings)
+}
+
+// TestDeletePartitionTreatsAlreadyRemovedKernelEntryAsCleaned is a regression
+// test for the flaky WAL/DB cleanup failure seen in the DSL "rm2" case
+// (https://github.com/canonical/microceph/issues/749).
+func TestDeletePartitionTreatsAlreadyRemovedKernelEntryAsCleaned(t *testing.T) {
+	var st mcTypes.State
+	mgr := NewOSDManager(st)
+	mgr.fs = afero.NewMemMapFs()
+	// Force the storage fallback in resolvePartitionStablePath to fail fast so
+	// the re-resolve after partx relies only on the in-memory fs state.
+	mgr.storage = staticStorage{err: assert.AnError}
+	runner := mocks.NewRunner(t)
+	mgr.runner = runner
+
+	parentPath := "/dev/disk/by-id/db"
+	partitionPath := "/dev/disk/by-id/db-part1"
+	require.NoError(t, mgr.fs.MkdirAll("/dev/disk/by-id", 0755))
+	require.NoError(t, afero.WriteFile(mgr.fs, partitionPath, []byte("db-part"), 0644))
+
+	// sfdisk --delete succeeds and, like the real tool without --no-reread,
+	// causes the kernel partition entry (the /dev node) to disappear.
+	runner.On("RunCommand", "sfdisk", "--delete", parentPath, "1").
+		Run(func(args mock.Arguments) {
+			require.NoError(t, mgr.fs.Remove(partitionPath))
+		}).Return("", nil).Once()
+
+	// By the time partx -d runs, the kernel entry is already gone, so partx
+	// fails exactly as observed in CI.
+	partxErr := fmt.Errorf("Failed to run: partx -d --nr 1:1 %s: exit status 1 "+
+		"(partx: %s: error deleting partition 1)", parentPath, parentPath)
+	runner.On("RunCommand", "partx", "-d", "--nr", "1:1", parentPath).
+		Return("", partxErr).Once()
+
+	err := mgr.deletePartition(parentPath, 1)
+	require.NoError(t, err,
+		"deletePartition must treat an already-removed kernel partition entry as cleaned, not as an error")
 }
 
 func TestResolvePartitionStablePathFallsBackToRawDeviceWhenStorageUnavailable(t *testing.T) {


### PR DESCRIPTION
# Description

deletePartition removes a generated WAL/DB partition in two steps: "sfdisk --delete" then "partx -d". Because the sfdisk call does not pass --no-reread, the kernel can re-read the partition table and drop the entry before "partx -d" runs, so partx exits non-zero with "error deleting partition". That redundant failure propagated up and intermittently failed "microceph disk remove" when generated partitions shared a WAL/DB carrier (DSL rm2 case).

Treat a "partx -d" failure as success when the partition no longer resolves, mirroring the existing idempotency handling on the preceding "sfdisk --delete" step. Add TestDeletePartitionTreatsAlreadyRemovedKernelEntryAsCleaned, which reproduces the race deterministically.

Fixes: #749

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Added unit test exercising regression

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change