### PR TITLE
fix: retry GetStorage at the daemon /resources endpoint (disk-list TOCTOU)

### DIFF
--- a/microceph/api/resources.go
+++ b/microceph/api/resources.go
@@ -3,8 +3,9 @@ package api
 import (
 	"net/http"
 
-	"github.com/canonical/lxd/lxd/resources"
 	mcTypes "github.com/canonical/microcluster/v3/microcluster/types"
+
+	"github.com/canonical/microceph/microceph/ceph"
 )
 
 // /1.0/resources endpoint.
@@ -15,7 +16,11 @@ var resourcesCmd = mcTypes.Endpoint{
 }
 
 func cmdResourcesGet(s mcTypes.State, r *http.Request) mcTypes.Response {
-	storage, err := resources.GetStorage()
+	// GetStorage() can hit a transient TOCTOU race in /dev/disk/by-id (udevd
+	// renames a .#-prefixed temp entry out from under the enumeration). Retry
+	// so a `microceph disk list` / disk-remove verification poll does not fail
+	// on a disappearing entry. See ceph.GetStorageWithRetry.
+	storage, err := ceph.GetStorageWithRetry(ceph.StorageImpl{}.GetStorage)
 	if err != nil {
 		return mcTypes.InternalError(err)
 	}

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -910,28 +910,11 @@ func (m *OSDManager) validateAddOSDArgs(data types.DiskParameter, wal *types.Dis
 	return nil
 }
 
-// storageRetrySleepFunc is the sleep function used between GetStorage retry attempts.
-// It is a package-level variable so that tests can replace it with a no-op for fast
-// execution without changing retry logic.
-var storageRetrySleepFunc = time.Sleep
-
-// getStorageWithRetry calls GetStorage() up to 3 times, retrying on any error
+// getStorageWithRetry calls GetStorage() up to 3 times, retrying on any error.
+// It delegates to the shared GetStorageWithRetry helper so the daemon /resources
+// endpoint and the OSD add/remove paths share identical retry behaviour.
 func (m *OSDManager) getStorageWithRetry() (*api.ResourcesStorage, error) {
-	const maxAttempts = 3
-	var err error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		var storage *api.ResourcesStorage
-		storage, err = m.storage.GetStorage()
-		if err == nil {
-			return storage, nil
-		}
-		if attempt < maxAttempts {
-			logger.Warnf("Transient error enumerating storage (attempt %d/%d): %v; retrying",
-				attempt, maxAttempts, err)
-			storageRetrySleepFunc(time.Duration(attempt) * 500 * time.Millisecond)
-		}
-	}
-	return nil, err
+	return GetStorageWithRetry(m.storage.GetStorage)
 }
 
 func (m *OSDManager) stabilizeDevicePath(data *types.DiskParameter) (*api.ResourcesStorage, error) {

--- a/microceph/ceph/storage.go
+++ b/microceph/ceph/storage.go
@@ -1,9 +1,13 @@
 package ceph
 
 import (
+	"time"
+
 	"github.com/canonical/lxd/lxd/resources"
 	"github.com/canonical/lxd/shared/api"
+
 	"github.com/canonical/microceph/microceph/interfaces"
+	"github.com/canonical/microceph/microceph/logger"
 )
 
 // StorageImpl provides the default implementation of StorageInterface.
@@ -16,3 +20,40 @@ func (s StorageImpl) GetStorage() (*api.ResourcesStorage, error) {
 
 // Ensure StorageImpl implements StorageInterface.
 var _ interfaces.StorageInterface = StorageImpl{}
+
+// storageRetrySleepFunc is the sleep function used between GetStorage retry
+// attempts. It is a package-level variable so tests can replace it with a no-op
+// for fast execution without changing retry logic.
+var storageRetrySleepFunc = time.Sleep
+
+// GetStorageWithRetry calls a GetStorage function up to 3 times, retrying on
+// any error.
+//
+// LXD's resources.GetStorage() enumerates /dev/disk/by-id and can hit a
+// TOCTOU race: udevd atomically replaces symlinks by writing a .#-prefixed
+// temp entry then renaming it, so GetStorage() can see the .# entry in
+// readdir and then get ENOENT on lstat because the rename completed between
+// the two calls. The error is transient — the temp entry is gone by the next
+// attempt — so a short retry absorbs it.
+//
+// getStorageFunc is passed in (rather than calling resources.GetStorage()
+// directly) so the retry is unit-testable without touching the live block
+// device layer. storageRetrySleepFunc is the package-level
+// sleep func that tests can swap for a no-op.
+func GetStorageWithRetry(getStorageFunc func() (*api.ResourcesStorage, error)) (*api.ResourcesStorage, error) {
+	const maxAttempts = 3
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var storage *api.ResourcesStorage
+		storage, err = getStorageFunc()
+		if err == nil {
+			return storage, nil
+		}
+		if attempt < maxAttempts {
+			logger.Warnf("Transient error enumerating storage (attempt %d/%d): %v; retrying",
+				attempt, maxAttempts, err)
+			storageRetrySleepFunc(time.Duration(attempt) * 500 * time.Millisecond)
+		}
+	}
+	return nil, err
+}

--- a/microceph/ceph/storage_test.go
+++ b/microceph/ceph/storage_test.go
@@ -1,0 +1,82 @@
+package ceph
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetStorageWithRetryAbsorbsTransientError verifies that GetStorageWithRetry
+// retries on a transient error (the udevd TOCTOU race in /dev/disk/by-id) and
+// succeeds on the next attempt. This is the regression path for the daemon
+// /resources endpoint, which previously called resources.GetStorage() once with
+// no retry and failed when a .#-prefixed temp entry vanished mid-enumeration.
+func TestGetStorageWithRetryAbsorbsTransientError(t *testing.T) {
+	storageRetrySleepFunc = func(_ time.Duration) {}
+	t.Cleanup(func() { storageRetrySleepFunc = time.Sleep })
+
+	goodStorage := &api.ResourcesStorage{
+		Disks: []api.ResourcesStorageDisk{{Device: "sda"}},
+	}
+
+	calls := 0
+	getStorage := func() (*api.ResourcesStorage, error) {
+		calls++
+		if calls == 1 {
+			// Exact error shape from the CI failure: udevd renamed a
+			// .#scsi-... entry out from under LXD's EvalSymlinks call.
+			return nil, fmt.Errorf(`Failed to find "/dev/disk/by-id/.#scsi-0QEMU_QEMU_HARDDISK_lxd_microceph--dsl--rm1x--part1": lstat /dev/disk/by-id/.#scsi-0QEMU_QEMU_HARDDISK_lxd_microceph--dsl--rm1x--part1: no such file or directory`)
+		}
+		return goodStorage, nil
+	}
+
+	storage, err := GetStorageWithRetry(getStorage)
+
+	require.NoError(t, err)
+	assert.Equal(t, goodStorage, storage)
+	assert.Equal(t, 2, calls, "should succeed on the second attempt")
+}
+
+// TestGetStorageWithRetryExhausted verifies that the last error is returned
+// after all retry attempts are exhausted, and that GetStorage() is called
+// exactly maxAttempts (3) times before giving up.
+func TestGetStorageWithRetryExhausted(t *testing.T) {
+	storageRetrySleepFunc = func(_ time.Duration) {}
+	t.Cleanup(func() { storageRetrySleepFunc = time.Sleep })
+
+	persistentErr := fmt.Errorf("persistent enumeration failure")
+	calls := 0
+	getStorage := func() (*api.ResourcesStorage, error) {
+		calls++
+		return nil, persistentErr
+	}
+
+	storage, err := GetStorageWithRetry(getStorage)
+
+	require.Error(t, err)
+	assert.Equal(t, persistentErr, err)
+	assert.Nil(t, storage)
+	assert.Equal(t, 3, calls, "should retry up to maxAttempts (3) times")
+}
+
+// TestGetStorageWithRetryFirstTrySuccess verifies that no retry occurs when
+// GetStorage() succeeds immediately.
+func TestGetStorageWithRetryFirstTrySuccess(t *testing.T) {
+	goodStorage := &api.ResourcesStorage{Disks: []api.ResourcesStorageDisk{{Device: "sda"}}}
+
+	calls := 0
+	getStorage := func() (*api.ResourcesStorage, error) {
+		calls++
+		return goodStorage, nil
+	}
+
+	storage, err := GetStorageWithRetry(getStorage)
+
+	require.NoError(t, err)
+	assert.Equal(t, goodStorage, storage)
+	assert.Equal(t, 1, calls, "should not retry on success")
+}


### PR DESCRIPTION
# Description

The daemon `/1.0/resources` endpoint called LXD's `resources.GetStorage()` once with no retry. `GetStorage()` enumerates `/dev/disk/by-id` and hits a udevd TOCTOU race (a `.#`-prefixed temp symlink is seen in `readdir` then vanishes on `lstat`), so `microceph disk list` fails intermittently. This surfaced in the **DSL WAL-DB cleanup** suite (9.1% over 60 days, per #717):

```
failed listing storage devices: Failed to find "/dev/disk/by-id/.#scsi-...": lstat ...: no such file or directory
```

PR #739 added this retry to the OSD-add path but not to the daemon `/resources` endpoint that `disk list` hits directly. This extracts a shared `ceph.GetStorageWithRetry` helper (3 attempts, linear backoff), routes both `cmdResourcesGet` and `OSDManager.getStorageWithRetry` through it, and adds unit tests.

CI evidence: [run 27990395702](https://github.com/canonical/microceph/actions/runs/27990395702/job/82841425600).

Fixes #773
Fixes #779
Relates to #717

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

New `ceph/storage_test.go` tests inject the exact CI error string and assert the retry absorbs it (and that it exhausts/returns correctly); the existing OSD-path `TestGetStorageWithRetry` still passes after the delegation refactor.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [ ] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [ ] verified that page title and headings accurately represent page content for new or modified documentation pages
- [ ] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change
