### PR TITLE
docs: Display license info in footer

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -41,15 +41,26 @@
     <div class="copyright">
       {%- if hasdoc('copyright') %}
         {% trans path=pathto('copyright'), copyright=copyright|e -%}
-          <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}
+          <a href="{{ path }}">&copy; {{ copyright }} {{ author }}</a>
         {%- endtrans %}
       {%- else %}
         {% trans copyright=copyright|e -%}
-          Copyright &#169; {{ copyright }}
+          &copy; {{ copyright }} {{ author }}
         {%- endtrans %}
       {%- endif %}
     </div>
     {%- endif %}
+    {%- if license and license.name -%}
+      {%- if license.url -%}
+      <div class="license">
+        This page is licensed under <a href="{{ license.url }}">{{ license.name }}</a>
+      </div>
+      {%- else -%}
+      <div class="license">
+        This page is licensed under {{ license.name }}
+      </div>
+      {%- endif -%}
+    {%- endif -%}
 
     {# mod: removed "Made with" #}
 


### PR DESCRIPTION
# Description

This PR adds license info to the footer of the docs. Sphinx Stack v2.0 aligns the copyright statement in the footer with legal standards, but this change was neglected in #794.

Release notes prescription:

```
To incorporate this change in your documentation, add the license information to html_context in your conf.py file:

html_context = {
    "license": {
        "name": "CC-BY-SA-3.0",
        "url": "https://github.com/canonical/sphinx-docs-starter-pack/blob/main/LICENSE",
    },
}
```

## Type of change

- Documentation update (change to documentation only)

## How has this been tested?
Tested locally; build passes with no errors or warnings:

    make clean && make run: Builds and serves successfully
    make spelling: No spelling errors
    make woke: No inclusive language issues
    make linkcheck: No broken links

<img width="1850" height="941" alt="image" src="https://github.com/user-attachments/assets/037c1a67-943f-4511-986c-ccc0a4a10705" />


## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation 
- [ ] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643)) - N/A
- [ ] verified that page title and headings accurately represent page content for new or modified documentation pages - N/A
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change