### PR TITLE
doc: Add bootstrap context to tutorial

### DIFF
--- a/docs/snap/tutorial/get-started.rst
+++ b/docs/snap/tutorial/get-started.rst
@@ -60,7 +60,10 @@ Disable the default automatic Snap upgrades to prevent MicroCeph from being upda
 Initialise your cluster
 -----------------------
 
-Next, bootstrap your new Ceph storage cluster:
+Next, bootstrap your new Ceph storage cluster. During bootstrap,
+MicroCeph creates the initial cluster configuration and keys, registers
+the first node, and starts the core Ceph services that the rest of the
+cluster will build on:
 
 .. code-block:: none
     


### PR DESCRIPTION
# Description

Adds brief context to the “Initialise your cluster” section of the MicroCeph tutorial, explaining what bootstrapping does at a high level before the user runs `microceph cluster bootstrap`.

This helps new users understand that bootstrap creates the initial cluster configuration and keys, registers the first node, and starts the core Ceph services.

Fixes: https://github.com/canonical/open-documentation-academy/issues/352#event-28082347486

## Type of change

- Documentation update (change to documentation only)

## How has this been tested?

- Ran `git diff --check` successfully.
- Attempted a local Sphinx build with `sphinx-build --fail-on-warning --keep-going -b dirhtml . _build -c . -d _dev\.doctrees -D llms_txt_enabled=0`, but it could not complete because the local environment is missing the `canonical_sphinx` Python package.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [ ] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change