### PR TITLE
ci: pin docs requirements and enable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot version updates.
+#
+# Dependabot updates dependencies that already declare a version; it never
+# *introduces* a pin. docs/requirements.txt is therefore pinned (==) so that it
+# falls under management; tests/robot/requirements.txt keeps its existing >=
+# floors, which Dependabot raises via versioning-strategy: increase below.
+version: 2
+updates:
+  # Go modules: microceph/go.mod (+ go.sum).
+  - package-ecosystem: gomod
+    directory: /microceph/
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    groups:
+      go-dependencies: # bundle all Go bumps into a single PR
+        patterns: ["*"]
+
+  # Python requirements.txt files (docs build + robot tests).
+  - package-ecosystem: pip
+    directories: # plural form takes a list (and globs); `directory` does not
+      - /docs # docs/requirements.txt
+      - /tests/robot # tests/robot/requirements.txt
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    groups:
+      python-requirements:
+        patterns: ["*"]
+
+  # microceph-orch: PEP 621 pyproject.toml + uv.lock (native uv ecosystem).
+  - package-ecosystem: uv
+    directory: /microceph-orch
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      orch-python:
+        patterns: ["*"]
+
+  # GitHub Actions referenced in .github/workflows/*.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      github-actions: # one PR for all action bumps
+        patterns: ["*"]

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: /microceph/
-    schedule:
-      interval: daily

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-canonical-sphinx[full]
-packaging
-sphinxcontrib-svg2pdfconverter[CairoSVG]
-sphinx-last-updated-by-git
-sphinx-sitemap
+canonical-sphinx[full]==0.6.0
+packaging==26.2
+sphinxcontrib-svg2pdfconverter[CairoSVG]==2.1.0
+sphinx-last-updated-by-git==0.3.8
+sphinx-sitemap==2.9.0


### PR DESCRIPTION
# Description

docs/requirements.txt declared its dependencies with no version at all, which makes the docs build non-reproducible and leaves them unmanageable by Dependabot (it only bumps an existing version constraint, it never introduces one). Pin them to their current released versions so the build is reproducible and they fall under automated updates. Existing version specifiers elsewhere (the robot test floors, the microceph-orch pyproject floors) are left unchanged.

Also move the Dependabot config from the repository root, where GitHub ignores it (so it never ran), to .github/dependabot.yml, and expand it from gomod-only to also cover the Python requirements (pip), the microceph-orch uv project, and GitHub Actions, on a weekly grouped schedule.

Fixes #785 

## Type of change

- Clean code (code refactor, test updates; does not introduce functional changes)

## How has this been tested?

Tested on fork:
* https://github.com/johnramsden/microceph/pull/9
* https://github.com/johnramsden/microceph/pull/10
* https://github.com/johnramsden/microceph/pull/11
* https://github.com/johnramsden/microceph/pull/12
