### PR TITLE
backport: Support multiple subnets for public and cluster networks (squid)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -635,6 +635,57 @@ jobs:
         run: |
           sudo snap logs microceph -n 1000
 
+  multi-subnet-tests:
+    name: Multi subnet public and cluster networks
+    runs-on: ubuntu-22.04
+    needs: build-microceph
+    steps:
+      - name: Download snap
+        uses: actions/download-artifact@v4
+        with:
+          name: snaps
+          path: /home/runner
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Copy utils
+        run: cp tests/scripts/actionutils.sh $HOME
+
+      - name: Clear FORWARD firewall rules
+        run: ~/actionutils.sh cleaript
+
+      - name: Free disk
+        run: ~/actionutils.sh free_runner_disk
+
+      - name: Install dependencies
+        run: ~/actionutils.sh setup_lxd
+
+      - name: Create containers with loopback devices
+        run: ~/actionutils.sh create_containers public
+
+      - name: Install local microceph snap
+        run: ~/actionutils.sh install_multinode
+
+      - name: Bootstrap across two subnets with mon-ip on the second
+        run: ~/actionutils.sh bootstrap_multi_subnet_head
+
+      - name: Test public network list is rendered verbatim
+        run: ~/actionutils.sh test_multi_subnet_public_network
+
+      - name: Test cluster network list is stored
+        run: ~/actionutils.sh test_multi_subnet_cluster_network
+
+      - name: Test mon binds on the second listed subnet
+        run: ~/actionutils.sh test_multi_subnet_mon_binding
+
+      - name: Print logs for failure
+        if: failure()
+        run: |
+          sudo snap logs microceph -n 1000
+
   test-sequential-mon-host-refresh:
     name: Regression test for sequential join mon host refresh (issue #556)
     runs-on: ubuntu-22.04

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -210,6 +210,7 @@ Cephx
 Charmhub
 chmod
 CIDR
+CIDRs
 CLA
 CLI
 cmd

--- a/docs/how-to/configure-network-keys.rst
+++ b/docs/how-to/configure-network-keys.rst
@@ -15,6 +15,25 @@ The MicroCeph cluster configuration CLI supports setting, getting, resetting and
    * - cluster_network
      - Set this key to desired CIDR to configure cluster network
 
+.. note::
+
+   ``cluster_network`` accepts a comma-delimited list of CIDRs, matching
+   Ceph's native ``ceph.conf`` syntax. The same applies to
+   ``--public-network`` and ``--cluster-network`` at
+   :command:`microceph cluster bootstrap` and
+   :command:`microceph cluster adopt`. Each host in the cluster must
+   have an interface address on at least one of the listed subnets.
+
+   ``public_network`` is set at :command:`microceph cluster bootstrap` (or
+   :command:`microceph cluster adopt`) time and is read-only afterwards: it
+   cannot be changed with :command:`microceph cluster config set`.
+
+   For example, to span two cluster networks:
+
+   .. code-block:: none
+
+      $ sudo microceph cluster config set cluster_network 10.5.0.0/16,10.6.0.0/16
+
 1. Supported config keys can be configured using the 'set' command:
 
   .. code-block:: shell

--- a/docs/reference/commands/cluster.rst
+++ b/docs/reference/commands/cluster.rst
@@ -67,8 +67,8 @@ Flags:
    --availability-zone string Availability zone for failure domain distribution.
    --microceph-ip      string Network address microceph daemon binds to.
    --mon-ip            string Public address for bootstrapping ceph mon service.
-   --public-network    string Public network Ceph daemons bind to.
-   --cluster-network   string Cluster network Ceph daemons bind to.
+   --public-network    string Comma-delimited list of CIDRs for the Ceph public network (Ceph daemons bind addresses).
+   --cluster-network   string Comma-delimited list of CIDRs for the Ceph cluster network (OSD replication/recovery traffic).
 
 ``config``
 ----------

--- a/microceph/ceph/config.go
+++ b/microceph/ceph/config.go
@@ -324,9 +324,9 @@ func backwardCompatPubnet(ctx context.Context, s interfaces.StateInterface) erro
 
 	// do we have a public_network configured?
 	// if it is unset, the below will evaluate to the empty string
-	// and subsequently fail the net.ParseCIDR check
+	// and subsequently fail the common.ParseSubnetList check
 	pubNet := config["public_network"]
-	_, _, err = net.ParseCIDR(pubNet)
+	_, err = common.ParseSubnetList(pubNet)
 	if err == nil {
 		return nil
 	}

--- a/microceph/ceph/config_test.go
+++ b/microceph/ceph/config_test.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/canonical/microceph/microceph/common"
+	"os"
 	"testing"
 
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/microceph/microceph/interfaces"
-	"github.com/canonical/microceph/microceph/tests"
-
-	"github.com/canonical/microceph/microceph/api/types"
-	"github.com/canonical/microceph/microceph/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/microceph/microceph/api/types"
+	"github.com/canonical/microceph/microceph/common"
+	"github.com/canonical/microceph/microceph/constants"
+	"github.com/canonical/microceph/microceph/interfaces"
+	"github.com/canonical/microceph/microceph/mocks"
+	"github.com/canonical/microceph/microceph/tests"
 )
 
 type configSuite struct {
@@ -254,4 +256,59 @@ func (s *configSuite) TestBackwardCompatPubnetInsertFails() {
 
 	err := backwardCompatPubnet(context.Background(), s.newMockState())
 	assert.ErrorIs(s.T(), err, dbErr)
+}
+
+// TestBackwardCompatPubnetMonitorsPresentPublicNetMultiSubnet verifies that the
+// shim treats a stored comma-delimited multi-subnet public_network as valid
+// and does not re-detect / overwrite.
+func (s *configSuite) TestBackwardCompatPubnetMonitorsPresentPublicNetMultiSubnet() {
+	s.overrideGetMonitorCount(1, nil)
+
+	origFetch := fetchConfigDb
+	s.T().Cleanup(func() { fetchConfigDb = origFetch })
+	fetchConfigDb = func(_ context.Context, _ interfaces.StateInterface) (map[string]string, error) {
+		return map[string]string{"public_network": "10.0.0.0/24,172.16.0.0/16"}, nil
+	}
+
+	net := mocks.NewNetworkIntf(s.T())
+	origNetwork := common.Network
+	s.T().Cleanup(func() { common.Network = origNetwork })
+	common.Network = net
+
+	err := backwardCompatPubnet(context.Background(), nil)
+	assert.NoError(s.T(), err)
+	net.AssertNotCalled(s.T(), "FindNetworkAddress")
+}
+
+// TestCephConfFileRendersMultiSubnetPublicNetwork verifies that a
+// comma-delimited public_network value is written verbatim into the rendered
+// ceph.conf. It exercises CephConfFile.Render, which renders via the same
+// NewCephConfig template that UpdateConfig uses.
+func (s *configSuite) TestCephConfFileRendersMultiSubnetPublicNetwork() {
+	s.CopyCephConfigs()
+
+	// Redirect GetPathConst to the temp dir that CopyCephConfigs prepared.
+	origGetPathConst := constants.GetPathConst
+	s.T().Cleanup(func() { constants.GetPathConst = origGetPathConst })
+	constants.GetPathConst = func() constants.PathConst {
+		return constants.PathConst{
+			ConfPath: s.Tmp + "/SNAP_DATA/conf",
+		}
+	}
+
+	const multiSubnet = "10.0.0.0/24,172.16.0.0/16"
+
+	ccf := CephConfFile{
+		FsID:     "aabbccdd-1234-5678-abcd-000000000000",
+		RunDir:   "/tmp/testrun",
+		Monitors: []string{"1.1.1.1"},
+		PubNet:   multiSubnet,
+	}
+	err := ccf.Render(constants.CephConfFileName)
+	assert.NoError(s.T(), err)
+
+	// Read back the rendered file and assert the multi-subnet value is present verbatim.
+	rendered, err := os.ReadFile(constants.GetPathConst().ConfPath + "/" + constants.CephConfFileName)
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), string(rendered), "public_network = "+multiSubnet)
 }

