### PR TITLE
feat: report flaky rate on active branches (CE144)

### DIFF
--- a/.github/scripts/ci_health_report/ci_health_report.py
+++ b/.github/scripts/ci_health_report/ci_health_report.py
@@ -2,14 +2,23 @@
 """
 CI Health Report
 
-Queries completed GitHub Actions workflow runs over a lookback window,
-calculates per-job failure rates, and posts a summary to a GitHub issue.
+Queries completed GitHub Actions workflow runs on the monitored branches over
+a lookback window, calculates per-job failure rates and the overall flaky
+rate, and posts a summary to a GitHub issue.
+
+Only runs on the monitored branches are counted. Code merged there has
+already passed the test suite, so any post-merge failure is a false positive
+(or a regression) - the "flaky rate" (CE144):
+
+  flaky rate = (jobs failing on monitored branches) / (total jobs)
 
 Required environment variables:
-  GH_TOKEN      - GitHub token with actions:read and issues:write
-  GH_REPO       - Repository in "owner/repo" format
-  REPORT_ISSUE  - Issue number to post the report to
-  LOOKBACK_DAYS - How many days back to look (default: 30)
+  GH_TOKEN        - GitHub token with actions:read and issues:write
+  GH_REPO         - Repository in "owner/repo" format
+  REPORT_ISSUE    - Issue number to post the report to
+  LOOKBACK_DAYS   - How many days back to look (default: 30)
+  TOP_JOBS        - Number of top failing jobs to highlight (default: 5)
+  REPORT_BRANCHES - Comma-separated branches to measure (e.g. "main,squid")
 """
 
 import os
@@ -19,9 +28,18 @@ from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 import urllib.request
 import urllib.error
+import urllib.parse
 import json
 
 COUNTED_CONCLUSIONS = {"success", "failure"}
+
+# Events that represent the branch's own code being tested. Excludes
+# pull_request so a fork PR whose head branch shares a monitored branch
+# name cannot leak into the stats.
+COUNTED_EVENTS = {"push", "schedule", "workflow_dispatch"}
+
+# CE144 acceptance criterion: flaky rate must stay below this (percent).
+FLAKY_RATE_THRESHOLD = 3.0
 
 
 def bucket_count(lookback_days):
@@ -101,14 +119,15 @@ def gh_get(token, path):
     return json.loads(_urlopen(req))
 
 
-def get_runs(token, repo, since):
-    """Return all completed workflow runs created on or after `since`."""
+def get_runs(token, repo, since, branch):
+    """Return all completed workflow runs on `branch` created on or after `since`."""
     runs = []
     page = 1
+    branch_q = urllib.parse.quote(branch, safe="")
     while True:
         data = gh_get(token, (
             f"/repos/{repo}/actions/runs"
-            f"?status=completed&created=>={since}&per_page=100&page={page}"
+            f"?status=completed&created=>={since}&branch={branch_q}&per_page=100&page={page}"
         ))
         batch = data.get("workflow_runs", [])
         if not batch:
@@ -119,13 +138,18 @@ def get_runs(token, repo, since):
 
 
 def get_jobs(token, repo, run_id):
-    """Return all jobs for a workflow run."""
+    """Return all jobs for a workflow run, including earlier re-run attempts.
+
+    `filter=all` matters for the flaky rate: the API default (`latest`) only
+    returns the newest attempt, so a flaky job that failed and was re-run to
+    green would disappear from the stats entirely.
+    """
     jobs = []
     page = 1
     while True:
         data = gh_get(token, (
             f"/repos/{repo}/actions/runs/{run_id}/jobs"
-            f"?per_page=100&page={page}"
+            f"?filter=all&per_page=100&page={page}"
         ))
         batch = data.get("jobs", [])
         if not batch:
@@ -146,8 +170,12 @@ def post_comment(token, repo, issue_number, body):
     _urlopen(req)
 
 
