### PR TITLE
fix: check remote paths (CVE-2026-10720)

### DIFF
--- a/microceph/api/cluster.go
+++ b/microceph/api/cluster.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/ceph"
@@ -30,9 +29,8 @@ func cmdClusterGet(s mcTypes.State, r *http.Request) mcTypes.Response {
 	}
 
 	// Check that the cluster name is conformant.
-	isOk, err := regexp.MatchString(constants.ClusterNameRegex, req.RemoteName)
-	if err != nil || !isOk {
-		err := fmt.Errorf("cluster names can only have [a-z] or [0-9] characters: %w", err)
+	if !constants.IsValidClusterName(req.RemoteName) {
+		err := fmt.Errorf("cluster names can only have [a-z] or [0-9] characters")
 		logger.Error(err.Error())
 		return mcTypes.BadRequest(err)
 	}

--- a/microceph/api/remote.go
+++ b/microceph/api/remote.go
@@ -44,6 +44,16 @@ func cmdRemotePut(state mcTypes.State, r *http.Request) mcTypes.Response {
 		return mcTypes.InternalError(err)
 	}
 
+	remoteName, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return mcTypes.BadRequest(err)
+	}
+
+	err = validateRemoteImportRequest(remoteName, req)
+	if err != nil {
+		return mcTypes.BadRequest(err)
+	}
+
 	err = renderConfAndKeyringFiles(req.Name, req.LocalName, req.Config)
 	if err != nil {
 		return mcTypes.InternalError(fmt.Errorf("couldn't render files: %w", err))
@@ -83,6 +93,13 @@ func cmdRemoteGet(state mcTypes.State, r *http.Request) mcTypes.Response {
 		return mcTypes.InternalError(err)
 	}
 
+	if remoteName != "" {
+		err = validateRemoteName(remoteName)
+		if err != nil {
+			return mcTypes.BadRequest(err)
+		}
+	}
+
 	remotes, err := database.GetRemoteDb(r.Context(), state, remoteName)
 	if err != nil {
 		return mcTypes.SmartError(err)
@@ -98,6 +115,11 @@ func cmdRemoteGet(state mcTypes.State, r *http.Request) mcTypes.Response {
 // cmdRemoteDelete is handler for removing Remote records from MicroCeph internal db.
 func cmdRemoteDelete(state mcTypes.State, r *http.Request) mcTypes.Response {
 	remoteName, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return mcTypes.BadRequest(err)
+	}
+
+	err = validateRemoteName(remoteName)
 	if err != nil {
 		return mcTypes.BadRequest(err)
 	}
@@ -122,6 +144,42 @@ func cmdRemoteDelete(state mcTypes.State, r *http.Request) mcTypes.Response {
 }
 
 /*****************HELPER FUNCTIONS**************************/
+
+var reservedRemoteNames = map[string]struct{}{
+	"ceph":    {},
+	"ganesha": {},
+	"radosgw": {},
+}
+
+func validateRemoteName(name string) error {
+	if !constants.IsValidClusterName(name) {
+		return fmt.Errorf("remote names can only have [a-z] or [0-9] characters")
+	}
+
+	_, isReserved := reservedRemoteNames[name]
+	if isReserved {
+		return fmt.Errorf("remote name %q is reserved", name)
+	}
+
+	return nil
+}
+
+func validateRemoteImportRequest(routeName string, req types.RemoteImportRequest) error {
+	err := validateRemoteName(req.Name)
+	if err != nil {
+		return err
+	}
+
+	if routeName != req.Name {
+		return fmt.Errorf("remote name in URL %q does not match request body %q", routeName, req.Name)
+	}
+
+	if !constants.IsValidClusterName(req.LocalName) {
+		return fmt.Errorf("local names can only have [a-z] or [0-9] characters")
+	}
+
+	return nil
+}
 
 func isRemoteConfigured(remoteName string) bool {
 	// check remote configured for RBD mirroring

--- a/microceph/api/remote_test.go
+++ b/microceph/api/remote_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRemoteNameRejectsTraversalAndReservedNames(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "../state"},
+		{name: ".."},
+		{name: "remote/name"},
+		{name: "remote-name"},
+		{name: ""},
+		{name: "ceph"},
+		{name: "ganesha"},
+		{name: "radosgw"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRemoteName(tt.name)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestValidateRemoteNameAcceptsClusterNames(t *testing.T) {
+	validNames := []string{
+		"remote1",
+		"a",
+		"abc123",
+		"123",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 64 chars - should fail via regex
+	}
+	valid := validNames[:4]
+	tooLong := validNames[4]
+
+	for _, name := range valid {
+		err := validateRemoteName(name)
+		assert.NoError(t, err, "expected %q to be valid", name)
+	}
+
+	err := validateRemoteName(tooLong)
+	assert.Error(t, err, "expected 64-char name to be rejected")
+}
+
+func TestValidateRemoteImportRequest(t *testing.T) {
+	req := types.RemoteImportRequest{
+		Name:      "remote1",
+		LocalName: "local1",
+	}
+
+	err := validateRemoteImportRequest("remote1", req)
+	assert.NoError(t, err)
+
+	err = validateRemoteImportRequest("other", req)
+	assert.Error(t, err)
+
+	req.LocalName = "../local"
+	err = validateRemoteImportRequest("remote1", req)
+	assert.Error(t, err)
+}

--- a/microceph/ceph/configwriter.go
+++ b/microceph/ceph/configwriter.go
@@ -24,8 +24,21 @@ func (c *Config) GetPath() string {
 	return filepath.Join(c.configDir, c.configFile)
 }
 
+func (c *Config) validateConfigFile() error {
+	if !filepath.IsLocal(c.configFile) || filepath.Base(c.configFile) != c.configFile {
+		return fmt.Errorf("invalid config filename %q", c.configFile)
+	}
+
+	return nil
+}
+
 // WriteConfig writes the configuration file given a data bag and a filemode
 func (c *Config) WriteConfig(data map[string]any, mode int) error {
+	err := c.validateConfigFile()
+	if err != nil {
+		return err
+	}
+
 	fd, err := os.OpenFile(c.GetPath(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, os.FileMode(mode))
 	if err != nil {
 		return fmt.Errorf("Couldn't write %s: %w", c.configFile, err)

--- a/microceph/ceph/configwriter_test.go
+++ b/microceph/ceph/configwriter_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/microceph/microceph/constants"
@@ -187,6 +188,31 @@ func (s *configWriterSuite) TestWriteCephKeyring() {
 	data, err := os.ReadFile(keyring.GetPath())
 	assert.Equal(s.T(), nil, err)
 	assert.Contains(s.T(), string(data), "key = secretkey")
+}
+
+func (s *configWriterSuite) TestWriteConfigRejectsNonLocalFilenames() {
+	tests := []string{
+		"../escaped.keyring",
+		"/tmp/escaped.keyring",
+		"subdir/escaped.keyring",
+	}
+
+	for _, configFile := range tests {
+		s.T().Run(configFile, func(t *testing.T) {
+			keyring := NewCephKeyring(s.Tmp, configFile)
+			err := keyring.WriteConfig(
+				map[string]any{
+					"name": "client.admin",
+					"key":  "secretkey",
+				},
+				0644,
+			)
+			assert.Error(t, err)
+		})
+	}
+
+	_, err := os.Stat(filepath.Join(s.Tmp, "..", "escaped.keyring"))
+	assert.True(s.T(), os.IsNotExist(err))
 }
 
 // Test NFS Ganesha config writing

--- a/microceph/ceph/rbd_mirror.go
+++ b/microceph/ceph/rbd_mirror.go
@@ -706,6 +706,10 @@ func appendRemoteClusterArgs(args []string, cluster string, client string) []str
 
 // writeRemotePeerToken writes the provided string to a newly created token file.
 func writeRemotePeerToken(token string, remoteName string) error {
+	if !constants.IsValidClusterName(remoteName) {
+		return fmt.Errorf("remote names can only have [a-z] or [0-9] characters")
+	}
+
 	// create token Dir
 	tokenDirPath := filepath.Join(
 		constants.GetPathConst().ConfPath,
@@ -729,6 +733,7 @@ func writeRemotePeerToken(token string, remoteName string) error {
 		logger.Errorf("REPRBD: %s", ne.Error())
 		return ne
 	}
+	defer file.Close()
 
 	// write to file
 	_, err = file.WriteString(token)

--- a/microceph/constants/constants.go
+++ b/microceph/constants/constants.go
@@ -4,6 +4,7 @@ package constants
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 )
 
 // Constants for Size Constraints
@@ -89,5 +90,12 @@ func GetPathFileMode() PathFileMode {
 
 // Regexes
 
-// ClusterNameRegex is the regex for validating cluster names (a-z0-9)
-const ClusterNameRegex = "^[a-z0-9]+$"
+// ClusterNameRegex is the regex for validating cluster names (a-z0-9, max 63 chars)
+const ClusterNameRegex = "^[a-z0-9]{1,63}$"
+
+var clusterNameRegex = regexp.MustCompile(ClusterNameRegex)
+
+// IsValidClusterName reports whether name is a valid cluster name.
+func IsValidClusterName(name string) bool {
+	return clusterNameRegex.MatchString(name)
+}

--- a/microceph/database/remote_extras.go
+++ b/microceph/database/remote_extras.go
@@ -71,6 +71,20 @@ var GetRemoteDb = func(ctx context.Context, s mcTypes.State, name string) (types
 var DeleteRemoteDb = func(ctx context.Context, s mcTypes.State, remoteName string) error {
 	pathConst := constants.GetPathConst()
 
+	if !constants.IsValidClusterName(remoteName) {
+		return fmt.Errorf("invalid remote name %q", remoteName)
+	}
+
+	confFile := fmt.Sprintf("%s.conf", remoteName)
+	keyringFile := fmt.Sprintf("%s.keyring", remoteName)
+	if !filepath.IsLocal(confFile) || filepath.Base(confFile) != confFile {
+		return fmt.Errorf("invalid remote name %q", remoteName)
+	}
+
+	if !filepath.IsLocal(keyringFile) || filepath.Base(keyringFile) != keyringFile {
+		return fmt.Errorf("invalid remote name %q", remoteName)
+	}
+
 	err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// Remove record to database.
 		err := DeleteRemote(ctx, tx, remoteName)
@@ -85,12 +99,12 @@ var DeleteRemoteDb = func(ctx context.Context, s mcTypes.State, remoteName strin
 	}
 
 	// Remove remote conf and keyring files.
-	err = os.Remove(filepath.Join(pathConst.ConfPath, fmt.Sprintf("%s.conf", remoteName)))
+	err = os.Remove(filepath.Join(pathConst.ConfPath, confFile))
 	if err != nil {
 		return err
 	}
 
-	err = os.Remove(filepath.Join(pathConst.ConfPath, fmt.Sprintf("%s.keyring", remoteName)))
+	err = os.Remove(filepath.Join(pathConst.ConfPath, keyringFile))
 	if err != nil {
 		return err
 	}

--- a/tests/scripts/adoptutils.sh
+++ b/tests/scripts/adoptutils.sh
@@ -89,7 +89,7 @@ function adopt_cephadm() {
   # Admin Key
   key=$(lxc exec $name -- sh -c "cat /etc/ceph/ceph.client.admin.keyring" | grep key | cut -d " " -f 3)
 
-  lxc --quiet file push /home/runner/*.snap $name/root/
+  lxc --quiet file push "$HOME"/microceph_*.snap $name/root/
 
   # install microceph snap
   lxc exec $name -- sh -c "sudo snap install --dangerous /root/microceph_*.snap"


### PR DESCRIPTION
Fix CVE-2026-10720:

MicroCeph versions from the squid and tentacle track are vulnerable to a path traversal issue in the remote-import API. Holders of a trusted cluster mTLS certificate (such as enrolled cluster members) or join token can manipulate files in an imported remote cluster within the /var/snap/microceph confinement. This would allow daemon disruption and pollution of the cluster state.

CVSS 3.1

CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:L (Medium, 4.4)