### PR TITLE
fix: control role mon quorum preservation

### DIFF
--- a/microceph/ceph/control_readiness.go
+++ b/microceph/ceph/control_readiness.go
@@ -44,29 +44,11 @@ func controlServiceReady(ctx context.Context, service string, member string) (bo
 // accepted as defense-in-depth so the check works if a future code path feeds
 // quorum_status-shaped output into this helper.
 func monInQuorum(ctx context.Context, member string) (bool, error) {
-	output, err := cephRunContext(ctx, "mon", "stat", "-f", "json")
+	quorum, err := getMonQuorumNames(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to run 'ceph mon stat': %w", err)
+		return false, err
 	}
-	var stat struct {
-		QuorumNames []string `json:"quorum_names"`
-		Quorum      []struct {
-			Name string `json:"name"`
-		} `json:"quorum"`
-	}
-	err = json.Unmarshal([]byte(output), &stat)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse 'ceph mon stat' output: %w", err)
-	}
-	if slices.Contains(stat.QuorumNames, member) {
-		return true, nil
-	}
-	for _, q := range stat.Quorum {
-		if q.Name == member {
-			return true, nil
-		}
-	}
-	return false, nil
+	return slices.Contains(quorum, member), nil
 }
 
 // mgrActiveOrStandby checks whether a MGR daemon on member is active or

--- a/microceph/ceph/control_removal.go
+++ b/microceph/ceph/control_removal.go
@@ -6,12 +6,21 @@ import (
 )
 
 // controlDaemonRemovalVerifyTimeout bounds the post-eviction verification poll
-// for MGR/MDS map convergence. It comfortably exceeds the default Ceph beacon
-// grace (mon_mgr_beacon_grace, 30s) so that even when the active eviction
-// command is a partial no-op for a standby daemon, verification still succeeds
+// for MGR/MDS map convergence. It must comfortably exceed the worst-case
+// beacon-aging fallback so that even when the active eviction command is a
+// partial no-op (a standby daemon) or is rejected, verification still succeeds
 // via beacon aging within the bounded window rather than returning a spurious
-// error. It is a var (not a const) so unit tests can shrink it.
-var controlDaemonRemovalVerifyTimeout = 60 * time.Second
+// error.
+//
+// The window is sized with generous margin over that fallback, not merely equal
+// to it: the default grace periods are mon_mgr_beacon_grace (30s) and
+// mds_beacon_grace (15s), but MDS teardown runs right after a MON is removed,
+// and a MON quorum/leader change resets the monitor's beacon last-seen timers,
+// so the effective aging window can restart from the new election. A timeout
+// equal to a single grace period could therefore expire just before Ceph ages a
+// stopped daemon out, skipping cleanup. 120s leaves clear headroom above the
+// stacked worst case. It is a var (not a const) so unit tests can shrink it.
+var controlDaemonRemovalVerifyTimeout = 120 * time.Second
 
 // controlDaemonRemovalVerifyInterval is the poll cadence for the verification
 // loop above. It is a var so unit tests can shrink it.

--- a/microceph/ceph/control_removal.go
+++ b/microceph/ceph/control_removal.go
@@ -1,0 +1,51 @@
+package ceph
+
+import (
+	"context"
+	"time"
+)
+
+// controlDaemonRemovalVerifyTimeout bounds the post-eviction verification poll
+// for MGR/MDS map convergence. It comfortably exceeds the default Ceph beacon
+// grace (mon_mgr_beacon_grace, 30s) so that even when the active eviction
+// command is a partial no-op for a standby daemon, verification still succeeds
+// via beacon aging within the bounded window rather than returning a spurious
+// error. It is a var (not a const) so unit tests can shrink it.
+var controlDaemonRemovalVerifyTimeout = 60 * time.Second
+
+// controlDaemonRemovalVerifyInterval is the poll cadence for the verification
+// loop above. It is a var so unit tests can shrink it.
+var controlDaemonRemovalVerifyInterval = 2 * time.Second
+
+// verifyControlDaemonAbsent polls presenceFunc until hostname is absent from the
+// relevant Ceph map or the bounded timeout elapses.
+//
+// Like the MON removal verification, it runs against a fresh, detached context
+// so an ambiguous eviction outcome stays resumable even when the original
+// request was cancelled while the eviction command's response was in flight.
+// The poll (rather than a single check) absorbs both map propagation lag and
+// the slower beacon-aging fallback when the eviction command did not itself
+// remove the daemon from the map.
+//
+// Returns (true, nil) once the daemon is absent. On timeout it returns
+// (false, lastErr): lastErr is the most recent presence-check error, or nil
+// when the daemon simply remained present without error.
+func verifyControlDaemonAbsent(ctx context.Context, hostname string, presenceFunc func(context.Context, string) (bool, error)) (bool, error) {
+	verifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), controlDaemonRemovalVerifyTimeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		present, err := presenceFunc(verifyCtx, hostname)
+		if err == nil && !present {
+			return true, nil
+		}
+		lastErr = err
+
+		select {
+		case <-verifyCtx.Done():
+			return false, lastErr
+		case <-time.After(controlDaemonRemovalVerifyInterval):
+		}
+	}
+}

--- a/microceph/ceph/control_removal_test.go
+++ b/microceph/ceph/control_removal_test.go
@@ -184,7 +184,7 @@ func TestEnsureMdsAbsentEvictsAndConfirms(t *testing.T) {
 	r := withMockRunner(t)
 	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
 		Return(mdsStandbys("node-a", "node-b"), nil).Once()
-	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "fail", "node-a").
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "fail", "node-a", "--yes-i-really-mean-it").
 		Return("", nil).Once()
 	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
 		Return(mdsStandbys("node-b"), nil).Once()
@@ -199,7 +199,7 @@ func TestEnsureMdsAbsentPreservesEvictionFailureWhenStillPresent(t *testing.T) {
 	evictErr := errors.New("mds fail rejected")
 	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
 		Return(mdsStandbys("node-a", "node-b"), nil).Once()
-	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "fail", "node-a").
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "fail", "node-a", "--yes-i-really-mean-it").
 		Return("", evictErr).Once()
 	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
 		Return(mdsStandbys("node-a", "node-b"), nil)