-def build_report(stats, lookback_days, top_n, now):
-    """Build the markdown report string from aggregated job stats."""
+def build_report(stats, branch_totals, lookback_days, top_n, now):
+    """Build the markdown report string from aggregated job stats.
+
+    `branch_totals` maps each monitored branch to {"runs", "failures"} job
+    totals and determines which branches are named in the report.
+    """
     # Sort by failure rate descending for the main table
     rows = sorted(stats.items(), key=lambda x: x[1]["failures"] / x[1]["runs"], reverse=True)
 
@@ -167,14 +195,29 @@ def build_report(stats, lookback_days, top_n, now):
 
     total_runs = sum(s["runs"] for s in stats.values())
     total_failures = sum(s["failures"] for s in stats.values())
-    overall_rate = (total_failures / total_runs * 100) if total_runs else 0.0
+    flaky_rate = (total_failures / total_runs * 100) if total_runs else 0.0
+    flaky_status = "✅" if flaky_rate < FLAKY_RATE_THRESHOLD else "❌"
 
+    branch_lines = []
+    for branch, t in branch_totals.items():
+        if t["runs"] == 0:
+            branch_lines.append(f"  - `{branch}`: no data")
+            continue
+        rate = t["failures"] / t["runs"] * 100
+        status = "✅" if rate < FLAKY_RATE_THRESHOLD else "❌"
+        failures_word = "failure" if t["failures"] == 1 else "failures"
+        runs_word = "job run" if t["runs"] == 1 else "job runs"
+        branch_lines.append(
+            f"  - `{branch}`: {rate:.1f}% {status} ({t['failures']} {failures_word} / {t['runs']} {runs_word})"
+        )
+
+    branches_label = ", ".join(branch_totals)
     timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     lines = [
         "## CI Health Report",
         "",
-        f"_Last {lookback_days} days — generated {timestamp}_",
+        f"_Last {lookback_days} days on {branches_label} — generated {timestamp}_",
         "",
         "### Job Failure Rates",
         "",
@@ -196,7 +239,9 @@ def build_report(stats, lookback_days, top_n, now):
         "",
         f"- **Total job runs:** {total_runs}",
         f"- **Total failures:** {total_failures}",
-        f"- **Overall failure rate:** {overall_rate:.1f}%",
+        f"- **Flaky rate:** {flaky_rate:.1f}% {flaky_status} (acceptance: < {FLAKY_RATE_THRESHOLD:.0f}%)",
+        "- **Per-branch flaky rate:**",
+        *branch_lines,
     ]
     return "\n".join(lines)
 
@@ -207,24 +252,34 @@ def main():
     issue_number = os.environ.get("REPORT_ISSUE", "")
     lookback_days_str = os.environ.get("LOOKBACK_DAYS", "")
     top_jobs_str = os.environ.get("TOP_JOBS", "")
+    branches_str = os.environ.get("REPORT_BRANCHES", "")
 
-    if not token or not repo or not issue_number or not lookback_days_str or not top_jobs_str:
-        print("Error: GH_TOKEN, GH_REPO, REPORT_ISSUE, LOOKBACK_DAYS, and TOP_JOBS must all be set.", file=sys.stderr)
+    if not token or not repo or not issue_number or not lookback_days_str or not top_jobs_str or not branches_str:
+        print("Error: GH_TOKEN, GH_REPO, REPORT_ISSUE, LOOKBACK_DAYS, TOP_JOBS, and REPORT_BRANCHES must all be set.", file=sys.stderr)
         sys.exit(1)
 
     lookback_days = int(lookback_days_str)
     top_jobs = int(top_jobs_str)
+    branches = [b.strip() for b in branches_str.split(",") if b.strip()]
+    if not branches:
+        print("Error: REPORT_BRANCHES contains no branch names.", file=sys.stderr)
+        sys.exit(1)
 
     now = datetime.now(timezone.utc)
     since_dt = now - timedelta(days=lookback_days)
     since = since_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
     num_buckets = bucket_count(lookback_days)
 