--- a/microceph/cmd/microceph/cluster_adopt.go
+++ b/microceph/cmd/microceph/cluster_adopt.go
@@ -41,8 +41,8 @@ func (c *cmdClusterAdopt) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagMicrocephIP, "microceph-ip", "", "Ceph cluster fsid")
 	cmd.Flags().StringVar(&c.flagFSID, "fsid", "", "Ceph cluster fsid")
 	cmd.Flags().StringSliceVar(&c.flagMonHosts, "mon-hosts", []string{}, "Comma separated list of mon addresses")
-	cmd.Flags().StringVar(&c.flagPubNet, "public-network", "", "Public network Ceph daemons bind to")
-	cmd.Flags().StringVar(&c.flagClusterNet, "cluster-network", "", "Cluster network Ceph daemons bind to")
+	cmd.Flags().StringVar(&c.flagPubNet, "public-network", "", "Comma-delimited list of CIDRs for the Ceph public network")
+	cmd.Flags().StringVar(&c.flagClusterNet, "cluster-network", "", "Comma-delimited list of CIDRs for the Ceph cluster network")
 	cmd.Flags().StringVar(&c.flagAvailabilityZone, "availability-zone", "", "Availability zone for failure domain distribution.")
 	return cmd
 }

--- a/microceph/cmd/microceph/cluster_bootstrap.go
+++ b/microceph/cmd/microceph/cluster_bootstrap.go
@@ -36,8 +36,8 @@ func (c *cmdClusterBootstrap) Command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagMicroCephIp, "microceph-ip", "", "Network address microceph daemon binds to.")
 	cmd.Flags().StringVar(&c.flagAvailabilityZone, "availability-zone", "", "Availability zone for failure domain distribution.")
 	cmd.Flags().StringVar(&c.flagMonIp, "mon-ip", "", "Public address for bootstrapping ceph mon service.")
-	cmd.Flags().StringVar(&c.flagPubNet, "public-network", "", "Public network Ceph daemons bind to.")
-	cmd.Flags().StringVar(&c.flagClusterNet, "cluster-network", "", "Cluster network Ceph daemons bind to.")
+	cmd.Flags().StringVar(&c.flagPubNet, "public-network", "", "Comma-delimited list of CIDRs for the Ceph public network (Ceph daemons bind addresses).")
+	cmd.Flags().StringVar(&c.flagClusterNet, "cluster-network", "", "Comma-delimited list of CIDRs for the Ceph cluster network (OSD replication/recovery traffic).")
 	cmd.Flags().BoolVar(&c.flagV2Only, "v2-only", false, "Whether to support V2 messenger only or both V1 and V2")
 	return cmd
 }

--- a/microceph/cmd/microcephd/bootstrapper_test.go
+++ b/microceph/cmd/microcephd/bootstrapper_test.go
@@ -167,3 +167,59 @@ func (s *bootstrapSuite) TestSimpleBootstrapNoParamsV2Only() {
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), expectedMonIP, bootstrapData.MonIp)
 }
+
+// Case 5: A multi-subnet public_network where mon-ip matches the second listed subnet.
+func (s *bootstrapSuite) TestSimpleBootstrapMonIpInSecondListedPubNet() {
+	r := mocks.NewRunner(s.T())
+	nw := mocks.NewNetworkIntf(s.T())
+
+	nw.On("FindNetworkAddress", "10.0.0.5").Return("10.0.0.0/24", nil)
+	nw.On("IsIpOnSubnet", "10.0.0.5", "192.168.1.0/24,10.0.0.0/24").Return(true)
+	nw.On("FindIpOnSubnet", "10.99.0.0/24").Return("10.99.0.7", nil)
+
+	common.ProcessExec = r
+	common.Network = nw
+	bootstrapData := common.BootstrapConfig{
+		MonIp:      "10.0.0.5",
+		PublicNet:  "192.168.1.0/24,10.0.0.0/24",
+		ClusterNet: "10.99.0.0/24",
+	}
+
+	err := PopulateDefaultNetworkParams(s.TestStateInterface, &bootstrapData.MonIp, &bootstrapData.PublicNet, &bootstrapData.ClusterNet)
+	assert.NoError(s.T(), err)
+
+	err = ValidateNetworkParams(s.TestStateInterface, &bootstrapData.MonIp, &bootstrapData.PublicNet, &bootstrapData.ClusterNet)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), cmp.Equal(bootstrapData, common.BootstrapConfig{
+		MonIp:      "10.0.0.5",
+		PublicNet:  "192.168.1.0/24,10.0.0.0/24",
+		ClusterNet: "10.99.0.0/24",
+	}))
+}
+
+// Case 6: Only multi-subnet public_network provided; mon-ip is deduced from the first listed subnet that has a local IP.
+func (s *bootstrapSuite) TestSimpleBootstrapMultiSubnetPubNetDeducesMonIP() {
+	r := mocks.NewRunner(s.T())
+	nw := mocks.NewNetworkIntf(s.T())
+
+	nw.On("FindIpOnSubnet", "192.168.1.0/24,10.0.0.0/24").Return("10.0.0.5", nil)
+	nw.On("IsIpOnSubnet", "10.0.0.5", "192.168.1.0/24,10.0.0.0/24").Return(true)
+	nw.On("FindNetworkAddress", "10.0.0.5").Return("10.0.0.0/24", nil)
+
+	common.ProcessExec = r
+	common.Network = nw
+	bootstrapData := common.BootstrapConfig{
+		PublicNet: "192.168.1.0/24,10.0.0.0/24",
+	}
+
+	err := PopulateDefaultNetworkParams(s.TestStateInterface, &bootstrapData.MonIp, &bootstrapData.PublicNet, &bootstrapData.ClusterNet)
+	assert.NoError(s.T(), err)
+
+	err = ValidateNetworkParams(s.TestStateInterface, &bootstrapData.MonIp, &bootstrapData.PublicNet, &bootstrapData.ClusterNet)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), cmp.Equal(bootstrapData, common.BootstrapConfig{
+		MonIp:      "10.0.0.5",
+		PublicNet:  "192.168.1.0/24,10.0.0.0/24",
+		ClusterNet: "192.168.1.0/24,10.0.0.0/24",
+	}))
+}

