### PR TITLE
ci(security): allowlist already-patched lxd govulncheck findings

### DIFF
--- a/.github/actions/govulncheck/action.yml
+++ b/.github/actions/govulncheck/action.yml
@@ -80,6 +80,44 @@ runs:
             | .finding.osv
           ] | unique[]
         ' "${OUTPUT_FILE}")
+
+        # Apply the documented allowlist. Some advisories (notably
+        # github.com/canonical/lxd) carry no fixed version in the Go
+        # vulnerability database, so govulncheck can never mark them resolved
+        # even when the pinned commit already contains the upstream fix. Each
+        # suppressed ID is justified in allowlist.txt.
+        allow_file="${GITHUB_ACTION_PATH}/allowlist.txt"
+        allow_ids=""
+        if [ -f "${allow_file}" ]; then
+          # Parse the allowlist into a clean ID list. 'sed' strips each line's
+          # '# justification' comment FIRST, so a GO-id mentioned inside prose
+          # can never be extracted; 'grep -oE' then pulls out the bare GO-ids.
+          # Sorting happens once below, just before 'comm'.
+          allow_ids=$(sed 's/#.*//' "${allow_file}" | grep -oE 'GO-[0-9]{4}-[0-9]+')
+        else
+          echo "::warning::govulncheck: allowlist file not found: ${allow_file}; no suppression applied"
+        fi
+
+        if [ -n "${allow_ids}" ] && [ -n "${called_ids}" ]; then
+          # 'comm' requires both inputs sorted. Sort each list once here and
+          # reuse the sorted copies for both set operations below, rather than
+          # re-sorting inline in every 'comm' call.
+          called_sorted=$(printf "%s\n" "${called_ids}" | sort -u)
+          allow_sorted=$(printf "%s\n" "${allow_ids}" | sort -u)
+
+          # comm -12 = lines common to both -> the IDs we are suppressing,
+          #            logged for transparency.
+          suppressed=$(comm -12 <(printf "%s\n" "${called_sorted}") <(printf "%s\n" "${allow_sorted}"))
+          if [ -n "${suppressed}" ]; then
+            echo "Suppressing allowlisted called-path vulnerabilities:"
+            printf "%s\n" "${suppressed}"
+          fi
+          # comm -23 = lines only in the first input -> called IDs that are NOT
+          #            allowlisted; these survive and drive the count and
+          #            pass/fail decision below.
+          called_ids=$(comm -23 <(printf "%s\n" "${called_sorted}") <(printf "%s\n" "${allow_sorted}"))
+        fi
+
         called=$(printf "%s\n" "${called_ids}" | grep -c . || true)
 
         {

--- a/.github/actions/govulncheck/allowlist.txt
+++ b/.github/actions/govulncheck/allowlist.txt
@@ -1,0 +1,32 @@
+# govulncheck called-path allowlist
+#
+# Vulnerability IDs listed here are excluded from the "called-path" count that
+# the govulncheck action reports (and that the daily cron job tracks as a GitHub
+# issue). Each entry must carry a justification.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# govulncheck has no native ignore mechanism, and the Go vulnerability database
+# entries for github.com/canonical/lxd are recorded as "introduced: 0" with NO
+# fixed version. LXD does not publish Go-module semver releases, so the Go DB
+# maintainers never mapped the upstream fixes (LXD 6.5.0 / 5.21.4 / 6.6 / 6.7)
+# onto a Go pseudo-version. As a result govulncheck flags every lxd version as
+# vulnerable and a dependency bump can never clear the finding -- even when the
+# pinned commit already contains the upstream fix.
+#
+# microceph pins lxd at commit d936c90d47cf (go.mod:
+# v0.0.0-20260224152359-d936c90d47cf), which IS the upstream fix commit for
+# GO-2026-4595 (PR #17738, Feb 2026). Being a later main-branch commit, it also
+# contains the three Nov-2025 fixes below. microceph additionally only imports
+# LXD shared utility packages (shared, shared/api, shared/logger, lxd/util,
+# lxd/db/query, lxd/resources); it does not run the LXD daemon Operations API,
+# storage-volume, LXD-UI, or certificate-listing code where the vulnerabilities
+# actually live.
+#
+# Format: one GO-id per line; text after '#' is an ignored justification comment.
+# Re-review whenever go.mod's lxd pin changes or the Go DB adds fixed versions.
+
+GO-2025-3999  # lxd: privilege escalation via WebSocket hijack in Operations API; fixed upstream 5.21.4/6.5.0, present in pinned d936c90d47cf; daemon-only path, not used by microceph.
+GO-2025-4003  # lxd: CSRF via client-cert auth in LXD-UI; fixed upstream 5.0.5/5.21.4/6.5.0, present in pinned d936c90d47cf; LXD-UI not used by microceph.
+GO-2025-4121  # lxd: local privesc via custom storage volumes; fixed upstream 4.0.11/5.21.5/6.6, present in pinned d936c90d47cf; storage-volume daemon path not used by microceph.
+GO-2026-4595  # lxd: non-recursive cert listing bypasses authz; fixed upstream by commit d936c90d47cf (6.7), which is the exact lxd pin in go.mod; cert endpoint not used by microceph.


### PR DESCRIPTION
# Description

The daily `govulncheck` scan (`vuln-scan-cron.yml`) opens a tracking issue
whenever it finds called-path vulnerabilities. It currently reports four, all in
`github.com/canonical/lxd`:

```
GO-2025-3999   Privilege escalation via WebSocket hijack in the Operations API
GO-2025-4003   CSRF when using client-certificate auth with the LXD-UI
GO-2025-4121   Local privilege escalation via custom storage volumes
GO-2026-4595   Non-recursive certificate listing bypasses per-object authz
```

These cannot be resolved by bumping the dependency, and they are already fixed in
the version MicroCeph pins. This PR adds a documented allowlist so the scan stops
flagging them, while still surfacing any genuinely new or unpatched vulnerability.

No supported silencing exists (https://github.com/golang/go/issues/61211), add custom mechanism

Fixes #774

## Why this is the correct fix (not a dependency bump)

**The Go vulnerability database has no fixed version for these advisories.** Each
entry is recorded as `introduced: 0` with **no `fixed` event**:

```
$ curl -s https://vuln.go.dev/ID/GO-2026-4595.json | jq '.affected[].ranges'
[ { "type": "SEMVER", "events": [ { "introduced": "0" } ] } ]
```

LXD does not publish Go-module semver releases, so the Go DB maintainers never
mapped the upstream fixes (LXD `6.5.0` / `5.21.4` / `6.6` / `6.7`) onto a Go
pseudo-version. As a result `govulncheck` treats **every** version of
`github.com/canonical/lxd` as vulnerable, and **no dependency bump can ever clear
the finding** — there is no patched version for the tool to compare against.

**MicroCeph already pins the patched code.** `microceph/go.mod` pins:

```
github.com/canonical/lxd v0.0.0-20260224152359-d936c90d47cf
```

Commit `d936c90d47cf` is the **upstream fix commit for GO-2026-4595**
([lxd PR #17738](https://github.com/canonical/lxd/pull/17738), Feb 2026). It is a
later `main`-branch commit than the three Nov-2025 fixes, so it already contains
all four upstream fixes:

| Advisory | Upstream fix | In pinned `d936c90d47cf`? |
|----------|--------------|---------------------------|
| GO-2025-3999 | lxd 5.21.4 / 6.5.0 (Nov 2025) | yes (ancestor of pin) |
| GO-2025-4003 | lxd 5.0.5 / 5.21.4 / 6.5.0 (Nov 2025) | yes (ancestor of pin) |
| GO-2025-4121 | lxd 4.0.11 / 5.21.5 / 6.6 (Nov 2025) | yes (ancestor of pin) |
| GO-2026-4595 | lxd 6.7, commit `d936c90d47cf` (Feb 2026) | yes (this is the pin) |

**MicroCeph does not use the vulnerable code paths.** It imports only LXD shared
utility packages — `shared`, `shared/api`, `shared/logger`, `shared/units`,
`shared/revert`, `lxd/util`, `lxd/db/query`, `lxd/resources` — never the LXD
daemon Operations API, LXD-UI, storage-volume, or certificate-listing endpoints
where the vulnerabilities actually live.

Because the advisories are already remediated in the pin and are not reachable in
MicroCeph, suppressing them with a justified allowlist is correct. `govulncheck`
has no native ignore mechanism, so the allowlist is applied in the composite
action that the scan jobs call.

## What changed

- **`.github/actions/govulncheck/allowlist.txt`** (new) — the four IDs, each with a
  per-ID justification plus a header explaining the missing-fixed-version
  situation and the `d936c90d47cf` pin. Includes a re-review trigger: revisit
  whenever the lxd pin changes or the Go DB adds fixed versions.
- **`.github/actions/govulncheck/action.yml`** — after computing the called-path
  IDs, the action reads the allowlist via `$GITHUB_ACTION_PATH`, subtracts the
  allowlisted IDs, and logs which were suppressed (`Suppressing allowlisted
  called-path vulnerabilities: ...`). A missing allowlist file emits a
  `::warning::` and applies no suppression (fail-safe: real findings are never
  hidden by an absent file).

A genuinely new or non-allowlisted called-path vulnerability is unaffected and
still fails the scan / reopens the tracking issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Clean code (code refactor, test updates; does not introduce functional changes)

## How has this been tested?

The change is CI-only (a Bash/`jq`/`comm` filter in a composite action); no Go
code is touched. The filtering logic was exercised against synthetic
`govulncheck` NDJSON:

- **Mixed input** (the four LXD findings + one non-allowlisted called vuln + one
  module-only finding): the four LXD IDs are suppressed, the non-allowlisted
  called vuln still surfaces (count `1`), and the module-only finding is correctly
  excluded by the existing `jq` reachability filter.
- **Real-world input** (only the four LXD findings): final called-count is `0`, so
  the cron job auto-closes the tracking issue and `fail-on-vuln` callers pass.
- **Missing allowlist file**: the `::warning::` branch fires and no suppression is
  applied, so real findings are never silently hidden.
- `action.yml` validated as well-formed YAML.

Success test: https://github.com/johnramsden/microceph/actions/runs/28202478778
Fail test (removed an allow): https://github.com/johnramsden/microceph/actions/runs/28202833740

### Reproduce the filter logic

The parse + set-difference is pure Bash, so it can be checked without
`govulncheck` or network. The script below mirrors the action's logic and
asserts that (a) a `GO-id` mentioned only in a justification comment is not
parsed as an entry, (b) allowlisted IDs are suppressed, and (c) a real,
non-allowlisted finding survives. It prints `PASS` and exits `0` on success:

```bash
#!/usr/bin/env bash
set -uo pipefail

workdir=$(mktemp -d)
trap 'rm -rf "${workdir}"' EXIT

# Miniature allowlist; the header prose mentions an unrelated GO-id on purpose.
cat > "${workdir}/allowlist.txt" <<'EOF'
# header prose referencing GO-9999-0001 must NOT be parsed as an entry
GO-2025-3999  # justified
GO-2026-4595  # justified
EOF

# Simulated called-path IDs: two allowlisted, one real, plus a duplicate.
called_ids=$'GO-2025-3999\nGO-2026-4595\nGO-2025-3999\nGO-2099-1234'

# --- identical to action.yml ---
allow_ids=$(sed 's/#.*//' "${workdir}/allowlist.txt" | grep -oE 'GO-[0-9]{4}-[0-9]+')
called_sorted=$(printf "%s\n" "${called_ids}" | sort -u)   # sort each list once
allow_sorted=$(printf "%s\n" "${allow_ids}" | sort -u)
suppressed=$(comm -12 <(printf "%s\n" "${called_sorted}") <(printf "%s\n" "${allow_sorted}"))
remaining=$(comm -23 <(printf "%s\n" "${called_sorted}") <(printf "%s\n" "${allow_sorted}"))
# --- end ---

[ "${allow_ids}"  = $'GO-2025-3999\nGO-2026-4595' ] || { echo "FAIL: prose GO-id leaked into allowlist"; exit 1; }
[ "${suppressed}" = $'GO-2025-3999\nGO-2026-4595' ] || { echo "FAIL: wrong suppressed set"; exit 1; }
[ "${remaining}"  = "GO-2099-1234" ]               || { echo "FAIL: real finding was dropped"; exit 1; }
echo "PASS: prose ignored, allowlisted IDs suppressed, real finding (GO-2099-1234) survives"
```

```
$ bash test_allowlist.sh
PASS: prose ignored, allowlisted IDs suppressed, real finding (GO-2099-1234) survives
```

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation (allowlist.txt header +
      per-ID justifications)
- [ ] added or updated HTML meta descriptions for any new or modified documentation pages (n/a)
- [ ] verified that page title and headings accurately represent page content for new or modified documentation pages (n/a)
- [ ] checked and added or updated relevant release notes (n/a — CI-only change)
- [x] added tests to verify effectiveness of this change (filter logic validated against synthetic scan output; see above)
