### PR TITLE
fix: run all cases in shared-mode DSL suites

### DIFF
--- a/tests/scripts/test_dsl_functest.sh
+++ b/tests/scripts/test_dsl_functest.sh
@@ -2527,21 +2527,42 @@ function run_dsl_shared_suite() {
 
         dsl_reset_test_tracking
         dsl_set_suite_context "suite: $suite_name"
-        while read -r test_function; do
+
+        # Read the planned cases ONCE into an array. Iterating an array rather than a
+        # `while read` fed by a process substitution keeps each case's stdin free:
+        # dsl_run_test reaches the VM through `lxc exec`, which reads stdin to EOF and
+        # would otherwise consume the remaining case names from the process
+        # substitution, ending the loop after the first case. run_dsl_case guards the
+        # isolated path against the same hazard with `</dev/null`.
+        local -a shared_tests=()
+        local test_function
+        mapfile -t shared_tests < <(dsl_suite_shared_tests "$suite_name")
+
+        for test_function in "${shared_tests[@]}"; do
             [[ -n "$test_function" ]] || continue
             dsl_plan_test "$test_function"
-        done < <(dsl_suite_shared_tests "$suite_name")
+        done
 
         setup_dsl_test
         install_microceph_in_vm
 
         log "=== Running $title ==="
-        while read -r test_function; do
+        for test_function in "${shared_tests[@]}"; do
             [[ -n "$test_function" ]] || continue
             dsl_run_test "$test_function"
-        done < <(dsl_suite_shared_tests "$suite_name")
+        done
 
         show_dsl_final_status
+
+        # A shared suite that silently skipped planned cases must fail the job rather
+        # than report green. Failed cases already exit non-zero via `fail`; this guards
+        # the "planned but never executed" case so a future stdin regression is caught.
+        local not_run
+        not_run=$(dsl_count_not_run_tests)
+        if (( not_run > 0 )); then
+            log "ERROR: ${not_run} planned test(s) did not run in suite '${suite_name}'"
+            return 1
+        fi
     )
 }
 


### PR DESCRIPTION
# Description

Fixes #800

The shared DSL suites (`baseline`, `waldb_validation`, `waldb_dryrun`) run only their **first** test and still pass.

Each suite loops over a list of test names. The command that runs a test (`lxc exec`) eats the rest of the list, so after the first test the loop sees an empty list and stops. The skipped tests are counted as `Not run`, but only failed tests fail the job, so it stays green.

These suites have never run more than their first test on CI. The script was added in #668 (not wired into CI), then #699 wired it into CI and switched to this loop — so it has been broken since the first CI run, not a regression from a working state. The isolated suites (`provision`, `cleanup`, `consistency`) are fine.

Fix: give the loop the test list as a plain array instead of a stream the test command can eat. Also fail the suite when any test is skipped.

Before — a green `main` run ([#761 DSL functional tests](https://github.com/canonical/microceph/actions/runs/27431052884/job/81081347015), 2026-06-12) shows each shared suite running one case and passing:

```
[dsl-functest] Context: suite: baseline
[dsl-functest] Passed: 1  Skipped: 0  Failed: 0  Not run: 11
[dsl-functest] Context: suite: waldb_validation
[dsl-functest] Passed: 1  Skipped: 0  Failed: 0  Not run: 13
[dsl-functest] Context: suite: waldb_dryrun
[dsl-functest] Passed: 1  Skipped: 0  Failed: 0  Not run: 18
```

After:

```
[dsl-functest] Passed: 12  Skipped: 0  Failed: 0  Not run: 0   (baseline)
[dsl-functest] Passed: 14  Skipped: 0  Failed: 0  Not run: 0   (waldb_validation)
[dsl-functest] Passed: 19  Skipped: 0  Failed: 0  Not run: 0   (waldb_dryrun)
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

All 6 DSL suites run on host LXD — every planned case now executes (`Not run: 0`): baseline 12, validation 14, dryrun 19, provision 7, cleanup 3, consistency 10. Guard confirmed to fail the suite when a case is skipped.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas