### PR TITLE
ci: add scheduled dispatcher for stable branch tests

### DIFF
--- a/.github/workflows/scheduled-branch-tests.yml
+++ b/.github/workflows/scheduled-branch-tests.yml
@@ -1,0 +1,24 @@
+name: Scheduled branch tests
+
+# GitHub only fires cron on the default branch, so stable branches get
+# their periodic CI via dispatch from here. Dispatched runs count toward
+# the per-branch flaky rate (CE144) on the CI health dashboard.
+on:
+  schedule:
+    - cron: "0 2 * * *" # Nightly dispatch to stable branches for flaky rate data
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ref: [squid]         # future stable branches: add here
+    steps:
+      - name: Dispatch tests.yml on ${{ matrix.ref }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run tests.yml --ref "${{ matrix.ref }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
# Description

GitHub only fires `schedule:` triggers on the default branch, so `squid` (and any future stable branch) gets no periodic CI signal — the CI health dashboard's CE144 flaky-rate calculation counts only `push`/`schedule`/`workflow_dispatch` runs, and `squid` saw just 2 pushes in the last 60 days, so it usually shows "no data".

Adds `.github/workflows/scheduled-branch-tests.yml`: runs Mon/Thu 02:00 UTC (plus manual dispatch), fanning out `gh workflow run tests.yml --ref <branch>` per entry in a matrix (currently just `squid`; add future stable branches to the matrix as needed).

`workflow_dispatch` events triggered via the default `GITHUB_TOKEN` are exempt from the Actions recursion guard, so no PAT is required — only `permissions: actions: write`.

**Depends on #791** — that PR adds the `workflow_dispatch` trigger to `squid`'s `tests.yml`; dispatch from this workflow will fail with "workflow does not have a workflow_dispatch trigger" until it merges.

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

After both PRs merge: `gh workflow run scheduled-branch-tests.yml --repo canonical/microceph --ref main` should spawn a Tests run on `squid`. Confirmed via:
```
gh api 'repos/canonical/microceph/actions/runs?branch=squid&event=workflow_dispatch&per_page=5' --jq '.workflow_runs[] | {name, event, head_branch, created_at}'
```
No dashboard config changes needed — it already monitors both `main` and `squid`.

## Contributor checklist

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change