-    print(f"Fetching workflow runs since {since}...")
-    runs = get_runs(token, repo, since)
-    print(f"Found {len(runs)} completed runs.")
+    # (branch, run) pairs across all monitored branches
+    branch_runs = []
+    for branch in branches:
+        print(f"Fetching workflow runs on {branch} since {since}...")
+        runs = get_runs(token, repo, since, branch)
+        runs = [r for r in runs if r.get("event") in COUNTED_EVENTS]
+        print(f"Found {len(runs)} completed runs on {branch}.")
+        branch_runs.extend((branch, run) for run in runs)
 
-    if not runs:
+    if not branch_runs:
         print("No runs found. Skipping report.")
         return
 
@@ -236,10 +291,12 @@ def main():
         "failures": 0,
         "buckets": [{"runs": 0, "failures": 0} for _ in range(num_buckets)],
     })
+    # branch -> job-level totals, for the per-branch flaky rate breakdown
+    branch_totals = {branch: {"runs": 0, "failures": 0} for branch in branches}
     window_secs = (now - since_dt).total_seconds()
 
-    for i, run in enumerate(runs, start=1):
-        print(f"  Fetching jobs for run {i}/{len(runs)} (id={run['id']})...")
+    for i, (branch, run) in enumerate(branch_runs, start=1):
+        print(f"  Fetching jobs for run {i}/{len(branch_runs)} (id={run['id']})...")
         run_dt = datetime.fromisoformat(run["created_at"].replace("Z", "+00:00"))
         elapsed = (run_dt - since_dt).total_seconds()  # seconds from window start to this run
         # clamp: elapsed==window_secs would produce index num_buckets
@@ -254,15 +311,17 @@ def main():
             key = (run["name"], job["name"])
             stats[key]["runs"] += 1
             stats[key]["buckets"][bucket_idx]["runs"] += 1
+            branch_totals[branch]["runs"] += 1
             if conclusion == "failure":
                 stats[key]["failures"] += 1
                 stats[key]["buckets"][bucket_idx]["failures"] += 1
+                branch_totals[branch]["failures"] += 1
 
     if not stats:
         print("No job data collected. Skipping report.")
         return
 
-    report = build_report(stats, lookback_days, top_jobs, now)
+    report = build_report(stats, branch_totals, lookback_days, top_jobs, now)
 
     # Write to GitHub step summary if available
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/.github/scripts/ci_health_report/simulate_report.py
+++ b/.github/scripts/ci_health_report/simulate_report.py
@@ -52,8 +52,16 @@ for workflow, job, buckets in SCENARIOS:
     stats[key]["failures"] = sum(b["failures"] for b in buckets)
     stats[key]["buckets"]  = buckets
 
+# Synthetic per-branch split of the totals above (main carries most runs).
+total_runs     = sum(s["runs"]     for s in stats.values())
+total_failures = sum(s["failures"] for s in stats.values())
+branch_totals = {
+    "main":  {"runs": total_runs - 20, "failures": total_failures - 3},
+    "squid": {"runs": 20,              "failures": 3},
+}
+
 now = datetime(2026, 4, 7, 9, 0, 0, tzinfo=timezone.utc)
-report = build_report(stats, lookback_days=30, top_n=5, now=now)
+report = build_report(stats, branch_totals, lookback_days=30, top_n=5, now=now)
 
 output = sys.argv[1] if len(sys.argv) > 1 else "sample_report.md"
 with open(output, "w") as f:

--- a/.github/scripts/ci_health_report/test_ci_health_report.py
+++ b/.github/scripts/ci_health_report/test_ci_health_report.py
@@ -73,12 +73,71 @@ class _Tests(unittest.TestCase):
         stats[("Tests", "build")]["runs"] = 10
         stats[("Tests", "build")]["failures"] = 5
         stats[("Tests", "build")]["buckets"] = buckets
