### PR TITLE
docs: update MicroCloud docs URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -352,7 +352,7 @@ intersphinx_mapping = {
     # Snap packaging documentation
     'snapcraft': ('https://snapcraft.io/docs/', None),
     # MicroCloud documentation
-    'microcloud': ('https://documentation.ubuntu.com/microcloud/latest/', None),
+    'microcloud': ('https://canonical.com/microcloud/docs/latest/', None),
     # Juju documentation (relevant for the MicroCeph charm)
     'juju': ('https://documentation.ubuntu.com/juju/latest/', None),
     # Ubuntu release notes

--- a/docs/snap/how-to/multi-node.rst
+++ b/docs/snap/how-to/multi-node.rst
@@ -4,7 +4,7 @@ Multi-node install
 ==================
 
 .. The note below is only visible when viewed through MicroCloud's docs site:
-   https://documentation.ubuntu.com/microcloud/latest/microceph/
+   https://canonical.com/microcloud/docs/latest/microceph/
 
 .. only:: integrated
 

--- a/docs/snap/how-to/single-node.rst
+++ b/docs/snap/how-to/single-node.rst
@@ -4,7 +4,7 @@ How to install MicroCeph on a single node
 =========================================
 
 .. The note below is only visible when viewed through MicroCloud's docs site:
-   https://documentation.ubuntu.com/microcloud/latest/microceph/
+   https://canonical.com/microcloud/docs/latest/microceph/
 
 .. only:: integrated
 

--- a/docs/snap/tutorial/get-started.rst
+++ b/docs/snap/tutorial/get-started.rst
@@ -7,7 +7,7 @@ Deploy a single-node MicroCeph cluster
 ======================================
 
 .. The note below is only visible when viewed through MicroCloud's docs site:
-   https://documentation.ubuntu.com/microcloud/latest/microceph/
+   https://canonical.com/microcloud/docs/latest/microceph/
 
 .. only:: integrated
 


### PR DESCRIPTION
# Description

The MicroCloud docs are now on https://canonical.com/microcloud/docs/.

## Type of change

- Documentation update (change to documentation only)

## How has this been tested?

Checked URLs manually.

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [ ] verified that page title and headings accurately represent page content for new or modified documentation pages
- [ ] checked and added or updated relevant release notes
- [ ] added tests to verify effectiveness of this change