### PR TITLE
Implement the storage role interfaces

### DIFF
--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -666,6 +666,11 @@ func (m *OSDManager) addLoopBackOSDs(ctx context.Context, spec string) error {
 	if err != nil {
 		return err
 	}
+	err = m.checkStorageEligibility(ctx)
+	if err != nil {
+		return err
+	}
+
 	// check available capacity for backing files under $SNAP_COMMON
 	freeSpace, err := getFreeSpace(os.Getenv("SNAP_COMMON"))
 	if err != nil {
@@ -918,7 +923,12 @@ func (m *OSDManager) addSingleDisk(ctx context.Context, disk types.DiskParameter
 		}
 	} else {
 		// Add physical disk based OSD.
-		err := m.doAddOSD(ctx, disk, wal, db)
+		err := m.checkStorageEligibility(ctx)
+		if err != nil {
+			return types.DiskAddReport{Path: disk.Path, Report: "Failure", Error: err.Error()}
+		}
+
+		err = m.doAddOSD(ctx, disk, wal, db)
 		if err != nil {
 			logger.Errorf("failed to add disk: path %s, err %v", disk.Path, err)
 			// return failure as response.

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -821,9 +821,60 @@ func prepareValidationFailureResp(disks []types.DiskParameter, err error) types.
 	return ret
 }
 
+// Verify that the local member is allowed to enroll OSD's.
+func (m *OSDManager) checkStorageEligibility(ctx context.Context) error {
+	if m.state == nil {
+		return nil
+	}
+
+	var active bool
+	var policyJSON string
+	err := m.state.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		rec, err := database.GetPlacementPolicy(ctx, tx)
+		if err != nil {
+			return err
+		}
+		active = rec.Active
+		policyJSON = rec.PolicyJSON
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to retrieve placement policy: %w", err)
+	}
+	if !active {
+		return nil
+	}
+	if policyJSON == "" {
+		return fmt.Errorf("role-management is enabled but no placement policy is installed")
+	}
+
+	var policy types.PlacementPolicy
+	err = json.Unmarshal([]byte(policyJSON), &policy)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal placement policy: %w", err)
+	}
+
+	localName := m.state.Name()
+	memberPolicy, ok := policy.Members[localName]
+	if !ok {
+		return fmt.Errorf("Cannot enroll OSD: member %q is not present in the active policy", localName)
+	}
+	if memberPolicy.StorageEligible == nil || !*memberPolicy.StorageEligible {
+		return fmt.Errorf("Cannot enroll OSD: member %q does not have the 'storage' role assigned", localName)
+	}
+
+	return nil
+}
+
 // addBulkDisks adds multiple disks as OSDs and generates the API response for request.
 func (m *OSDManager) addBulkDisks(ctx context.Context, disks []types.DiskParameter, wal *types.DiskParameter, db *types.DiskParameter) types.DiskAddResponse {
 	ret := types.DiskAddResponse{}
+
+	err := m.checkStorageEligibility(ctx)
+	if err != nil {
+		return prepareValidationFailureResp(disks, err)
+	}
 
 	if len(disks) == 1 {
 		// Validate
@@ -839,7 +890,7 @@ func (m *OSDManager) addBulkDisks(ctx context.Context, disks []types.DiskParamet
 	}
 
 	// validate Arguments for batch request.
-	err := validateBulkDiskAdditionArgs(disks, wal, db)
+	err = validateBulkDiskAdditionArgs(disks, wal, db)
 	if err != nil {
 		// Disk addition is skipped if validation errors are found.
 		return prepareValidationFailureResp(disks, err)
@@ -884,7 +935,12 @@ func (m *OSDManager) addSingleDisk(ctx context.Context, disk types.DiskParameter
 func (m *OSDManager) addOSD(ctx context.Context, data types.DiskParameter, wal *types.DiskParameter, db *types.DiskParameter) error {
 	logger.Infof("addOSD, params: %s, WAL: %v, DB: %v", data.Path, wal, db)
 
-	err := m.validateAddOSDArgs(data, wal, db)
+	err := m.checkStorageEligibility(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = m.validateAddOSDArgs(data, wal, db)
 	if err != nil {
 		return err
 	}
@@ -1591,6 +1647,11 @@ func (m *OSDManager) AddDisksWithDSL(ctx context.Context, dslExpr string, encryp
 
 // AddDisksWithDSLRequest handles OSD DSL execution and WAL/DB dry-run planning.
 func (m *OSDManager) AddDisksWithDSLRequest(ctx context.Context, req types.DisksPost) types.DiskAddResponse {
+	err := m.checkStorageEligibility(ctx)
+	if err != nil {
+		return types.DiskAddResponse{ValidationError: err.Error()}
+	}
+
 	if req.WALMatch != "" || req.DBMatch != "" {
 		if req.DryRun {
 			return m.buildDSLDryRunPlan(ctx, req)

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -2,6 +2,7 @@ package ceph
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1505,4 +1506,119 @@ func (s *osdSuite) TestGetStorageWithRetryExhausted() {
 	_, err := osdmgr.getStorageWithRetry()
 
 	require.ErrorIs(s.T(), err, persistentErr)
+}
+
+// TestCheckStorageEligibility verifies that CheckStorageEligibility enforces OSD enrollment restrictions based on the declarative placement policy.
+func (s *osdSuite) TestCheckStorageEligibility() {
+	ctx := context.Background()
+
+	// Case 1: State is nil. Any member is allowed.
+	{
+		osdmgr := NewOSDManager(nil)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.NoError(s.T(), err)
+	}
+
+	// Helper to create a mock state with in-memory SQLite and populate the placement policy table.
+	createTestState := func(active bool, policyJSON string) (*mocks.MockState, func()) {
+		db, err := sql.Open("sqlite3", ":memory:")
+		require.NoError(s.T(), err)
+
+		_, err = db.Exec(`
+CREATE TABLE placement_policy (
+  id               INTEGER PRIMARY KEY NOT NULL CHECK (id = 1),
+  active           INTEGER NOT NULL DEFAULT 0,
+  policy_json      TEXT,
+  last_refusal     TEXT,
+  apply_lock_token INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO placement_policy (id, active, policy_json) VALUES (1, 0, '');
+`)
+		require.NoError(s.T(), err)
+
+		activeInt := 0
+		if active {
+			activeInt = 1
+		}
+		_, err = db.Exec("UPDATE placement_policy SET active = ?, policy_json = ? WHERE id = 1", activeInt, policyJSON)
+		require.NoError(s.T(), err)
+
+		txFn := func(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				return err
+			}
+			err = f(ctx, tx)
+			if err != nil {
+				_ = tx.Rollback()
+				return err
+			}
+			return tx.Commit()
+		}
+
+		mockDB := &mocks.MockDB{TxFn: txFn}
+		state := &mocks.MockState{
+			ClusterName: "node-a",
+			DBObj:       mockDB,
+		}
+
+		cleanup := func() {
+			db.Close()
+		}
+
+		return state, cleanup
+	}
+
+	// Case 2. Active is false, thus there's no enforcement. Allow.
+	{
+		state, cleanup := createTestState(false, "")
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.NoError(s.T(), err)
+	}
+
+	// Case 3: Active is true and policy is empty. Reject.
+	{
+		state, cleanup := createTestState(true, "")
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.Error(s.T(), err)
+	}
+
+	// Case 4: Active is true and member has storage eligibility. Allow.
+	{
+		policyJSON := `{"members":{"node-a":{"storage_eligible":true}}}`
+		state, cleanup := createTestState(true, policyJSON)
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.NoError(s.T(), err)
+	}
+
+	// Case 5: Active is true but member has no storage eligibility. Reject.
+	{
+		policyJSON := `{"members":{"node-a":{"storage_eligible":false}}}`
+		state, cleanup := createTestState(true, policyJSON)
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.Error(s.T(), err)
+	}
+
+	// Case 6: Active is true but member is omitted. Reject.
+	{
+		policyJSON := `{"members":{"node-b":{"storage_eligible":true}}}`
+		state, cleanup := createTestState(true, policyJSON)
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.Error(s.T(), err)
+	}
 }


### PR DESCRIPTION
This changeset implements the necessary changes to support the storage role such that the necessary checks are performed before enrolling OSD's to make sure that the target node has the necessary capability.