+        branch_totals = {"main": {"runs": 10, "failures": 5}}
         now = datetime(2026, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
-        report = build_report(stats, 30, 5, now)
+        report = build_report(stats, branch_totals, 30, 5, now)
         self.assertIn("| Workflow | Job | Runs | Failures | Rate | Trend |", report)
         self.assertIn("| Tests | build | 10 | 5 | 50.0% | ↑", report)
         self.assertIn("**Total job runs:** 10", report)
-        self.assertIn("**Overall failure rate:** 50.0%", report)
+        self.assertIn("**Flaky rate:** 50.0% ❌", report)
+
+    def test_build_report_flaky_rate_within_acceptance(self):
+        """build_report marks the flaky rate ✅ when below the 3% threshold."""
+        buckets = [{"runs": 50, "failures": 1}, {"runs": 50, "failures": 1}]
+        stats = defaultdict(lambda: {"runs": 0, "failures": 0, "buckets": []})
+        stats[("Tests", "build")]["runs"] = 100
+        stats[("Tests", "build")]["failures"] = 2
+        stats[("Tests", "build")]["buckets"] = buckets
+        branch_totals = {"main": {"runs": 100, "failures": 2}}
+        now = datetime(2026, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+        report = build_report(stats, branch_totals, 30, 5, now)
+        self.assertIn("**Flaky rate:** 2.0% ✅ (acceptance: < 3%)", report)
+
+    def test_build_report_per_branch_breakdown(self):
+        """build_report names monitored branches and lists per-branch flaky rates."""
+        buckets = [{"runs": 10, "failures": 2}, {"runs": 10, "failures": 2}]
+        stats = defaultdict(lambda: {"runs": 0, "failures": 0, "buckets": []})
+        stats[("Tests", "build")]["runs"] = 20
+        stats[("Tests", "build")]["failures"] = 4
+        stats[("Tests", "build")]["buckets"] = buckets
+        branch_totals = {
+            "main":  {"runs": 15, "failures": 3},
+            "squid": {"runs": 5,  "failures": 1},
+        }
+        now = datetime(2026, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+        report = build_report(stats, branch_totals, 30, 5, now)
+        self.assertIn("on main, squid —", report)
+        self.assertIn("- `main`: 20.0% ❌ (3 failures / 15 job runs)", report)
+        self.assertIn("- `squid`: 20.0% ❌ (1 failure / 5 job runs)", report)
+
+    def test_build_report_flaky_rate_at_threshold_fails(self):
+        """build_report marks exactly 3.0% as ❌ (acceptance is strictly below)."""
+        buckets = [{"runs": 50, "failures": 2}, {"runs": 50, "failures": 1}]
+        stats = defaultdict(lambda: {"runs": 0, "failures": 0, "buckets": []})
+        stats[("Tests", "build")]["runs"] = 100
+        stats[("Tests", "build")]["failures"] = 3
+        stats[("Tests", "build")]["buckets"] = buckets
+        branch_totals = {"main": {"runs": 100, "failures": 3}}
+        now = datetime(2026, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+        report = build_report(stats, branch_totals, 30, 5, now)
+        self.assertIn("**Flaky rate:** 3.0% ❌", report)
+        self.assertIn("- `main`: 3.0% ❌", report)
+
+    def test_build_report_zero_run_branch_shows_no_data(self):
+        """build_report renders 'no data' for a monitored branch with no runs."""
+        buckets = [{"runs": 5, "failures": 0}, {"runs": 5, "failures": 0}]
+        stats = defaultdict(lambda: {"runs": 0, "failures": 0, "buckets": []})
+        stats[("Tests", "build")]["runs"] = 10
+        stats[("Tests", "build")]["buckets"] = buckets
+        branch_totals = {
+            "main":  {"runs": 10, "failures": 0},
+            "squid": {"runs": 0,  "failures": 0},
+        }
+        now = datetime(2026, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+        report = build_report(stats, branch_totals, 30, 5, now)
+        self.assertIn("- `main`: 0.0% ✅", report)
+        self.assertIn("- `squid`: no data", report)
+        self.assertNotIn("- `squid`: 0.0%", report)
 
     def test_build_report_trend_suppressed_when_sparse(self):
         """build_report shows — for trend when runs < num_buckets * 2."""
@@ -88,8 +147,9 @@ class _Tests(unittest.TestCase):
         stats[("Nightly", "deploy")]["runs"] = 2
         stats[("Nightly", "deploy")]["failures"] = 1
         stats[("Nightly", "deploy")]["buckets"] = buckets
+        branch_totals = {"main": {"runs": 2, "failures": 1}}
         now = datetime(2026, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
-        report = build_report(stats, 30, 5, now)
+        report = build_report(stats, branch_totals, 30, 5, now)
         self.assertIn("| Nightly | deploy | 2 | 1 | 50.0% | — |", report)
 
     @patch("ci_health_report.post_comment")
@@ -97,17 +157,93 @@ class _Tests(unittest.TestCase):
     @patch("ci_health_report.get_runs")
     def test_skipped_and_cancelled_not_counted(self, mock_runs, mock_jobs, mock_comment):
         """skipped and cancelled conclusions are excluded from run and failure counts."""
-        mock_runs.return_value = [{"id": 1, "name": "Tests", "created_at": "2026-01-15T00:00:00Z"}]
+        mock_runs.return_value = [{"id": 1, "name": "Tests", "created_at": "2026-01-15T00:00:00Z", "event": "push"}]
         mock_jobs.return_value = [
             {"name": "build", "conclusion": "success"},
             {"name": "build", "conclusion": "failure"},
             {"name": "build", "conclusion": "skipped"},
             {"name": "build", "conclusion": "cancelled"},
         ]
-        with patch.dict("os.environ", {"GH_TOKEN": "tok", "GH_REPO": "o/r", "REPORT_ISSUE": "1", "LOOKBACK_DAYS": "30", "TOP_JOBS": "5"}):
+        env = {"GH_TOKEN": "tok", "GH_REPO": "o/r", "REPORT_ISSUE": "1",
+               "LOOKBACK_DAYS": "30", "TOP_JOBS": "5", "REPORT_BRANCHES": "main"}
+        with patch.dict("os.environ", env):
             main()
         report = mock_comment.call_args[0][3]
         self.assertIn("| Tests | build | 2 | 1 |", report)
+
+    @patch("ci_health_report.post_comment")
+    @patch("ci_health_report.get_jobs")
+    @patch("ci_health_report.get_runs")
+    def test_pull_request_runs_not_counted(self, mock_runs, mock_jobs, mock_comment):
+        """runs from events other than push/schedule/workflow_dispatch are excluded."""
+        mock_runs.return_value = [
+            {"id": 1, "name": "Tests", "created_at": "2026-01-15T00:00:00Z", "event": "push"},
+            {"id": 2, "name": "Tests", "created_at": "2026-01-15T00:00:00Z", "event": "pull_request"},
+        ]
+        mock_jobs.return_value = [{"name": "build", "conclusion": "failure"}]
+        env = {"GH_TOKEN": "tok", "GH_REPO": "o/r", "REPORT_ISSUE": "1",
+               "LOOKBACK_DAYS": "30", "TOP_JOBS": "5", "REPORT_BRANCHES": "main"}
+        with patch.dict("os.environ", env):
+            main()
+        report = mock_comment.call_args[0][3]
+        # Only the push run's single job is counted
+        self.assertIn("| Tests | build | 1 | 1 |", report)
+
+    @patch("ci_health_report.post_comment")
+    @patch("ci_health_report.get_jobs")
+    @patch("ci_health_report.get_runs")
+    def test_runs_fetched_per_monitored_branch(self, mock_runs, mock_jobs, mock_comment):
+        """main() queries each branch in REPORT_BRANCHES separately."""
+        mock_runs.return_value = [{"id": 1, "name": "Tests", "created_at": "2026-01-15T00:00:00Z", "event": "push"}]
+        mock_jobs.return_value = [{"name": "build", "conclusion": "success"}]
+        env = {"GH_TOKEN": "tok", "GH_REPO": "o/r", "REPORT_ISSUE": "1",
+               "LOOKBACK_DAYS": "30", "TOP_JOBS": "5", "REPORT_BRANCHES": "main, squid"}
+        with patch.dict("os.environ", env):
+            main()
+        branches_queried = [call.args[3] for call in mock_runs.call_args_list]
+        self.assertEqual(branches_queried, ["main", "squid"])
+
+    @patch("ci_health_report.gh_get")
+    def test_get_runs_filters_by_branch(self, mock_gh_get):
+        """get_runs passes the branch as a query parameter."""
+        mock_gh_get.return_value = {"workflow_runs": []}
+        ci_health_report.get_runs("tok", "o/r", "2026-01-01T00:00:00Z", "squid")
+        path = mock_gh_get.call_args[0][1]
+        self.assertIn("branch=squid", path)
+
+    @patch("ci_health_report.post_comment")
+    @patch("ci_health_report.get_jobs")
+    @patch("ci_health_report.get_runs")
+    def test_failures_attributed_to_correct_branch(self, mock_runs, mock_jobs, mock_comment):
+        """per-branch totals reflect the branch each run was fetched from."""
+        def runs_for(token, repo, since, branch):
+            run_id = {"main": 1, "squid": 2}[branch]
+            return [{"id": run_id, "name": "Tests", "created_at": "2026-01-15T00:00:00Z", "event": "push"}]
+
+        def jobs_for(token, repo, run_id):
+            return {
+                1: [{"name": "build", "conclusion": "success"}],
+                2: [{"name": "build", "conclusion": "failure"}],
+            }[run_id]
+
+        mock_runs.side_effect = runs_for
+        mock_jobs.side_effect = jobs_for
+        env = {"GH_TOKEN": "tok", "GH_REPO": "o/r", "REPORT_ISSUE": "1",
+               "LOOKBACK_DAYS": "30", "TOP_JOBS": "5", "REPORT_BRANCHES": "main,squid"}
+        with patch.dict("os.environ", env):
+            main()
+        report = mock_comment.call_args[0][3]
+        self.assertIn("- `main`: 0.0% ✅ (0 failures / 1 job run)", report)
+        self.assertIn("- `squid`: 100.0% ❌ (1 failure / 1 job run)", report)
+
+    def test_whitespace_only_branches_exits(self):
+        """a REPORT_BRANCHES value with no branch names is a configuration error."""
+        env = {"GH_TOKEN": "tok", "GH_REPO": "o/r", "REPORT_ISSUE": "1",
+               "LOOKBACK_DAYS": "30", "TOP_JOBS": "5", "REPORT_BRANCHES": " , "}
+        with patch.dict("os.environ", env):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci-health-report.yml
+++ b/.github/workflows/ci-health-report.yml
@@ -22,11 +22,16 @@ on:
         description: "Number of top failing jobs to highlight (default: 5)"
         required: false
         default: "5"
+      branches:
+        description: "Comma-separated branches to measure (default: main,squid)"
+        required: false
+        default: "main,squid"
 
 env:
   REPORT_ISSUE: ${{ inputs.report-issue || vars.CI_HEALTH_REPORT_ISSUE }}
   LOOKBACK_DAYS: ${{ inputs.lookback-days || vars.LOOKBACK_DAYS || '30' }}
   TOP_JOBS: ${{ inputs.top-jobs || vars.TOP_JOBS || '5' }}
+  REPORT_BRANCHES: ${{ inputs.branches || vars.REPORT_BRANCHES || 'main,squid' }}
 
 permissions:
   actions: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,10 @@
 name: Tests
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # Nightly full run on main for flaky rate data
 
 jobs:
   build-microceph:


### PR DESCRIPTION
# Description

Adjust CI health report to report per branch metrics.

Show overall flaky rate (failing jobs / total jobs) in the report summary, checked against the < 3% acceptance threshold from the CE144 spec.

Add a nightly scheduled full test run and workflow_dispatch trigger to tests.yml to provide steady data points on main.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

Added unit tests
See example: https://github.com/johnramsden/microceph/issues/1#issuecomment-4675625350

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change