--- a/microceph/ceph/control_removal_test.go
+++ b/microceph/ceph/control_removal_test.go
@@ -1,0 +1,209 @@
+package ceph
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// shrinkDaemonRemovalVerify shrinks the detached verification window so tests
+// that exercise the timeout path finish quickly. Originals are restored via
+// t.Cleanup.
+func shrinkDaemonRemovalVerify(t *testing.T) {
+	origTimeout := controlDaemonRemovalVerifyTimeout
+	origInterval := controlDaemonRemovalVerifyInterval
+	t.Cleanup(func() {
+		controlDaemonRemovalVerifyTimeout = origTimeout
+		controlDaemonRemovalVerifyInterval = origInterval
+	})
+	controlDaemonRemovalVerifyTimeout = 30 * time.Millisecond
+	controlDaemonRemovalVerifyInterval = 5 * time.Millisecond
+}
+
+// --- verifyControlDaemonAbsent ---
+
+func TestVerifyControlDaemonAbsentReturnsOnceAbsent(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	calls := 0
+	presence := func(_ context.Context, _ string) (bool, error) {
+		calls++
+		if calls < 3 {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	absent, err := verifyControlDaemonAbsent(context.Background(), "node-a", presence)
+	assert.NoError(t, err)
+	assert.True(t, absent)
+	assert.Equal(t, 3, calls)
+}
+
+func TestVerifyControlDaemonAbsentTimesOutStillPresent(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	presence := func(_ context.Context, _ string) (bool, error) {
+		return true, nil
+	}
+
+	absent, err := verifyControlDaemonAbsent(context.Background(), "node-a", presence)
+	assert.False(t, absent)
+	assert.NoError(t, err)
+}
+
+func TestVerifyControlDaemonAbsentReturnsLastError(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	checkErr := errors.New("map read failed")
+	presence := func(_ context.Context, _ string) (bool, error) {
+		return false, checkErr
+	}
+
+	absent, err := verifyControlDaemonAbsent(context.Background(), "node-a", presence)
+	assert.False(t, absent)
+	assert.ErrorIs(t, err, checkErr)
+}
+
+func TestVerifyControlDaemonAbsentUsesDetachedContext(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // parent already cancelled
+
+	sawLiveContext := false
+	presence := func(checkCtx context.Context, _ string) (bool, error) {
+		// The verification must not use the cancelled parent context.
+		if checkCtx.Err() == nil {
+			sawLiveContext = true
+		}
+		return false, nil
+	}
+
+	absent, err := verifyControlDaemonAbsent(ctx, "node-a", presence)
+	assert.NoError(t, err)
+	assert.True(t, absent)
+	assert.True(t, sawLiveContext, "verification should run on a fresh, live context")
+}
+
+// --- ensureMgrAbsent ---
+
+func mgrMetadata(names ...string) string {
+	out := "["
+	for i, n := range names {
+		if i > 0 {
+			out += ","
+		}
+		out += `{"name":"` + n + `"}`
+	}
+	return out + "]"
+}
+
+func TestEnsureMgrAbsentAlreadyAbsent(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-b"), nil).Once()
+
+	err := ensureMgrAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMgrAbsentEvictsAndConfirms(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	r := withMockRunner(t)
+	// Present before eviction.
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-a", "node-b"), nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "fail", "node-a").
+		Return("", nil).Once()
+	// Absent after eviction (verification poll).
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-b"), nil).Once()
+
+	err := ensureMgrAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMgrAbsentAcceptsAmbiguousEvictionWhenVerified(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-a", "node-b"), nil).Once()
+	// `ceph mgr fail` errors (e.g. the daemon was already gone), but the map
+	// converges via beacon aging within the verification window.
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "fail", "node-a").
+		Return("", errors.New("mgr.node-a does not exist")).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-b"), nil).Once()
+
+	err := ensureMgrAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMgrAbsentPreservesEvictionFailureWhenStillPresent(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	r := withMockRunner(t)
+	evictErr := errors.New("mgr fail rejected")
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-a", "node-b"), nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "fail", "node-a").
+		Return("", evictErr).Once()
+	// Remains present through the verification window.
+	r.On("RunCommandContext", mock.Anything, "ceph", "mgr", "metadata", "-f", "json").
+		Return(mgrMetadata("node-a", "node-b"), nil)
+
+	err := ensureMgrAbsent(context.Background(), "node-a")
+	assert.ErrorIs(t, err, evictErr)
+}
+
+// --- ensureMdsAbsent ---
+
+func mdsStandbys(names ...string) string {
+	out := `{"fsmap":{"standbys":[`
+	for i, n := range names {
+		if i > 0 {
+			out += ","
+		}
+		out += `{"name":"` + n + `","state":"up:standby"}`
+	}
+	out += `],"filesystems":[]}}`
+	return out
+}
+
+func TestEnsureMdsAbsentAlreadyAbsent(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
+		Return(mdsStandbys("node-b"), nil).Once()
+
+	err := ensureMdsAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMdsAbsentEvictsAndConfirms(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
+		Return(mdsStandbys("node-a", "node-b"), nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "fail", "node-a").
+		Return("", nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
+		Return(mdsStandbys("node-b"), nil).Once()
+
+	err := ensureMdsAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMdsAbsentPreservesEvictionFailureWhenStillPresent(t *testing.T) {
+	shrinkDaemonRemovalVerify(t)
+	r := withMockRunner(t)
+	evictErr := errors.New("mds fail rejected")
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
+		Return(mdsStandbys("node-a", "node-b"), nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "fail", "node-a").
+		Return("", evictErr).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mds", "stat", "-f", "json").
+		Return(mdsStandbys("node-a", "node-b"), nil)
+
+	err := ensureMdsAbsent(context.Background(), "node-a")
+	assert.ErrorIs(t, err, evictErr)
+}

--- a/microceph/ceph/manager.go
+++ b/microceph/ceph/manager.go
@@ -50,6 +50,66 @@ func getActiveMgrs() ([]string, error) {
 	return activeMgrs, nil
 }
 
+// ensureMgrAbsentFunc commits MGR map removal after the local daemon is
+// stopped. It is injectable so DeleteService ordering can be unit-tested
+// without touching Ceph.
+var ensureMgrAbsentFunc = ensureMgrAbsent
+
+// evictMgrFunc actively removes a MGR daemon from the mgrmap. Injectable for
+// testing.
+var evictMgrFunc = evictMgr
+
+// evictMgr runs `ceph mgr fail <hostname>`, which removes a standby MGR from
+// the mgrmap (or fails the active MGR so a standby takes over) instead of
+// waiting out the mon_mgr_beacon_grace aging window.
+func evictMgr(ctx context.Context, hostname string) error {
+	_, err := cephRunContext(ctx, "mgr", "fail", hostname)
+	if err != nil {
+		logger.Errorf("failed to fail mgr %q: %v", hostname, err)
+		return fmt.Errorf("failed to fail mgr %q: %w", hostname, err)
+	}
+	return nil
+}
+
+// ensureMgrAbsent makes MGR teardown synchronous: it actively evicts the MGR
+// from the mgrmap and verifies the map converged before returning, so a
+// reconcile does not report success while a stopped standby still lingers in
+// `ceph mgr metadata` during the beacon-aging window.
+//
+// The operation is idempotent. An already-absent MGR returns immediately, so
+// a retry after a later teardown phase failed resumes local cleanup rather
+// than erroring. `ceph mgr fail` on an already-gone daemon may itself error;
+// that is tolerated as long as verification confirms absence (possibly via
+// beacon aging), mirroring the ambiguous-outcome handling in ensureMonAbsent.
+func ensureMgrAbsent(ctx context.Context, hostname string) error {
+	present, err := mgrActiveOrStandby(ctx, hostname)
+	if err != nil {
+		return fmt.Errorf("failed to read mgr map: %w", err)
+	}
+	if !present {
+		return nil
+	}
+
+	evictErr := evictMgrFunc(ctx, hostname)
+	absent, verifyErr := verifyControlDaemonAbsent(ctx, hostname, mgrActiveOrStandby)
+	if verifyErr != nil {
+		if evictErr != nil {
+			return fmt.Errorf("%w; failed to verify mgr removal: %v", evictErr, verifyErr)
+		}
+		return fmt.Errorf("mgr %q removal could not be verified: %w", hostname, verifyErr)
+	}
+	if absent {
+		// Absent now: either the eviction committed, or a stopped standby aged
+		// out within the verification window. An ambiguous eviction error is
+		// therefore benign.
+		return nil
+	}
+	if evictErr != nil {
+		return evictErr
+	}
+	return fmt.Errorf("mgr %q remains in the mgr map after removal", hostname)
+}
+
 // Mgr Module Ops
 
 // EnableMgrModule enabled a mgr module on specified ceph cluster and verifies if is comes up

--- a/microceph/ceph/metadata.go
+++ b/microceph/ceph/metadata.go
@@ -19,11 +19,18 @@ var ensureMdsAbsentFunc = ensureMdsAbsent
 // testing.
 var evictMdsFunc = evictMds
 
-// evictMds runs `ceph mds fail <hostname>`, which removes a standby MDS from
-// the fsmap (or fails the active MDS so a standby takes over) instead of
-// waiting out the beacon-aging window.
+// evictMds runs `ceph mds fail <hostname> --yes-i-really-mean-it`, which
+// removes a standby MDS from the fsmap (or fails the active MDS so a standby
+// takes over) instead of waiting out the beacon-aging window.
+//
+// The confirmation flag is required: since Ceph tracker #61866 (backported to
+// reef/squid) the monitor rejects `ceph mds fail` with -EPERM when the cluster
+// carries MDS_HEALTH_TRIM or MDS_HEALTH_CACHE_OVERSIZED warnings unless the flag
+// is passed. Without it the fast-path eviction would silently fail under those
+// warnings and teardown would fall back entirely to beacon aging. The local
+// daemon is already stopped by the time this runs, so forcing the fail is safe.
 func evictMds(ctx context.Context, hostname string) error {
-	_, err := cephRunContext(ctx, "mds", "fail", hostname)
+	_, err := cephRunContext(ctx, "mds", "fail", hostname, "--yes-i-really-mean-it")
 	if err != nil {
 		logger.Errorf("failed to fail mds %q: %v", hostname, err)
 		return fmt.Errorf("failed to fail mds %q: %w", hostname, err)

--- a/microceph/ceph/metadata.go
+++ b/microceph/ceph/metadata.go
@@ -1,6 +1,7 @@
 package ceph
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -8,6 +9,66 @@ import (
 	"github.com/canonical/microceph/microceph/logger"
 	"github.com/tidwall/gjson"
 )
+
+// ensureMdsAbsentFunc commits MDS map removal after the local daemon is
+// stopped. Injectable so DeleteService ordering can be unit-tested without
+// touching Ceph.
+var ensureMdsAbsentFunc = ensureMdsAbsent
+
+// evictMdsFunc actively removes an MDS daemon from the fsmap. Injectable for
+// testing.
+var evictMdsFunc = evictMds
+
+// evictMds runs `ceph mds fail <hostname>`, which removes a standby MDS from
+// the fsmap (or fails the active MDS so a standby takes over) instead of
+// waiting out the beacon-aging window.
+func evictMds(ctx context.Context, hostname string) error {
+	_, err := cephRunContext(ctx, "mds", "fail", hostname)
+	if err != nil {
+		logger.Errorf("failed to fail mds %q: %v", hostname, err)
+		return fmt.Errorf("failed to fail mds %q: %w", hostname, err)
+	}
+	return nil
+}
+
+// ensureMdsAbsent makes MDS teardown synchronous: it actively evicts the MDS
+// from the fsmap and verifies the map converged before returning, so a
+// reconcile does not report success while a stopped standby still lingers in
+// `ceph mds stat` during the beacon-aging window.
+//
+// The operation is idempotent. An already-absent MDS returns immediately, so
+// a retry after a later teardown phase failed resumes local cleanup rather
+// than erroring. `ceph mds fail` on an already-gone daemon may itself error;
+// that is tolerated as long as verification confirms absence (possibly via
+// beacon aging), mirroring the ambiguous-outcome handling in ensureMonAbsent.
+func ensureMdsAbsent(ctx context.Context, hostname string) error {
+	present, err := mdsUp(ctx, hostname)
+	if err != nil {
+		return fmt.Errorf("failed to read mds map: %w", err)
+	}
+	if !present {
+		return nil
+	}
+
+	evictErr := evictMdsFunc(ctx, hostname)
+	absent, verifyErr := verifyControlDaemonAbsent(ctx, hostname, mdsUp)
+	if verifyErr != nil {
+		if evictErr != nil {
+			return fmt.Errorf("%w; failed to verify mds removal: %v", evictErr, verifyErr)
+		}
+		return fmt.Errorf("mds %q removal could not be verified: %w", hostname, verifyErr)
+	}
+	if absent {
+		// Absent now: either the eviction committed, or a stopped standby aged
+		// out within the verification window. An ambiguous eviction error is
+		// therefore benign.
+		return nil
+	}
+	if evictErr != nil {
+		return evictErr
+	}
+	return fmt.Errorf("mds %q remains in the mds map after removal", hostname)
+}
 
 func bootstrapMds(hostname string, path string) error {
 	args := []string{

--- a/microceph/ceph/monitor.go
+++ b/microceph/ceph/monitor.go
@@ -1,9 +1,12 @@
 package ceph
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/canonical/microceph/microceph/common"
 	"github.com/canonical/microceph/microceph/interfaces"
@@ -97,14 +100,185 @@ func joinMon(hostname string, path string) error {
 	return bootstrapMon(hostname, path, monmap, keyring)
 }
 
-// removeMon removes a monitor from the cluster.
-func removeMon(hostname string) error {
-	_, err := cephRun("mon", "rm", hostname)
+// monRemovalVerifyTimeout bounds the detached postcondition check after
+// `ceph mon rm`. The command may have committed just as its caller's context
+// expired, so checking with the cancelled context would turn a successful
+// removal into an ambiguous failure.
+const monRemovalVerifyTimeout = 30 * time.Second
+
+// getMonmapNames returns the monitor names in the committed monmap.
+func getMonmapNames(ctx context.Context) ([]string, error) {
+	output, err := cephRunContext(ctx, "mon", "dump", "-f", "json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read monitor map: %w", err)
+	}
+
+	var dump struct {
+		Mons json.RawMessage `json:"mons"`
+	}
+	if err := json.Unmarshal([]byte(output), &dump); err != nil {
+		return nil, fmt.Errorf("failed to parse monitor map: %w", err)
+	}
+	if len(dump.Mons) == 0 {
+		return nil, fmt.Errorf("failed to parse monitor map: missing %q field", "mons")
+	}
+
+	var mons *[]struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(dump.Mons, &mons); err != nil {
+		return nil, fmt.Errorf("failed to parse monitor map: invalid %q field: %w", "mons", err)
+	}
+	if mons == nil {
+		return nil, fmt.Errorf("failed to parse monitor map: %q must be a non-null array", "mons")
+	}
+	if len(*mons) == 0 {
+		return nil, fmt.Errorf("failed to parse monitor map: %q must contain at least one monitor", "mons")
+	}
+
+	names := make([]string, 0, len(*mons))
+	for i, mon := range *mons {
+		if mon.Name == "" {
+			return nil, fmt.Errorf("failed to parse monitor map: monitor at index %d has no name", i)
+		}
+		names = append(names, mon.Name)
+	}
+	return names, nil
+}
+
+// monInMonmap reports whether hostname is present in the committed monmap.
+func monInMonmap(ctx context.Context, hostname string) (bool, error) {
+	names, err := getMonmapNames(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, name := range names {
+		if name == hostname {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getMonQuorumNames returns the monitor names in the current Ceph quorum.
+func getMonQuorumNames(ctx context.Context) ([]string, error) {
+	output, err := cephRunContext(ctx, "mon", "stat", "-f", "json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to run 'ceph mon stat': %w", err)
+	}
+
+	var stat struct {
+		QuorumNames []string `json:"quorum_names"`
+		Quorum      []struct {
+			Name string `json:"name"`
+		} `json:"quorum"`
+	}
+	if err := json.Unmarshal([]byte(output), &stat); err != nil {
+		return nil, fmt.Errorf("failed to parse 'ceph mon stat' output: %w", err)
+	}
+	if len(stat.QuorumNames) > 0 {
+		return stat.QuorumNames, nil
+	}
+
+	names := make([]string, 0, len(stat.Quorum))
+	for _, mon := range stat.Quorum {
+		names = append(names, mon.Name)
+	}
+	return names, nil
+}
+
+// removeMon removes a monitor from the committed monmap while respecting the
+// caller's deadline.
+func removeMon(ctx context.Context, hostname string) error {
+	_, err := cephRunContext(ctx, "mon", "rm", hostname)
 	if err != nil {
 		logger.Errorf("failed to remove monitor %q: %v", hostname, err)
 		return fmt.Errorf("failed to remove monitor %q: %w", hostname, err)
 	}
 	return nil
+}
+
+// verifyMonAbsent checks the monmap with a fresh, bounded context. This makes
+// an ambiguous `ceph mon rm` outcome resumable even when the original request
+// was cancelled while the command response was in flight.
+func verifyMonAbsent(ctx context.Context, hostname string) (bool, error) {
+	verifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), monRemovalVerifyTimeout)
+	defer cancel()
+
+	present, err := monInMonmap(verifyCtx, hostname)
+	return !present, err
+}
+
+// ensureMonAbsent commits MON membership removal before the local daemon is
+// stopped. Stopping first can destroy quorum in a two-to-one migration and
+// leave the quorum-dependent `ceph mon rm` command unable to complete.
+//
+// The operation is deliberately idempotent. If an earlier attempt committed
+// the monmap change but failed during local teardown, the still-present service
+// database row causes reconciliation to call this again; an already-absent MON
+// then proceeds directly to stop, cleanup, and database removal.
+func ensureMonAbsent(ctx context.Context, hostname string) error {
+	monmap, err := getMonmapNames(ctx)
+	if err != nil {
+		return err
+	}
+	present := false
+	monmapSet := make(map[string]bool, len(monmap))
+	for _, name := range monmap {
+		monmapSet[name] = true
+		if name == hostname {
+			present = true
+		}
+	}
+	if !present {
+		return nil
+	}
+
+	quorum, err := getMonQuorumNames(ctx)
+	if err != nil {
+		return err
+	}
+	// The committed post-removal monmap has len(monmap)-1 members and needs a
+	// majority of those members to remain in quorum. Merely finding one other
+	// quorum member is insufficient for a degraded larger monmap: removing A
+	// from map {A,B,C} with quorum {A,B} would leave {B,C}, which needs both B
+	// and C but has only B available.
+	remainingMons := len(monmap) - 1
+	requiredQuorum := remainingMons/2 + 1
+	remainingInQuorum := 0
+	for _, name := range quorum {
+		if name != hostname && monmapSet[name] {
+			remainingInQuorum++
+		}
+	}
+	if remainingInQuorum < requiredQuorum {
+		return fmt.Errorf(
+			"%w: refusing to remove monitor %q: %d remaining monitor(s) in quorum, need %d for the resulting %d-monitor map",
+			ErrKeepOneInvariant,
+			hostname,
+			remainingInQuorum,
+			requiredQuorum,
+			remainingMons,
+		)
+	}
+
+	removeErr := removeMon(ctx, hostname)
+	absent, verifyErr := verifyMonAbsent(ctx, hostname)
+	if verifyErr != nil {
+		if removeErr != nil {
+			return fmt.Errorf("%w; failed to verify monitor removal: %v", removeErr, verifyErr)
+		}
+		return fmt.Errorf("monitor %q removal could not be verified: %w", hostname, verifyErr)
+	}
+	if absent {
+		// This also handles an ambiguous command error after the monmap change
+		// committed successfully.
+		return nil
+	}
+	if removeErr != nil {
+		return removeErr
+	}
+	return fmt.Errorf("monitor %q remains in the monitor map after removal", hostname)
 }
 
 func getActiveMons() ([]string, error) {

--- a/microceph/ceph/monitor_removal_test.go
+++ b/microceph/ceph/monitor_removal_test.go
@@ -1,0 +1,185 @@
+package ceph
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEnsureMonAbsentAlreadyAbsent(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-b"}]}`, nil).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMonAbsentRefusesWithoutAnotherQuorumMember(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"}]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "stat", "-f", "json").
+		Return(`{"quorum":[{"rank":0,"name":"node-a"}]}`, nil).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.ErrorIs(t, err, ErrKeepOneInvariant)
+}
+
+func TestEnsureMonAbsentRefusesDegradedResultingMonmap(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"},{"name":"node-b"},{"name":"node-c"}]}`, nil).Once()
+	// node-a and node-b form the current two-of-three quorum. Removing node-a
+	// would produce a two-MON map where node-b alone cannot form quorum.
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "stat", "-f", "json").
+		Return(`{"quorum_names":["node-a","node-b"]}`, nil).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.ErrorIs(t, err, ErrKeepOneInvariant)
+}
+
+func TestEnsureMonAbsentRemovesAndConfirmsMembership(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"},{"name":"node-b"}]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "stat", "-f", "json").
+		Return(`{"quorum":[{"rank":0,"name":"node-a"},{"rank":1,"name":"node-b"}]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "rm", "node-a").
+		Return("", nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-b"}]}`, nil).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.NoError(t, err)
+}
+
+func TestEnsureMonAbsentAcceptsAmbiguousSuccessWithDetachedVerification(t *testing.T) {
+	r := withMockRunner(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"},{"name":"node-b"}]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "stat", "-f", "json").
+		Return(`{"quorum_names":["node-a","node-b"]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "rm", "node-a").
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return("", context.Canceled).Once()
+	// The command response was lost and cancelled the request context. The
+	// postcondition check must use a fresh bounded context, not the cancelled
+	// parent, and proves that membership removal committed.
+	liveBoundedContext := mock.MatchedBy(func(checkCtx context.Context) bool {
+		_, hasDeadline := checkCtx.Deadline()
+		return checkCtx.Err() == nil && hasDeadline
+	})
+	r.On("RunCommandContext", liveBoundedContext, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-b"}]}`, nil).Once()
+
+	err := ensureMonAbsent(ctx, "node-a")
+	assert.NoError(t, err)
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestEnsureMonAbsentPreservesRemovalFailure(t *testing.T) {
+	r := withMockRunner(t)
+	removeErr := errors.New("monmap update failed")
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"},{"name":"node-b"}]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "stat", "-f", "json").
+		Return(`{"quorum_names":["node-a","node-b"]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "rm", "node-a").
+		Return("", removeErr).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"},{"name":"node-b"}]}`, nil).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.ErrorIs(t, err, removeErr)
+}
+
+func TestEnsureMonAbsentFailsWhenSuccessfulRemovalCannotBeVerified(t *testing.T) {
+	r := withMockRunner(t)
+	verifyErr := errors.New("verification unavailable")
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":[{"name":"node-a"},{"name":"node-b"}]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "stat", "-f", "json").
+		Return(`{"quorum_names":["node-a","node-b"]}`, nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "rm", "node-a").
+		Return("", nil).Once()
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return("", verifyErr).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.ErrorIs(t, err, verifyErr)
+}
+
+func TestEnsureMonAbsentRejectsMalformedMonmap(t *testing.T) {
+	r := withMockRunner(t)
+	r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+		Return(`{"mons":`, nil).Once()
+
+	err := ensureMonAbsent(context.Background(), "node-a")
+	assert.ErrorContains(t, err, "failed to parse monitor map")
+}
+
+func TestEnsureMonAbsentRejectsIncompleteMonmap(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantErrMsg string
+	}{
+		{
+			name:       "null document",
+			output:     `null`,
+			wantErrMsg: `missing "mons" field`,
+		},
+		{
+			name:       "missing monitors",
+			output:     `{}`,
+			wantErrMsg: `missing "mons" field`,
+		},
+		{
+			name:       "null monitors",
+			output:     `{"mons":null}`,
+			wantErrMsg: `"mons" must be a non-null array`,
+		},
+		{
+			name:       "non-array monitors",
+			output:     `{"mons":{}}`,
+			wantErrMsg: `invalid "mons" field`,
+		},
+		{
+			name:       "empty monitors",
+			output:     `{"mons":[]}`,
+			wantErrMsg: `"mons" must contain at least one monitor`,
+		},
+		{
+			name:       "monitor without name",
+			output:     `{"mons":[{}]}`,
+			wantErrMsg: "monitor at index 0 has no name",
+		},
+		{
+			name:       "monitor with null name",
+			output:     `{"mons":[{"name":null}]}`,
+			wantErrMsg: "monitor at index 0 has no name",
+		},
+		{
+			name:       "monitor with empty name",
+			output:     `{"mons":[{"name":""}]}`,
+			wantErrMsg: "monitor at index 0 has no name",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := withMockRunner(t)
+			r.On("RunCommandContext", mock.Anything, "ceph", "mon", "dump", "-f", "json").
+				Return(test.output, nil).Once()
+
+			err := ensureMonAbsent(context.Background(), "node-a")
+
+			assert.ErrorContains(t, err, test.wantErrMsg)
+		})
+	}
+}

--- a/microceph/ceph/pre_remove_test.go
+++ b/microceph/ceph/pre_remove_test.go
@@ -1,15 +1,16 @@
 package ceph
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
 	"github.com/canonical/microceph/microceph/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/stretchr/testify/suite"
 )
 
 type clusterRemoveSuite struct {
@@ -112,4 +113,70 @@ func (s *clusterRemoveSuite) TestRemoveNodeForce() {
 	err := removeNode(nil, "foonode", true)
 
 	assert.NoError(s.T(), err)
+}
+
+func (s *clusterRemoveSuite) TestRemoveNodeReturnsServiceDeletionFailure() {
+	m := mocks.NewClientInterface(s.T())
+	client.MClient = m
+
+	m.On("GetClusterMembers", mock.Anything).Return([]string{"foonode", "barnode", "quuxnode"}, nil).Once()
+	m.On("GetDisks", mock.Anything).Return(types.Disks{}, nil).Once()
+	services := types.Services{
+		{Service: "mon", Location: "foonode"},
+		{Service: "mon", Location: "barnode"},
+		{Service: "mon", Location: "quuxnode"},
+		{Service: "mon", Location: "othernode"},
+		{Service: "mgr", Location: "barnode"},
+		{Service: "mds", Location: "barnode"},
+	}
+	m.On("GetServices", mock.Anything).Return(services, nil).Twice()
+	monSafetyErr := errors.New("monitor removal would lose quorum")
+	m.On("DeleteService", mock.Anything, "foonode", "mon").Return(monSafetyErr).Once()
+
+	err := removeNode(nil, "foonode", false)
+
+	assert.ErrorIs(s.T(), err, monSafetyErr)
+	assert.ErrorContains(s.T(), err, `failed to delete service "mon" on node "foonode"`)
+}
+
+func (s *clusterRemoveSuite) TestRemoveNodeForceSuppressesServiceDeletionFailure() {
+	m := mocks.NewClientInterface(s.T())
+	client.MClient = m
+
+	services := types.Services{
+		{Service: "mon", Location: "foonode"},
+		{Service: "mgr", Location: "foonode"},
+	}
+	m.On("GetServices", mock.Anything).Return(services, nil).Once()
+	monSafetyErr := errors.New("monitor removal would lose quorum")
+	mgrDeleteErr := errors.New("manager deletion failed")
+	m.On("DeleteService", mock.Anything, "foonode", "mon").Return(monSafetyErr).Once()
+	m.On("DeleteService", mock.Anything, "foonode", "mgr").Return(mgrDeleteErr).Once()
+
+	err := removeNode(nil, "foonode", true)
+
+	assert.NoError(s.T(), err)
+}
+
+func (s *clusterRemoveSuite) TestDeleteNodeServicesAggregatesFailures() {
+	m := mocks.NewClientInterface(s.T())
+	client.MClient = m
+
+	services := types.Services{
+		{Service: "mon", Location: "foonode"},
+		{Service: "mgr", Location: "foonode"},
+		{Service: "mds", Location: "barnode"},
+	}
+	m.On("GetServices", mock.Anything).Return(services, nil).Once()
+	monDeleteErr := errors.New("monitor deletion failed")
+	mgrDeleteErr := errors.New("manager deletion failed")
+	m.On("DeleteService", mock.Anything, "foonode", "mon").Return(monDeleteErr).Once()
+	m.On("DeleteService", mock.Anything, "foonode", "mgr").Return(mgrDeleteErr).Once()
+
+	err := deleteNodeServices(nil, "foonode")
+
+	assert.ErrorIs(s.T(), err, monDeleteErr)
+	assert.ErrorIs(s.T(), err, mgrDeleteErr)
+	assert.ErrorContains(s.T(), err, `failed to delete service "mon" on node "foonode"`)
+	assert.ErrorContains(s.T(), err, `failed to delete service "mgr" on node "foonode"`)
 }

--- a/microceph/ceph/remove.go
+++ b/microceph/ceph/remove.go
@@ -2,14 +2,15 @@ package ceph
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/canonical/microceph/microceph/logger"
 	"github.com/canonical/microcluster/v3/microcluster"
 	mcTypes "github.com/canonical/microcluster/v3/microcluster/types"
 
 	"github.com/canonical/microceph/microceph/api/types"
 	"github.com/canonical/microceph/microceph/client"
+	"github.com/canonical/microceph/microceph/logger"
 )
 
 // PreRemove cleans up the underlying ceph services before the node is removed from the dqlite cluster.
@@ -131,6 +132,8 @@ func deleteNodeServices(cli mcTypes.Client, name string) error {
 	if err != nil {
 		return err
 	}
+
+	deleteErrors := []error{}
 	for _, service := range services {
 		logger.Debugf("Check for deletion: %s", service)
 		if service.Location == name {
@@ -138,8 +141,10 @@ func deleteNodeServices(cli mcTypes.Client, name string) error {
 			err = client.MClient.DeleteService(cli, service.Location, service.Service)
 			if err != nil {
 				logger.Warnf("Fault deleting service %v on node %v: %v", service.Service, service.Location, err)
+				deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete service %q on node %q: %w", service.Service, service.Location, err))
 			}
 		}
 	}
-	return nil
+
+	return errors.Join(deleteErrors...)
 }

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -216,6 +216,11 @@ var (
 	removeServiceDatabaseFunc = removeServiceDatabase
 )
 
+// ensureMgrAbsentFunc / ensureMdsAbsentFunc are declared alongside their
+// implementations in manager.go and metadata.go respectively; DeleteService
+// invokes them through those injectable vars so teardown ordering and failure
+// boundaries stay unit-testable.
+
 // DeleteService deletes a service from the node.
 func DeleteService(ctx context.Context, s interfaces.StateInterface, service string) error {
 	// Serialize teardown with bootstrap, join, service enablement, and startup
@@ -242,6 +247,27 @@ func DeleteService(ctx context.Context, s interfaces.StateInterface, service str
 	if err != nil {
 		logger.Errorf("failed to stop daemon %q: %v", service, err)
 		return fmt.Errorf("failed to stop daemon %q: %w", service, err)
+	}
+
+	// After the local daemon is stopped, actively evict MGR/MDS from their
+	// Ceph maps and verify convergence. Stopping alone only halts the daemon's
+	// beacon; without an explicit fail the stopped daemon lingers in
+	// `ceph mgr metadata` / `ceph mds stat` for the beacon-aging window, so a
+	// reconcile would report success while the map still shows the removed
+	// member. MON is handled above (before stop) because its removal needs
+	// quorum. All ensure*Absent helpers are idempotent, so a retry after a
+	// later phase failed resumes cleanly.
+	switch service {
+	case "mgr":
+		err = ensureMgrAbsentFunc(ctx, hostname)
+		if err != nil {
+			return fmt.Errorf("failed to remove mgr map membership %q: %w", hostname, err)
+		}
+	case "mds":
+		err = ensureMdsAbsentFunc(ctx, hostname)
+		if err != nil {
+			return fmt.Errorf("failed to remove mds map membership %q: %w", hostname, err)
+		}
 	}
 
 	err = cleanServiceFunc(hostname, service)

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -207,29 +207,50 @@ func removeServiceDatabase(ctx context.Context, s interfaces.StateInterface, ser
 	return err
 }
 
+// Delete-service phases are injectable so tests can verify their ordering and
+// failure boundaries without mutating snap, Ceph, filesystem, or dqlite state.
+var (
+	ensureMonAbsentFunc       = ensureMonAbsent
+	snapStopFunc              = snapStop
+	cleanServiceFunc          = cleanService
+	removeServiceDatabaseFunc = removeServiceDatabase
+)
+
 // DeleteService deletes a service from the node.
 func DeleteService(ctx context.Context, s interfaces.StateInterface, service string) error {
-	err := snapStop(service, true)
+	// Serialize teardown with bootstrap, join, service enablement, and startup
+	// re-enablement. In particular, reEnableServices must not observe the service
+	// DB row mid-delete and restart a MON that was already removed from the
+	// monmap.
+	serviceStartMu.Lock()
+	defer serviceStartMu.Unlock()
+
+	hostname := s.ClusterState().Name()
+
+	if service == "mon" {
+		// Commit membership removal while the source MON is still running. With
+		// two MONs, stopping one first loses the majority needed by `ceph mon rm`.
+		// ensureMonAbsent is idempotent, so retries after a later phase failed
+		// resume local teardown rather than trying to recreate membership.
+		err := ensureMonAbsentFunc(ctx, hostname)
+		if err != nil {
+			return fmt.Errorf("failed to remove monitor membership %q: %w", hostname, err)
+		}
+	}
+
+	err := snapStopFunc(service, true)
 	if err != nil {
 		logger.Errorf("failed to stop daemon %q: %v", service, err)
 		return fmt.Errorf("failed to stop daemon %q: %w", service, err)
 	}
 
-	if service == "mon" {
-		err = removeMon(s.ClusterState().Name())
-		if err != nil {
-			return err
-		}
-	}
-
-	err = cleanService(s.ClusterState().Name(), service)
+	err = cleanServiceFunc(hostname, service)
 	if err != nil {
 		return fmt.Errorf("failed to clean service %q: %w", service, err)
 	}
-	err = removeServiceDatabase(ctx, s, service)
+	err = removeServiceDatabaseFunc(ctx, s, service)
 	if err != nil {
 		return fmt.Errorf("failed to remove service %q from database: %w", service, err)
 	}
 	return nil
-
 }

--- a/microceph/ceph/services_placement.go
+++ b/microceph/ceph/services_placement.go
@@ -74,6 +74,10 @@ func ServicePlacementHandler(ctx context.Context, s interfaces.StateInterface, p
 // tests of the placement pipeline can bypass database-dependent config
 // rendering.
 func EnableService(ctx context.Context, s interfaces.StateInterface, payload types.EnableService, item PlacementIntf) error {
+	// Serialize direct service placement with bootstrap, join, deletion, and
+	// startup re-enablement so their snapctl and database phases cannot overlap.
+	serviceStartMu.Lock()
+	defer serviceStartMu.Unlock()
 
 	// Ensure ceph.conf and the admin keyring are rendered from the shared
 	// cluster database before enabling any service. This is intentional for

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -1,12 +1,16 @@
 package ceph
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/canonical/microceph/microceph/common"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/canonical/microceph/microceph/common"
+	"github.com/canonical/microceph/microceph/interfaces"
 
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/microceph/microceph/api/types"
@@ -36,7 +40,7 @@ func (s *servicesSuite) SetupTest() {
 		URL:         u,
 		ClusterName: "foohost",
 	}
-	s.TestStateInterface.On("ClusterState").Return(state).Maybe()
+	s.TestStateInterface.On("ClusterState").Return(&state).Maybe()
 }
 
 func addOsdDumpExpectations(r *mocks.Runner) {
@@ -102,4 +106,106 @@ func (s *servicesSuite) TestCleanService() {
 	_ = os.MkdirAll(svcPath, 0770)
 	_ = cleanService("foo-host", "mon")
 	assert.NoDirExists(s.T(), svcPath)
+}
+
+// installDeleteServiceRecorder replaces the external deletion phases and
+// records their exact order. The originals are restored after each test.
+func installDeleteServiceRecorder(t *testing.T, stopErr error) *[]string {
+	origEnsureMonAbsent := ensureMonAbsentFunc
+	origSnapStop := snapStopFunc
+	origCleanService := cleanServiceFunc
+	origRemoveServiceDatabase := removeServiceDatabaseFunc
+	t.Cleanup(func() {
+		ensureMonAbsentFunc = origEnsureMonAbsent
+		snapStopFunc = origSnapStop
+		cleanServiceFunc = origCleanService
+		removeServiceDatabaseFunc = origRemoveServiceDatabase
+	})
+
+	events := []string{}
+	ensureMonAbsentFunc = func(_ context.Context, hostname string) error {
+		events = append(events, "monmap:"+hostname)
+		return nil
+	}
+	snapStopFunc = func(service string, disable bool) error {
+		events = append(events, fmt.Sprintf("stop:%s:%t", service, disable))
+		return stopErr
+	}
+	cleanServiceFunc = func(hostname, service string) error {
+		events = append(events, "clean:"+service+":"+hostname)
+		return nil
+	}
+	removeServiceDatabaseFunc = func(_ context.Context, _ interfaces.StateInterface, service string) error {
+		events = append(events, "db:"+service)
+		return nil
+	}
+	return &events
+}
+
+func (s *servicesSuite) TestDeleteMonRemovesMembershipBeforeStoppingDaemon() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+
+	err := DeleteService(context.Background(), s.TestStateInterface, "mon")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), []string{
+		"monmap:foohost",
+		"stop:mon:true",
+		"clean:mon:foohost",
+		"db:mon",
+	}, *events)
+}
+
+func (s *servicesSuite) TestDeleteMonMembershipFailureLeavesDaemonRunning() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+	membershipErr := errors.New("monmap unavailable")
+	ensureMonAbsentFunc = func(_ context.Context, hostname string) error {
+		*events = append(*events, "monmap:"+hostname)
+		return membershipErr
+	}
+
+	err := DeleteService(context.Background(), s.TestStateInterface, "mon")
+	assert.ErrorIs(s.T(), err, membershipErr)
+	assert.Equal(s.T(), []string{"monmap:foohost"}, *events)
+}
+
+func (s *servicesSuite) TestDeleteMonResumesAfterStopFailure() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+	stopErr := errors.New("snap stop failed")
+	stopAttempts := 0
+	snapStopFunc = func(service string, disable bool) error {
+		*events = append(*events, fmt.Sprintf("stop:%s:%t", service, disable))
+		stopAttempts++
+		if stopAttempts == 1 {
+			return stopErr
+		}
+		return nil
+	}
+
+	// The first pass models a committed monmap update followed by a local stop
+	// failure. The retained DB row causes a retry; ensureMonAbsent is idempotent
+	// and local teardown then finishes.
+	err := DeleteService(context.Background(), s.TestStateInterface, "mon")
+	assert.ErrorIs(s.T(), err, stopErr)
+	err = DeleteService(context.Background(), s.TestStateInterface, "mon")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), []string{
+		"monmap:foohost",
+		"stop:mon:true",
+		"monmap:foohost",
+		"stop:mon:true",
+		"clean:mon:foohost",
+		"db:mon",
+	}, *events)
+}
+
+func (s *servicesSuite) TestDeleteNonMonRetainsStopFirstOrder() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+
+	err := DeleteService(context.Background(), s.TestStateInterface, "mgr")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), []string{
+		"stop:mgr:true",
+		"clean:mgr:foohost",
+		"db:mgr",
+	}, *events)
 }

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -112,11 +112,15 @@ func (s *servicesSuite) TestCleanService() {
 // records their exact order. The originals are restored after each test.
 func installDeleteServiceRecorder(t *testing.T, stopErr error) *[]string {
 	origEnsureMonAbsent := ensureMonAbsentFunc
+	origEnsureMgrAbsent := ensureMgrAbsentFunc
+	origEnsureMdsAbsent := ensureMdsAbsentFunc
 	origSnapStop := snapStopFunc
 	origCleanService := cleanServiceFunc
 	origRemoveServiceDatabase := removeServiceDatabaseFunc
 	t.Cleanup(func() {
 		ensureMonAbsentFunc = origEnsureMonAbsent
+		ensureMgrAbsentFunc = origEnsureMgrAbsent
+		ensureMdsAbsentFunc = origEnsureMdsAbsent
 		snapStopFunc = origSnapStop
 		cleanServiceFunc = origCleanService
 		removeServiceDatabaseFunc = origRemoveServiceDatabase
@@ -125,6 +129,14 @@ func installDeleteServiceRecorder(t *testing.T, stopErr error) *[]string {
 	events := []string{}
 	ensureMonAbsentFunc = func(_ context.Context, hostname string) error {
 		events = append(events, "monmap:"+hostname)
+		return nil
+	}
+	ensureMgrAbsentFunc = func(_ context.Context, hostname string) error {
+		events = append(events, "mgrmap:"+hostname)
+		return nil
+	}
+	ensureMdsAbsentFunc = func(_ context.Context, hostname string) error {
+		events = append(events, "mdsmap:"+hostname)
 		return nil
 	}
 	snapStopFunc = func(service string, disable bool) error {
@@ -198,14 +210,46 @@ func (s *servicesSuite) TestDeleteMonResumesAfterStopFailure() {
 	}, *events)
 }
 
-func (s *servicesSuite) TestDeleteNonMonRetainsStopFirstOrder() {
+func (s *servicesSuite) TestDeleteMgrEvictsMapAfterStoppingDaemon() {
 	events := installDeleteServiceRecorder(s.T(), nil)
 
 	err := DeleteService(context.Background(), s.TestStateInterface, "mgr")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), []string{
 		"stop:mgr:true",
+		"mgrmap:foohost",
 		"clean:mgr:foohost",
 		"db:mgr",
+	}, *events)
+}
+
+func (s *servicesSuite) TestDeleteMdsEvictsMapAfterStoppingDaemon() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+
+	err := DeleteService(context.Background(), s.TestStateInterface, "mds")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), []string{
+		"stop:mds:true",
+		"mdsmap:foohost",
+		"clean:mds:foohost",
+		"db:mds",
+	}, *events)
+}
+
+func (s *servicesSuite) TestDeleteMgrMapFailureLeavesCleanupPending() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+	mapErr := errors.New("mgr map unavailable")
+	ensureMgrAbsentFunc = func(_ context.Context, hostname string) error {
+		*events = append(*events, "mgrmap:"+hostname)
+		return mapErr
+	}
+
+	err := DeleteService(context.Background(), s.TestStateInterface, "mgr")
+	assert.ErrorIs(s.T(), err, mapErr)
+	// The daemon is stopped and eviction attempted, but on-disk and DB cleanup
+	// must not run so a retry resumes teardown.
+	assert.Equal(s.T(), []string{
+		"stop:mgr:true",
+		"mgrmap:foohost",
 	}, *events)
 }

--- a/tests/robot/deferred-ceph-multinode-tests/deferred_ceph_multinode_tests.robot
+++ b/tests/robot/deferred-ceph-multinode-tests/deferred_ceph_multinode_tests.robot
@@ -68,14 +68,35 @@ Test Declarative Control Placement Add
     Wait For Mon Count    2
     Run In Container    node-wrk0    microceph.ceph -s    30
 
+Test Declarative Control Placement Migration Preserves Quorum
+    [Documentation]    Moving the only desired control placement from the bootstrap member
+    ...    to its replacement must commit MON membership removal before stopping the source.
+    ...    The destination remains a one-MON quorum and repeating the policy is idempotent.
+    [Tags]    placement    migration
+    ${policy}=    Set Variable    {"mode":"reconcile","members":{"node-wrk0":{"control":true},"node-wrk1":{"control":false}}}
+    ${resp}=    MicroCeph API Put In Container    node-wrk0    placement    ${policy}
+    ${code}=    Response Status Code    ${resp}
+    Should Be Equal As Integers    ${code}    200    msg=Control migration failed: ${resp}
+    ${mons}=    Get Mon Count
+    Should Be Equal As Integers    ${mons}    1    msg=Expected destination-only monmap after migration
+    Assert Mon Quorum Members    node-wrk0
+    Assert Member Has Control Services    node-wrk0    yes
+    Assert Member Has Control Services    node-wrk1    no
+
+    # A second reconcile must observe the completed migration as a no-op.
+    ${retry}=    MicroCeph API Put In Container    node-wrk0    placement    ${policy}
+    ${retry_code}=    Response Status Code    ${retry}
+    Should Be Equal As Integers    ${retry_code}    200    msg=Idempotent migration retry failed: ${retry}
+    Assert Mon Quorum Members    node-wrk0
+
 Test Declarative Control Placement Keep One Invariant
     [Documentation]    A placement that would remove the last control service must be
     ...    rejected with a clear keep-one reason (HTTP non-2xx / error), and the last MON must
     ...    remain. We request control:false on the only control member while no other control
     ...    member exists.
     [Tags]    placement
-    # node-wrk1 has control from bootstrap; node-wrk0 has control from the previous test.
-    # Request control:false on BOTH current control members at once -> keep-one refuses the last.
+    # node-wrk0 is the only control member after the preceding migration.
+    # Include the already-drained bootstrap member as false as an idempotency check.
     ${resp}=    MicroCeph API Put In Container    node-wrk0    placement    {"mode":"reconcile","members":{"node-wrk0":{"control":false},"node-wrk1":{"control":false}}}
     ${code}=    Response Status Code    ${resp}
     Run Keyword And Continue On Failure    Should Not Be Equal As Integers    ${code}    200

--- a/tests/robot/deferred-ceph-multinode-tests/deferred_ceph_multinode_tests.robot
+++ b/tests/robot/deferred-ceph-multinode-tests/deferred_ceph_multinode_tests.robot
@@ -81,7 +81,12 @@ Test Declarative Control Placement Migration Preserves Quorum
     Should Be Equal As Integers    ${mons}    1    msg=Expected destination-only monmap after migration
     Assert Mon Quorum Members    node-wrk0
     Assert Member Has Control Services    node-wrk0    yes
-    Assert Member Has Control Services    node-wrk1    no
+    # The source's MON/MDS/MGR teardown commits the daemon stop, map eviction,
+    # and DB removal, but the mgrmap/fsmap may take a moment to converge (or up
+    # to the beacon-aging window if an eviction was a no-op). Poll for absence
+    # rather than asserting a single-shot snapshot, mirroring the add path's
+    # Wait For Mon Count.
+    Wait For Member Control Services    node-wrk1    no
 
     # A second reconcile must observe the completed migration as a no-op.
     ${retry}=    MicroCeph API Put In Container    node-wrk0    placement    ${policy}

--- a/tests/robot/resources/microceph_harness.py
+++ b/tests/robot/resources/microceph_harness.py
@@ -1888,8 +1888,12 @@ class microceph_harness:
                 f"Expected MON quorum {expected}, got {actual}. quorum_status: {res.stdout}"
             )
 
-    def assert_member_has_control_services(self, member, expected="yes"):
-        """Assert explicit MON, MGR, and MDS presence or absence on *member*."""
+    def _observe_control_services(self, member):
+        """Return the explicit MON/MGR/MDS presence dict for *member* from Ceph.
+
+        Raises AssertionError if any of the three Ceph queries fail, so callers
+        can distinguish an unreadable cluster from a genuine presence result.
+        """
         commands = {
             "mon": ("quorum_status", "-f", "json"),
             "mgr": ("mgr", "metadata", "-f", "json"),
@@ -1911,12 +1915,16 @@ class microceph_harness:
             )
             raise AssertionError(f"Unable to inspect control services: {detail}")
 
-        present = placement_status.control_service_presence(
+        return placement_status.control_service_presence(
             results["mon"].stdout,
             results["mgr"].stdout,
             results["mds"].stdout,
             member,
         )
+
+    def assert_member_has_control_services(self, member, expected="yes"):
+        """Assert explicit MON, MGR, and MDS presence or absence on *member*."""
+        present = self._observe_control_services(member)
         want_present = str(expected).strip().lower() == "yes"
         mismatched = [
             service for service, is_present in present.items() if is_present != want_present
@@ -1926,6 +1934,36 @@ class microceph_harness:
             raise AssertionError(
                 f"Expected {mismatched} to be {expectation} on {member}; observed {present}"
             )
+
+    def wait_for_member_control_services(self, member, expected="yes", tries=24, interval=5):
+        """Poll until MON, MGR, and MDS presence on *member* matches *expected*.
+
+        Control-service teardown commits the daemon stop, map eviction, and DB
+        removal, but Ceph's mgrmap/fsmap can still take a moment to converge
+        (and, if an eviction is a partial no-op, up to the beacon-aging grace
+        window). This poller absorbs that convergence lag so an immediately
+        following absence assertion is not racy, mirroring how the add path
+        polls with Wait For Mon Count. The final observed state is folded into
+        the failure message on timeout.
+        """
+        want_present = str(expected).strip().lower() == "yes"
+        expectation = "present" if want_present else "absent"
+        last = {}
+
+        def predicate():
+            nonlocal last
+            last = self._observe_control_services(member)
+            return all(is_present == want_present for is_present in last.values())
+
+        self._poll_until(
+            predicate,
+            attempts=tries,
+            interval=interval,
+            fail_msg=lambda: (
+                f"Control services on {member} never became {expectation}; "
+                f"last observed {last}"
+            ),
+        )
 
     def assert_no_ceph_cluster_on_container(self, container):
         """Asserts that *container* has NOT bootstrapped Ceph: ceph status fails

--- a/tests/robot/resources/microceph_harness.py
+++ b/tests/robot/resources/microceph_harness.py
@@ -1924,7 +1924,14 @@ class microceph_harness:
 
     def assert_member_has_control_services(self, member, expected="yes"):
         """Assert explicit MON, MGR, and MDS presence or absence on *member*."""
-        present = self._observe_control_services(member)
+        try:
+            present = self._observe_control_services(member)
+        except ValueError as exc:
+            # Unparseable Ceph output cannot prove presence *or* absence; fail
+            # rather than silently treating garbage as "service absent".
+            raise AssertionError(
+                f"Unable to determine control services on {member}: {exc}"
+            )
         want_present = str(expected).strip().lower() == "yes"
         mismatched = [
             service for service, is_present in present.items() if is_present != want_present
@@ -1952,7 +1959,14 @@ class microceph_harness:
 
         def predicate():
             nonlocal last
-            last = self._observe_control_services(member)
+            try:
+                last = self._observe_control_services(member)
+            except ValueError as exc:
+                # Bad or empty Ceph output does not confirm the target state.
+                # Record it and keep polling so an absence check never passes
+                # on garbage; if it persists, the timeout surfaces the error.
+                last = {"error": str(exc)}
+                return False
             return all(is_present == want_present for is_present in last.values())
 
         self._poll_until(

--- a/tests/robot/resources/microceph_harness.py
+++ b/tests/robot/resources/microceph_harness.py
@@ -1872,24 +1872,60 @@ class microceph_harness:
             fail_msg=f"Never reached {n} mon daemons",
         )
 
-    def assert_member_has_control_services(self, member, expected="yes"):
-        """Asserts that mon/mgr/mds are present on *member* via ceph -s on the head node.
+    def assert_mon_quorum_members(self, *expected_members):
+        """Assert that the Ceph MON quorum contains exactly *expected_members*."""
+        res = self.exec_in_container(
+            HEAD_NODE, "microceph.ceph", "quorum_status", "-f", "json", timeout=30
+        )
+        if res.rc != 0:
+            raise AssertionError(
+                f"Unable to read MON quorum (rc={res.rc}): {res.stderr or res.stdout}"
+            )
+        actual = sorted(placement_status.mon_quorum_names(res.stdout))
+        expected = sorted(str(name) for name in expected_members)
+        if actual != expected:
+            raise AssertionError(
+                f"Expected MON quorum {expected}, got {actual}. quorum_status: {res.stdout}"
+            )
 
-        *expected* is 'yes' or 'no'.
-        """
-        res = self.exec_in_container(HEAD_NODE, "microceph.ceph", "-s", timeout=30)
-        status = res.stdout if res.rc == 0 else ""
-        present = placement_status.member_in_ceph_status(status, member)
-        if str(expected).strip().lower() == "yes":
-            if not present:
-                raise AssertionError(
-                    f"{member} not found in ceph status; expected control services there. Status: {status}"
-                )
-        else:
-            if present:
-                raise AssertionError(
-                    f"{member} unexpectedly in ceph status; expected no control services there. Status: {status}"
-                )
+    def assert_member_has_control_services(self, member, expected="yes"):
+        """Assert explicit MON, MGR, and MDS presence or absence on *member*."""
+        commands = {
+            "mon": ("quorum_status", "-f", "json"),
+            "mgr": ("mgr", "metadata", "-f", "json"),
+            "mds": ("mds", "stat", "-f", "json"),
+        }
+        results = {
+            service: self.exec_in_container(HEAD_NODE, "microceph.ceph", *args, timeout=30)
+            for service, args in commands.items()
+        }
+        failed = {
+            service: result
+            for service, result in results.items()
+            if result.rc != 0
+        }
+        if failed:
+            detail = "; ".join(
+                f"{service}: rc={result.rc}, output={result.stderr or result.stdout}"
+                for service, result in failed.items()
+            )
+            raise AssertionError(f"Unable to inspect control services: {detail}")
+
+        present = placement_status.control_service_presence(
+            results["mon"].stdout,
+            results["mgr"].stdout,
+            results["mds"].stdout,
+            member,
+        )
+        want_present = str(expected).strip().lower() == "yes"
+        mismatched = [
+            service for service, is_present in present.items() if is_present != want_present
+        ]
+        if mismatched:
+            expectation = "present" if want_present else "absent"
+            raise AssertionError(
+                f"Expected {mismatched} to be {expectation} on {member}; observed {present}"
+            )
 
     def assert_no_ceph_cluster_on_container(self, container):
         """Asserts that *container* has NOT bootstrapped Ceph: ceph status fails

--- a/tests/robot/resources/placement_status.py
+++ b/tests/robot/resources/placement_status.py
@@ -89,11 +89,99 @@ def mon_count(raw):
     return 0
 
 
+def mon_quorum_names(raw):
+    """Return MON names in quorum from ``ceph quorum_status -f json``.
+
+    Current Ceph output includes ``quorum_names`` directly. On schemas where
+    that field is absent, ``quorum`` contains numeric monitor ranks; resolve
+    those ranks through ``monmap.mons``. Malformed or incomplete responses
+    return an empty list so assertions fail closed.
+    """
+    data = _parse(raw)
+    if not isinstance(data, dict):
+        return []
+
+    if "quorum_names" in data:
+        quorum_names = data["quorum_names"]
+        if not isinstance(quorum_names, list):
+            return []
+        if not all(isinstance(name, str) and name for name in quorum_names):
+            return []
+        return quorum_names
+
+    quorum = data.get("quorum")
+    monmap = data.get("monmap")
+    if not isinstance(quorum, list) or not isinstance(monmap, dict):
+        return []
+    mons = monmap.get("mons")
+    if not isinstance(mons, list):
+        return []
+
+    names_by_rank = {}
+    for mon in mons:
+        if not isinstance(mon, dict):
+            return []
+        rank = mon.get("rank")
+        name = mon.get("name")
+        if type(rank) is not int or not isinstance(name, str) or not name:
+            return []
+        names_by_rank[rank] = name
+
+    names = []
+    for rank in quorum:
+        if type(rank) is not int or rank not in names_by_rank:
+            return []
+        names.append(names_by_rank[rank])
+    return names
+
+
+def control_service_presence(mon_raw, mgr_raw, mds_raw, member):
+    """Return explicit MON/MGR/MDS membership for *member* from Ceph JSON.
+
+    Invalid responses fail closed for each service. This is stricter than a
+    substring search over ``ceph -s``: a hostname appearing anywhere in status
+    does not prove that all three role-managed control services are present.
+    """
+    mgr = _parse(mgr_raw)
+    mds = _parse(mds_raw)
+
+    mon_names = mon_quorum_names(mon_raw)
+
+    mgr_names = []
+    if isinstance(mgr, list):
+        mgr_names = [entry.get("name") for entry in mgr if isinstance(entry, dict)]
+
+    mds_names = []
+    if isinstance(mds, dict) and isinstance(mds.get("fsmap"), dict):
+        fsmap = mds["fsmap"]
+        standbys = fsmap.get("standbys", [])
+        if isinstance(standbys, list):
+            mds_names.extend(
+                entry.get("name") for entry in standbys if isinstance(entry, dict)
+            )
+        filesystems = fsmap.get("filesystems", [])
+        if isinstance(filesystems, list):
+            for filesystem in filesystems:
+                if not isinstance(filesystem, dict):
+                    continue
+                mdsmap = filesystem.get("mdsmap", {})
+                info = mdsmap.get("info", {}) if isinstance(mdsmap, dict) else {}
+                if isinstance(info, dict):
+                    mds_names.extend(
+                        entry.get("name") for entry in info.values() if isinstance(entry, dict)
+                    )
+
+    return {
+        "mon": member in mon_names,
+        "mgr": member in mgr_names,
+        "mds": member in mds_names,
+    }
+
+
 def member_in_ceph_status(status_text, member):
     """Return True when *member* appears in ``ceph -s`` output.
 
-    Preserves the original suite decision (a substring check over the status
-    text: MON/MGR/MDS entries name their host) while keeping it local and
-    unit-testable instead of embedded in a remote shell pipeline.
+    Retained for callers that explicitly need the historical broad status-text
+    check. Control-placement assertions use :func:`control_service_presence`.
     """
     return member in (status_text or "")

--- a/tests/robot/resources/placement_status.py
+++ b/tests/robot/resources/placement_status.py
@@ -138,38 +138,49 @@ def mon_quorum_names(raw):
 def control_service_presence(mon_raw, mgr_raw, mds_raw, member):
     """Return explicit MON/MGR/MDS membership for *member* from Ceph JSON.
 
-    Invalid responses fail closed for each service. This is stricter than a
-    substring search over ``ceph -s``: a hostname appearing anywhere in status
-    does not prove that all three role-managed control services are present.
+    This is stricter than a substring search over ``ceph -s``: a hostname
+    appearing anywhere in status does not prove that all three role-managed
+    control services are present.
+
+    Raises :class:`ValueError` when any of the three raw bodies is not
+    parseable into its expected shape (bad or empty output). Treating an
+    unparseable body as "service absent" would let an absence assertion pass on
+    garbage rather than on a genuine removal, so callers must decide explicitly
+    whether to fail or retry -- see :meth:`wait_for_member_control_services`,
+    which retries, and :meth:`assert_member_has_control_services`, which fails.
     """
+    mon = _parse(mon_raw)
+    if not isinstance(mon, dict):
+        raise ValueError(f"unparseable mon quorum_status output: {mon_raw!r}")
     mgr = _parse(mgr_raw)
+    if not isinstance(mgr, list):
+        raise ValueError(f"unparseable mgr metadata output: {mgr_raw!r}")
     mds = _parse(mds_raw)
+    if not isinstance(mds, dict) or not isinstance(mds.get("fsmap"), dict):
+        raise ValueError(f"unparseable mds stat output: {mds_raw!r}")
 
     mon_names = mon_quorum_names(mon_raw)
 
-    mgr_names = []
-    if isinstance(mgr, list):
-        mgr_names = [entry.get("name") for entry in mgr if isinstance(entry, dict)]
+    mgr_names = [entry.get("name") for entry in mgr if isinstance(entry, dict)]
 
     mds_names = []
-    if isinstance(mds, dict) and isinstance(mds.get("fsmap"), dict):
-        fsmap = mds["fsmap"]
-        standbys = fsmap.get("standbys", [])
-        if isinstance(standbys, list):
-            mds_names.extend(
-                entry.get("name") for entry in standbys if isinstance(entry, dict)
-            )
-        filesystems = fsmap.get("filesystems", [])
-        if isinstance(filesystems, list):
-            for filesystem in filesystems:
-                if not isinstance(filesystem, dict):
-                    continue
-                mdsmap = filesystem.get("mdsmap", {})
-                info = mdsmap.get("info", {}) if isinstance(mdsmap, dict) else {}
-                if isinstance(info, dict):
-                    mds_names.extend(
-                        entry.get("name") for entry in info.values() if isinstance(entry, dict)
-                    )
+    fsmap = mds["fsmap"]
+    standbys = fsmap.get("standbys", [])
+    if isinstance(standbys, list):
+        mds_names.extend(
+            entry.get("name") for entry in standbys if isinstance(entry, dict)
+        )
+    filesystems = fsmap.get("filesystems", [])
+    if isinstance(filesystems, list):
+        for filesystem in filesystems:
+            if not isinstance(filesystem, dict):
+                continue
+            mdsmap = filesystem.get("mdsmap", {})
+            info = mdsmap.get("info", {}) if isinstance(mdsmap, dict) else {}
+            if isinstance(info, dict):
+                mds_names.extend(
+                    entry.get("name") for entry in info.values() if isinstance(entry, dict)
+                )
 
     return {
         "mon": member in mon_names,

--- a/tests/robot/resources/test_harness_helpers.py
+++ b/tests/robot/resources/test_harness_helpers.py
@@ -1160,3 +1160,53 @@ def test_log_exec_no_output_prints_nothing(monkeypatch):
     cap = _with_logger(monkeypatch)
     H()._log_exec("mkdir -p ~/x", _Res(0, "", ""), quiet=False)
     assert cap.console_lines == []
+
+# ---------------------------------------------------------------------------
+# wait_for_member_control_services (polling absence/presence with convergence)
+# ---------------------------------------------------------------------------
+
+def _harness_with_observations(monkeypatch, observations):
+    """Return a harness whose _observe_control_services yields *observations*
+    in order (the last value repeats once exhausted), counting calls."""
+    h = H()
+    seq = list(observations)
+    state = {"calls": 0}
+
+    def fake_observe(member):
+        idx = min(state["calls"], len(seq) - 1)
+        state["calls"] += 1
+        return seq[idx]
+
+    monkeypatch.setattr(h, "_observe_control_services", fake_observe)
+    # Avoid real sleeps between probes.
+    monkeypatch.setattr(_mh.time, "sleep", lambda *_: None)
+    return h, state
+
+
+def test_wait_for_control_services_absent_after_convergence(monkeypatch):
+    # mgr lingers for the first two probes, then converges to fully absent.
+    observations = [
+        {"mon": False, "mgr": True, "mds": False},
+        {"mon": False, "mgr": True, "mds": False},
+        {"mon": False, "mgr": False, "mds": False},
+    ]
+    h, state = _harness_with_observations(monkeypatch, observations)
+    h.wait_for_member_control_services("node-wrk1", "no", tries=10, interval=0)
+    assert state["calls"] == 3
+
+
+def test_wait_for_control_services_present_immediately(monkeypatch):
+    observations = [{"mon": True, "mgr": True, "mds": True}]
+    h, state = _harness_with_observations(monkeypatch, observations)
+    h.wait_for_member_control_services("node-wrk0", "yes", tries=5, interval=0)
+    assert state["calls"] == 1
+
+
+def test_wait_for_control_services_absent_timeout_folds_last_observed(monkeypatch):
+    observations = [{"mon": False, "mgr": True, "mds": False}]
+    h, _ = _harness_with_observations(monkeypatch, observations)
+    with pytest.raises(AssertionError) as exc:
+        h.wait_for_member_control_services("node-wrk1", "no", tries=3, interval=0)
+    msg = str(exc.value)
+    assert "never became absent" in msg
+    assert "'mgr': True" in msg

--- a/tests/robot/resources/test_harness_helpers.py
+++ b/tests/robot/resources/test_harness_helpers.py
@@ -954,6 +954,99 @@ def test_mon_count_garbage_is_zero():
     assert placement_status.mon_count("{}") == 0
 
 
+def test_mon_quorum_names_prefers_explicit_names():
+    raw = json.dumps(
+        {
+            "quorum_names": ["node-a", "node-b"],
+            "quorum": [1],
+            "monmap": {"mons": [{"rank": 1, "name": "wrong-fallback"}]},
+        }
+    )
+    assert placement_status.mon_quorum_names(raw) == ["node-a", "node-b"]
+
+
+def test_mon_quorum_names_maps_numeric_ranks_through_monmap():
+    raw = json.dumps(
+        {
+            "quorum": [2, 0],
+            "monmap": {
+                "mons": [
+                    {"rank": 0, "name": "node-a"},
+                    {"rank": 1, "name": "node-b"},
+                    {"rank": 2, "name": "node-c"},
+                ]
+            },
+        }
+    )
+    assert placement_status.mon_quorum_names(raw) == ["node-c", "node-a"]
+
+
+def test_mon_quorum_names_malformed_fails_closed():
+    malformed = [
+        "bad",
+        "[]",
+        "{}",
+        json.dumps({"quorum": [0]}),
+        json.dumps({"quorum": [0], "monmap": {"mons": []}}),
+        json.dumps(
+            {
+                "quorum": [1],
+                "monmap": {"mons": [{"rank": 0, "name": "node-a"}]},
+            }
+        ),
+        json.dumps({"quorum_names": ["node-a", 1]}),
+        json.dumps(
+            {
+                "quorum_names": None,
+                "quorum": [0],
+                "monmap": {"mons": [{"rank": 0, "name": "node-a"}]},
+            }
+        ),
+    ]
+    for raw in malformed:
+        assert placement_status.mon_quorum_names(raw) == []
+
+
+def test_control_service_presence_requires_each_explicit_service():
+    mon = json.dumps({"quorum_names": ["node-a", "node-b"]})
+    mgr = json.dumps([{"name": "node-a"}, {"name": "node-b"}])
+    mds = json.dumps(
+        {
+            "fsmap": {
+                "standbys": [{"name": "node-b", "state": "up:standby"}],
+                "filesystems": [
+                    {
+                        "mdsmap": {
+                            "info": {
+                                "1": {"name": "node-a", "state": "up:active"}
+                            }
+                        }
+                    }
+                ],
+            }
+        }
+    )
+
+    assert placement_status.control_service_presence(mon, mgr, mds, "node-a") == {
+        "mon": True,
+        "mgr": True,
+        "mds": True,
+    }
+    assert placement_status.control_service_presence(mon, mgr, mds, "node-c") == {
+        "mon": False,
+        "mgr": False,
+        "mds": False,
+    }
+
+
+def test_control_service_presence_malformed_fails_closed():
+    assert placement_status.control_service_presence("bad", "bad", "bad", "node-a") == {
+        "mon": False,
+        "mgr": False,
+        "mds": False,
+    }
+
+
 def test_member_in_ceph_status_substring():
     status = "  services:\n    mon: 2 daemons, quorum node-wrk0,node-wrk1\n"
     assert placement_status.member_in_ceph_status(status, "node-wrk1") is True

--- a/tests/robot/resources/test_harness_helpers.py
+++ b/tests/robot/resources/test_harness_helpers.py
@@ -1039,12 +1039,25 @@ def test_control_service_presence_requires_each_explicit_service():
     }
 
 
-def test_control_service_presence_malformed_fails_closed():
-    assert placement_status.control_service_presence("bad", "bad", "bad", "node-a") == {
-        "mon": False,
-        "mgr": False,
-        "mds": False,
-    }
+def test_control_service_presence_malformed_raises():
+    # Unparseable output must not be reported as "service absent": an absence
+    # assertion would otherwise pass on garbage rather than a genuine removal.
+    import pytest as _pytest
+
+    mon = json.dumps({"quorum_names": ["node-a"]})
+    mgr = json.dumps([{"name": "node-a"}])
+    mds = json.dumps({"fsmap": {"standbys": [], "filesystems": []}})
+
+    for bad_mon, bad_mgr, bad_mds in (
+        ("bad", mgr, mds),
+        (mon, "bad", mds),
+        (mon, mgr, "bad"),
+        ("", "", ""),
+    ):
+        with _pytest.raises(ValueError):
+            placement_status.control_service_presence(
+                bad_mon, bad_mgr, bad_mds, "node-a"
+            )
 
 
 def test_member_in_ceph_status_substring():
@@ -1210,3 +1223,44 @@ def test_wait_for_control_services_absent_timeout_folds_last_observed(monkeypatc
     msg = str(exc.value)
     assert "never became absent" in msg
     assert "'mgr': True" in msg
+
+
+def test_wait_for_control_services_absent_ignores_unparseable_then_converges(monkeypatch):
+    # Bad/empty Ceph output (ValueError) must NOT be treated as absence: the
+    # poll keeps going until a genuine all-absent reading arrives.
+    h = H()
+    seq = [
+        ValueError("unparseable mds stat output: ''"),
+        {"mon": False, "mgr": True, "mds": False},
+        {"mon": False, "mgr": False, "mds": False},
+    ]
+    state = {"calls": 0}
+
+    def fake_observe(member):
+        idx = min(state["calls"], len(seq) - 1)
+        state["calls"] += 1
+        result = seq[idx]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(h, "_observe_control_services", fake_observe)
+    monkeypatch.setattr(_mh.time, "sleep", lambda *_: None)
+    h.wait_for_member_control_services("node-wrk1", "no", tries=10, interval=0)
+    assert state["calls"] == 3
+
+
+def test_wait_for_control_services_absent_timeout_on_persistent_bad_output(monkeypatch):
+    # Unparseable output that never recovers must time out (fail), never pass.
+    h = H()
+
+    def fake_observe(member):
+        raise ValueError("unparseable mds stat output: ''")
+
+    monkeypatch.setattr(h, "_observe_control_services", fake_observe)
+    monkeypatch.setattr(_mh.time, "sleep", lambda *_: None)
+    with pytest.raises(AssertionError) as exc:
+        h.wait_for_member_control_services("node-wrk1", "no", tries=3, interval=0)
+    msg = str(exc.value)
+    assert "never became absent" in msg
+    assert "unparseable" in msg


### PR DESCRIPTION
- Remove the MON from the committed monmap before stopping its daemon.
- Verify the resulting monmap retains enough active monitors to form quorum.
- Make monitor removal idempotent and safe to retry after partial teardown failures.
- Serialize service placement and deletion with other service lifecycle operations.
- Reuse a common helper for reading MON quorum membership.
- Added unit/robot tests.


Assisted-by: pi:z-ai/glm-5.2, claude:opus-5
