### PR TITLE
ci: add workflow_dispatch trigger to squid tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,8 @@
 name: Tests
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-microceph:


### PR DESCRIPTION
# Description

`squid`'s `tests.yml` only declares `on: [push, pull_request]`, so `workflow_dispatch` is rejected on this branch today. This adds `workflow_dispatch:` (converting the `on:` block to mapping form, matching `main`'s style) so the branch can be triggered manually or by an external dispatcher.

This is part of a two-PR change to give `squid` a periodic CI signal for the CI health dashboard's flaky-rate (CE144) calculation, which currently shows "no data" for this branch. The companion PR against `main` adds the scheduled dispatcher that relies on this trigger existing here.

No `schedule:` trigger is added directly — GitHub only fires `schedule:` on the default branch, so it would be dead config on `squid`.

## Type of change

- Clean code (code refactor, test updates; does not introduce functional changes)

## How has this been tested?

After merge, `gh workflow run tests.yml --repo canonical/microceph --ref squid` should be accepted (it currently fails with "workflow does not have a workflow_dispatch trigger"). Confirmed the resulting run is attributed as `event=workflow_dispatch`, `head_branch=squid` via:
```
gh api 'repos/canonical/microceph/actions/runs?branch=squid&event=workflow_dispatch&per_page=5' --jq '.workflow_runs[] | {name, event, head_branch, created_at}'
```

## Contributor checklist

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change