--- a/microceph/common/network.go
+++ b/microceph/common/network.go
@@ -8,10 +8,13 @@ import (
 	"github.com/canonical/microceph/microceph/logger"
 )
 
+// NetworkIntf defines the network helper operations available to MicroCeph
+// components. Implementations are injectable for testing via the cidrLister
+// mechanism.
 type NetworkIntf interface {
-	FindIpOnSubnet(subnet string) (string, error)
+	FindIpOnSubnet(subnets string) (string, error)
 	FindNetworkAddress(address string) (string, error)
-	IsIpOnSubnet(address string, subnet string) bool
+	IsIpOnSubnet(address string, subnets string) bool
 	FindIpForPeers(peers []string) (string, error)
 }
 
@@ -48,10 +51,11 @@ type networkImpl struct {
 }
 
 // FindIpOnSubnet returns the first local interface address that lies within
-// the given CIDR.
-func (nwi *networkImpl) FindIpOnSubnet(subnet string) (string, error) {
-	subnet = strings.TrimSpace(subnet)
-	_, sn, err := net.ParseCIDR(subnet)
+// any subnet in the comma-delimited CIDR list. A single CIDR is accepted as a
+// one-element list. Subnets are iterated in input order, so the first listed
+// subnet that has a local-IP match wins.
+func (nwi *networkImpl) FindIpOnSubnet(subnets string) (string, error) {
+	parsed, err := ParseSubnetList(subnets)
 	if err != nil {
 		return "", err
 	}
@@ -61,15 +65,17 @@ func (nwi *networkImpl) FindIpOnSubnet(subnet string) (string, error) {
 		return "", err
 	}
 
-	for _, ipNet := range cidrs {
-		if !ipNet.IP.IsGlobalUnicast() {
-			continue
-		}
-		if sn.Contains(ipNet.IP) {
-			return ipNet.IP.String(), nil
+	for _, sn := range parsed {
+		for _, ipNet := range cidrs {
+			if !ipNet.IP.IsGlobalUnicast() {
+				continue
+			}
+			if sn.Contains(ipNet.IP) {
+				return ipNet.IP.String(), nil
+			}
 		}
 	}
-	return "", fmt.Errorf("no IP belongs to provided subnet %s", subnet)
+	return "", fmt.Errorf("no local IP belongs to any of the listed subnets [%s]", subnets)
 }
 
 // FindNetworkAddress returns the local CIDR that owns the given IP.
@@ -100,22 +106,27 @@ func (nwi *networkImpl) FindNetworkAddress(address string) (string, error) {
 	return "", fmt.Errorf("provided mon-ip (%s) does not belong to any suitable network: %v", monIP, nw)
 }
 
-// IsIpOnSubnet checks if the provided ip address is on the provided subnet.
-func (nwi *networkImpl) IsIpOnSubnet(address string, subnet string) bool {
+// IsIpOnSubnet reports whether address lies within any subnet in the
+// comma-delimited CIDR list. A single CIDR is accepted as a one-element list.
+// Returns false (not an error) on parse failure.
+func (nwi *networkImpl) IsIpOnSubnet(address string, subnets string) bool {
 	address = strings.TrimSpace(address)
-	subnet = strings.TrimSpace(subnet)
-
 	ip := net.ParseIP(address)
 	if ip == nil {
 		return false
 	}
 
-	_, sn, err := net.ParseCIDR(subnet)
+	parsed, err := ParseSubnetList(subnets)
 	if err != nil {
 		return false
 	}
 
-	return sn.Contains(ip)
+	for _, sn := range parsed {
+		if sn.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // FindIpForPeers returns the first local interface address whose subnet
@@ -154,6 +165,31 @@ func (nwi *networkImpl) FindIpForPeers(peers []string) (string, error) {
 	return "", fmt.Errorf("no local interface shares a subnet with any of the cluster peers %v", peers)
 }
 
+// ParseSubnetList parses a comma-delimited CIDR list. Whitespace around
+// entries is trimmed. Empty input and empty entries (e.g. trailing comma,
+// "a,,b") are rejected. Order is preserved. No deduplication.
+func ParseSubnetList(s string) ([]*net.IPNet, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("empty subnet list")
+	}
+
+	parts := strings.Split(s, ",")
+	nets := make([]*net.IPNet, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("empty entry in subnet list %q", s)
+		}
+		_, n, err := net.ParseCIDR(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q in subnet list: %w", part, err)
+		}
+		nets = append(nets, n)
+	}
+	return nets, nil
+}
+
 // parsePeerIP extracts the IP from a bare-IP or "ip:port" string.
 func parsePeerIP(peer string) (net.IP, error) {
 	peer = strings.TrimSpace(peer)
@@ -171,4 +207,6 @@ func parsePeerIP(peer string) (net.IP, error) {
 	return ip, nil
 }
 
+// Network is the package-level NetworkIntf used by MicroCeph components;
+// tests override it with a mock.
 var Network NetworkIntf = &networkImpl{lister: hostCIDRs}

--- a/microceph/common/network_test.go
+++ b/microceph/common/network_test.go
@@ -122,35 +122,6 @@ func (s *NetworkSuite) TestFindIpForPeers_ListerError() {
 	s.Contains(err.Error(), "boom")
 }
 
-// --- FindIpOnSubnet ---
-
-func (s *NetworkSuite) TestFindIpOnSubnet_Match() {
-	nw := &networkImpl{
-		lister: staticLister(
-			mustCIDR("172.17.0.1/16"),
-			mustCIDR("192.168.1.50/24"),
-		),
-	}
-
-	ip, err := nw.FindIpOnSubnet("192.168.1.0/24")
-	s.Require().NoError(err)
-	s.Equal("192.168.1.50", ip)
-}
-
-func (s *NetworkSuite) TestFindIpOnSubnet_NoMatch() {
-	nw := &networkImpl{lister: staticLister(mustCIDR("172.17.0.1/16"))}
-
-	_, err := nw.FindIpOnSubnet("192.168.1.0/24")
-	s.Require().Error(err)
-}
-
-func (s *NetworkSuite) TestFindIpOnSubnet_InvalidCIDR() {
-	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
-
-	_, err := nw.FindIpOnSubnet("garbage")
-	s.Require().Error(err)
-}
-
 // --- FindNetworkAddress ---
 
 func (s *NetworkSuite) TestFindNetworkAddress_Match() {
@@ -175,13 +146,165 @@ func (s *NetworkSuite) TestFindNetworkAddress_InvalidIP() {
 	s.Require().Error(err)
 }
 
+// --- ParseSubnetList ---
+
+func (s *NetworkSuite) TestParseSubnetList_Single() {
+	nets, err := ParseSubnetList("10.0.0.0/24")
+	s.Require().NoError(err)
+	s.Require().Len(nets, 1)
+	s.Equal("10.0.0.0/24", nets[0].String())
+}
+
+func (s *NetworkSuite) TestParseSubnetList_Multiple() {
+	nets, err := ParseSubnetList("10.0.0.0/24,172.16.0.0/16")
+	s.Require().NoError(err)
+	s.Require().Len(nets, 2)
+	s.Equal("10.0.0.0/24", nets[0].String())
+	s.Equal("172.16.0.0/16", nets[1].String())
+}
+
+func (s *NetworkSuite) TestParseSubnetList_TrimsWhitespace() {
+	nets, err := ParseSubnetList("  10.0.0.0/24 ,  172.16.0.0/16 ")
+	s.Require().NoError(err)
+	s.Require().Len(nets, 2)
+	s.Equal("10.0.0.0/24", nets[0].String())
+	s.Equal("172.16.0.0/16", nets[1].String())
+}
+
+func (s *NetworkSuite) TestParseSubnetList_MixedFamilies() {
+	nets, err := ParseSubnetList("10.0.0.0/24,2001:db8::/64")
+	s.Require().NoError(err)
+	s.Require().Len(nets, 2)
+	s.Equal("10.0.0.0/24", nets[0].String())
+	s.Equal("2001:db8::/64", nets[1].String())
+}
+
+func (s *NetworkSuite) TestParseSubnetList_PreservesOrder() {
+	nets, err := ParseSubnetList("172.16.0.0/16,10.0.0.0/24,192.168.1.0/24")
+	s.Require().NoError(err)
+	s.Require().Len(nets, 3)
+	s.Equal("172.16.0.0/16", nets[0].String())
+	s.Equal("10.0.0.0/24", nets[1].String())
+	s.Equal("192.168.1.0/24", nets[2].String())
+}
+
+func (s *NetworkSuite) TestParseSubnetList_NoDeduplication() {
+	nets, err := ParseSubnetList("10.0.0.0/24,10.0.0.0/24")
+	s.Require().NoError(err)
+	s.Require().Len(nets, 2)
+}
+
+func (s *NetworkSuite) TestParseSubnetList_EmptyInput() {
+	_, err := ParseSubnetList("")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "empty subnet list")
+}
+
+func (s *NetworkSuite) TestParseSubnetList_WhitespaceOnly() {
+	_, err := ParseSubnetList("   ")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "empty subnet list")
+}
+
+func (s *NetworkSuite) TestParseSubnetList_TrailingComma() {
+	_, err := ParseSubnetList("10.0.0.0/24,")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "empty entry")
+}
+
+func (s *NetworkSuite) TestParseSubnetList_DoubleComma() {
+	_, err := ParseSubnetList("10.0.0.0/24,,172.16.0.0/16")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "empty entry")
+}
+
+func (s *NetworkSuite) TestParseSubnetList_InvalidCIDR() {
+	_, err := ParseSubnetList("10.0.0.0/24,garbage")
+	s.Require().Error(err)
+	s.Contains(err.Error(), `"garbage"`)
+}
+
+// --- FindIpOnSubnet ---
+
+func (s *NetworkSuite) TestFindIpOnSubnet_SingleEntryParity() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	ip, err := nw.FindIpOnSubnet("192.168.1.0/24")
+	s.Require().NoError(err)
+	s.Equal("192.168.1.50", ip)
+}
+
+// First listed subnet that has a local IP wins.
+func (s *NetworkSuite) TestFindIpOnSubnet_FirstListedMatchWins() {
+	nw := &networkImpl{
+		lister: staticLister(
+			mustCIDR("10.0.0.5/24"),     // matches subnet #2
+			mustCIDR("192.168.1.50/24"), // matches subnet #3
+		),
+	}
+
+	ip, err := nw.FindIpOnSubnet("172.16.0.0/16,10.0.0.0/24,192.168.1.0/24")
+	s.Require().NoError(err)
+	s.Equal("10.0.0.5", ip)
+}
+
+func (s *NetworkSuite) TestFindIpOnSubnet_MixedFamiliesIPv6Match() {
+	nw := &networkImpl{
+		lister: staticLister(
+			mustCIDR("2001:db8::5/64"),
+		),
+	}
+
+	ip, err := nw.FindIpOnSubnet("10.0.0.0/24,2001:db8::/64")
+	s.Require().NoError(err)
+	s.Equal("2001:db8::5", ip)
+}
+
+func (s *NetworkSuite) TestFindIpOnSubnet_NoMatch() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("172.17.0.1/16"))}
+
+	_, err := nw.FindIpOnSubnet("10.0.0.0/24,192.168.1.0/24")
+	s.Require().Error(err)
+	s.Contains(err.Error(), "no local IP")
+	s.Contains(err.Error(), "10.0.0.0/24")
+	s.Contains(err.Error(), "192.168.1.0/24")
+}
+
+func (s *NetworkSuite) TestFindIpOnSubnet_InvalidList() {
+	nw := &networkImpl{lister: staticLister(mustCIDR("192.168.1.50/24"))}
+
+	_, err := nw.FindIpOnSubnet("garbage")
+	s.Require().Error(err)
+}
+
 // --- IsIpOnSubnet ---
 
-func (s *NetworkSuite) TestIsIpOnSubnet() {
+func (s *NetworkSuite) TestIsIpOnSubnet_SingleEntryMatch() {
 	nw := &networkImpl{}
-
 	s.True(nw.IsIpOnSubnet("192.168.1.10", "192.168.1.0/24"))
-	s.False(nw.IsIpOnSubnet("10.0.0.1", "192.168.1.0/24"))
-	s.False(nw.IsIpOnSubnet("garbage", "192.168.1.0/24"))
+}
+
+func (s *NetworkSuite) TestIsIpOnSubnet_SecondEntryMatch() {
+	nw := &networkImpl{}
+	s.True(nw.IsIpOnSubnet("10.0.0.5", "192.168.1.0/24,10.0.0.0/24"))
+}
+
+func (s *NetworkSuite) TestIsIpOnSubnet_NoMatch() {
+	nw := &networkImpl{}
+	s.False(nw.IsIpOnSubnet("172.16.0.1", "192.168.1.0/24,10.0.0.0/24"))
+}
+
+func (s *NetworkSuite) TestIsIpOnSubnet_InvalidList() {
+	nw := &networkImpl{}
 	s.False(nw.IsIpOnSubnet("192.168.1.10", "garbage"))
+}
+
+func (s *NetworkSuite) TestIsIpOnSubnet_InvalidAddress() {
+	nw := &networkImpl{}
+	s.False(nw.IsIpOnSubnet("not-an-ip", "192.168.1.0/24"))
+}
+
+func (s *NetworkSuite) TestIsIpOnSubnet_IPv6() {
+	nw := &networkImpl{}
+	s.True(nw.IsIpOnSubnet("2001:db8::10", "10.0.0.0/24,2001:db8::/64"))
 }

--- a/microceph/mocks/NetworkIntf.go
+++ b/microceph/mocks/NetworkIntf.go
@@ -9,23 +9,23 @@ type NetworkIntf struct {
 	mock.Mock
 }
 
-// FindIpOnSubnet provides a mock function with given fields: subnet
-func (_m *NetworkIntf) FindIpOnSubnet(subnet string) (string, error) {
-	ret := _m.Called(subnet)
+// FindIpOnSubnet provides a mock function with given fields: subnets
+func (_m *NetworkIntf) FindIpOnSubnet(subnets string) (string, error) {
+	ret := _m.Called(subnets)
 
 	var r0 string
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
-		return rf(subnet)
+		return rf(subnets)
 	}
 	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(subnet)
+		r0 = rf(subnets)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(subnet)
+		r1 = rf(subnets)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -81,13 +81,13 @@ func (_m *NetworkIntf) FindIpForPeers(peers []string) (string, error) {
 	return r0, r1
 }
 
-// IsIpOnSubnet provides a mock function with given fields: address, subnet
-func (_m *NetworkIntf) IsIpOnSubnet(address string, subnet string) bool {
-	ret := _m.Called(address, subnet)
+// IsIpOnSubnet provides a mock function with given fields: address, subnets
+func (_m *NetworkIntf) IsIpOnSubnet(address string, subnets string) bool {
+	ret := _m.Called(address, subnets)
 
 	var r0 bool
 	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
-		r0 = rf(address, subnet)
+		r0 = rf(address, subnets)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -448,6 +448,26 @@ function get_lxd_network() {
     echo "$nw"
 }
 
+# host_address <cidr> <host_offset>
+# Prints the address at <host_offset> hosts into <cidr>'s network.
+# Does arithmetic on the network address rather than string-appending to the
+# gateway (as "${gw}${i}" elsewhere does), which could overflow an octet: a
+# gateway whose host part is not .1 would otherwise turn into an invalid
+# address such as 10.0.0.2490. For '10.0.0.1/24' with an offset of 10 this
+# prints '10.0.0.10'. strict=False tolerates the host bits set on the LXD
+# gateway CIDR.
+function host_address() {
+    local cidr="${1?missing}"
+    local host_offset="${2?missing}"
+    python3 -c '
+import ipaddress
+import sys
+
+network = ipaddress.ip_network(sys.argv[1], strict=False)
+print(network.network_address + int(sys.argv[2]))
+' "${cidr}" "${host_offset}"
+}
+
 function create_vms() {
   set -eux
   # print useful information about the system
@@ -1207,6 +1227,119 @@ function bootstrap_head() {
     lxc exec node-wrk0 -- sh -c 'microceph.ceph -s | egrep "mon: 1 daemons, quorum node-wrk0"'
 }
 
+# get_ceph_conf_value <node> <key>
+# Prints the value of the "key = value" line in <node>'s ceph.conf, else "".
+# The remote command only does I/O (cat); the parse happens here. ceph.conf
+# carries "name = value" lines under section headers, so this prints the
+# right-hand side of the first line whose key -- the text left of the first
+# "=", stripped -- equals <key>. Section headers and blank lines have no "="
+# and are skipped. Keeps a comma-delimited public_network value intact so the
+# multi-subnet tests can compare it verbatim.
+function get_ceph_conf_value() {
+    local node="${1?missing}"
+    local key="${2?missing}"
+
+    lxc exec "${node}" -- sh -c "cat /var/snap/microceph/current/conf/ceph.conf" | \
+        awk -v key="${key}" '
+            { eq = index($0, "=") }
+            eq == 0 { next }
+            {
+                name = substr($0, 1, eq - 1)
+                gsub(/^[ \t]+|[ \t]+$/, "", name)
+                if (name != key) next
+                value = substr($0, eq + 1)
+                gsub(/^[ \t]+|[ \t]+$/, "", value)
+                print value
+                exit
+            }'
+}
+
+# multi_subnet_networks prints the comma-delimited CIDR list the head is
+# bootstrapped with: the "public" network followed by the second, "subnetb".
+function multi_subnet_networks() {
+    echo "$(get_lxd_network public),$(get_lxd_network subnetb)"
+}
+
+# multi_subnet_mon_ip prints the head's address on "subnetb", i.e. the address
+# on the SECOND subnet of the list the head is bootstrapped with.
+function multi_subnet_mon_ip() {
+    host_address "$(get_lxd_network subnetb)" 10
+}
+
+# bootstrap_multi_subnet_head bootstraps node-wrk0 across two subnets, with
+# --mon-ip on the SECOND listed one.
+#
+# Reproduces issue #734: the head already has an address on the "public"
+# network (eth2, from create_containers). This creates a second LXD network
+# ("subnetb"), attaches it as an extra NIC, assigns the head an address on it,
+# and bootstraps with a comma-delimited --public-network / --cluster-network
+# plus --mon-ip set to the address on the SECOND listed subnet -- the exact
+# case that previously failed with "provided mon-ip ... is not available on
+# provided public network ...".
+function bootstrap_multi_subnet_head() {
+    set -ex
+
+    lxc network create subnetb
+
+    local second_cidr=$(get_lxd_network subnetb)
+    local mask=$(echo "${second_cidr}" | cut -d/ -f2)
+    local networks=$(multi_subnet_networks)
+    local mon_ip=$(multi_subnet_mon_ip)
+
+    lxc network attach subnetb node-wrk0 eth3
+    sleep 2
+
+    # Allocate the mon address on the newly attached NIC.
+    local dev_name=$(lxc exec node-wrk0 -- sh -c "ip a | grep ': eth' | tail -n 1 | cut -d@ -f1 | cut -d ' ' -f2")
+    lxc exec node-wrk0 -- sh -c "ip a add ${mon_ip}/${mask} dev ${dev_name}"
+
+    lxc exec node-wrk0 -- sh -c "microceph cluster bootstrap --public-network=${networks} --cluster-network=${networks} --mon-ip=${mon_ip}"
+    sleep 5
+    lxc exec node-wrk0 -- sh -c "microceph status"
+}
+
+# test_multi_subnet_public_network checks the comma-delimited public_network is
+# written to ceph.conf unchanged.
+function test_multi_subnet_public_network() {
+    set -eux
+
+    local networks=$(multi_subnet_networks)
+    local pub_net=$(get_ceph_conf_value node-wrk0 public_network)
+
+    if [[ "${pub_net}" != "${networks}" ]]; then
+        lxc exec node-wrk0 -- sh -c "cat /var/snap/microceph/current/conf/ceph.conf"
+        echo "expected public_network '${networks}' in ceph.conf, got '${pub_net}'"
+        exit 1
+    fi
+}
+
+# test_multi_subnet_cluster_network checks the comma-delimited cluster_network
+# is stored in the cluster config.
+function test_multi_subnet_cluster_network() {
+    set -eux
+
+    local networks=$(multi_subnet_networks)
+    local cluster_net=$(lxc exec node-wrk0 -- sh -c "microceph.ceph config get osd cluster_network")
+
+    if [[ "${cluster_net}" != "${networks}" ]]; then
+        echo "expected cluster_network '${networks}', got '${cluster_net}'"
+        exit 1
+    fi
+}
+
+# test_multi_subnet_mon_binding checks the mon-ip on the non-first listed
+# subnet is accepted, written to ceph.conf, and reaches single-node quorum.
+function test_multi_subnet_mon_binding() {
+    set -eux
+
+    local mon_ip=$(multi_subnet_mon_ip)
+    local mon_host=$(get_ceph_conf_value node-wrk0 "mon host")
+
+    assert_output_contains "${mon_host}" "${mon_ip}" \
+        "mon-ip ${mon_ip} not present in the ceph.conf mon host list"
+
+    lxc exec node-wrk0 -- sh -c 'microceph.ceph -s | grep "mon: 1 daemons, quorum node-wrk0"'
+}
 
 function cluster_nodes() {
     set -ex


### PR DESCRIPTION
# Description

Backport #768 to squid.

Fixes #734 for squid

## Type of change

- New feature (non-breaking change which adds functionality)

## How has this been tested?

* unit tests from original PR
* convert robot integration tests to bash

## Contributor checklist

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change