### PR TITLE
fix: make placement policy a full-replacement snapshot and move apply orchestration

### DIFF
--- a/microceph/api/placement.go
+++ b/microceph/api/placement.go
@@ -26,7 +26,9 @@ var placementCmd = mcTypes.Endpoint{
 	Delete: mcTypes.EndpointAction{Handler: cmdPlacementDelete, ProxyTarget: true},
 }
 
-// cmdPlacementGet returns the current placement status.
+// cmdPlacementGet returns the current placement status: the canonical desired
+// policy as stored (the complete snapshot from the last accepted PUT), the
+// observed placement, and the lifecycle/refusal state.
 func cmdPlacementGet(s mcTypes.State, r *http.Request) mcTypes.Response {
 	status, err := ceph.GetPlacementStatusFunc(r.Context(), interfaces.CephState{State: s})
 	if err != nil {
@@ -44,10 +46,11 @@ func cmdPlacementGet(s mcTypes.State, r *http.Request) mcTypes.Response {
 // operation completes and records its result even if the client disconnects.
 const placementPutTimeout = 10 * time.Minute
 
-// isClientSidePlacementError reports whether an ApplyPlacement error is a
+// isClientSidePlacementError reports whether a placement engine error is a
 // client-side precondition failure (not bootstrapped, unknown member,
 // keep-one refusal) that should map to HTTP 400 rather than the SmartError 500
-// fallback.
+// fallback. It covers both engine phases: the first two sentinels come from
+// ValidatePlacement, the keep-one refusal from ReconcilePlacement.
 func isClientSidePlacementError(err error) bool {
 	return errors.Is(err, ceph.ErrCephNotBootstrapped) ||
 		errors.Is(err, ceph.ErrUnknownPlacementMember) ||
@@ -66,6 +69,13 @@ func inProgressResponse(err error) mcTypes.Response {
 }
 
 // cmdPlacementPut installs and applies a declarative placement policy.
+//
+// PUT is a full replacement of the canonical desired policy, not a delta: the
+// submitted document is applied and stored as the complete desired state, and
+// nothing is merged in from the policy it replaces. A member or field the
+// caller omits is therefore unmanaged under the new policy rather than
+// inheriting its previous declaration -- which, for storage_eligible, means an
+// omitted grant is revoked (see ceph.OSDManager.checkStorageEligibility).
 func cmdPlacementPut(s mcTypes.State, r *http.Request) mcTypes.Response {
 	var policy types.PlacementPolicy
 	dec := json.NewDecoder(r.Body)
@@ -95,7 +105,7 @@ func cmdPlacementPut(s mcTypes.State, r *http.Request) mcTypes.Response {
 	ctx, ctxCancel := context.WithTimeout(context.WithoutCancel(r.Context()), placementPutTimeout)
 	defer ctxCancel()
 
-	// Serialize placement applies cluster-wide (CE142). ApplyPlacement reads
+	// Serialize placement applies cluster-wide (CE142). ReconcilePlacement reads
 	// observed service state and then mutates services over minutes; two
 	// overlapping PUTs (possibly served by different members) could each count
 	// the other's removal targets as keep-one retainers and together remove the
@@ -126,70 +136,90 @@ func cmdPlacementPut(s mcTypes.State, r *http.Request) mcTypes.Response {
 		}
 	}()
 
-	// Apply (validate + apply) FIRST; only store the policy if apply succeeds.
-	// This prevents a rejected policy (e.g. unknown member) from being stored
-	// as active.
-	applyErr := ceph.ApplyPlacementFunc(ctx, interfaces.CephState{State: s}, policy)
-	if applyErr != nil {
-		logger.Errorf("failed to apply placement policy: %v", applyErr)
-
-		// A keep-one refusal is a well-defined partial apply: all requested
-		// control-service adds have already taken effect in Ceph, and only
-		// removals were refused for keep-one safety. Persist the policy as the
-		// active declared intent so GET /placement reports the
-		// observed-vs-declared gap with last_refusal explaining it, rather than
-		// leaving the declared policy stale while the observed services have
-		// moved. Other errors do not persist the policy: client-side
-		// precondition failures (not bootstrapped, unknown member) fail before
-		// any service operation, and a mid-apply server-side failure (e.g. an
-		// add that errors partway) also leaves the previously declared policy
-		// in place — its partial state is arbitrary rather than a coherent
-		// intent, and last_refusal records what failed so the caller can retry
-		// the same policy to converge.
-		if errors.Is(applyErr, ceph.ErrKeepOneInvariant) {
-			storeErr := ceph.StorePlacementPolicyFunc(ctx, interfaces.CephState{State: s}, policy)
-			if storeErr != nil {
-				logger.Warnf("failed to store placement policy after keep-one refusal: %v", storeErr)
-			}
+	// Phase 1 -- validate. Check the complete incoming snapshot against cluster
+	// preconditions before it displaces the stored desired state. A policy that
+	// can never apply (Ceph not bootstrapped, unknown member) is rejected here
+	// without any service operation and without disturbing the currently stored
+	// policy, so a bad request cannot revoke the grants of a good one.
+	validateErr := ceph.ValidatePlacementFunc(ctx, interfaces.CephState{State: s}, policy)
+	if validateErr != nil {
+		logger.Errorf("rejected placement policy: %v", validateErr)
+		recordPlacementRefusal(ctx, s, validateErr)
+		if isClientSidePlacementError(validateErr) {
+			return mcTypes.BadRequest(validateErr)
 		}
-
-		// Persist the refusal reason so operators/charms polling GET /placement
-		// can inspect why the last PUT was rejected. Use the detached context so
-		// the refusal is recorded even if the client already disconnected.
-		refusalErr := ceph.SetPlacementRefusalFunc(ctx, interfaces.CephState{State: s}, applyErr.Error())
-		if refusalErr != nil {
-			logger.Warnf("failed to persist placement refusal: %v", refusalErr)
-		}
-		// Client-side precondition failures (not bootstrapped, unknown member,
-		// keep-one) return HTTP 400 so callers can distinguish operator errors
-		// from genuine server faults. Other errors (DB failures, etc.) fall
-		// through to SmartError which maps known sentinels or returns 500.
-		if isClientSidePlacementError(applyErr) {
-			return mcTypes.BadRequest(applyErr)
-		}
-		return mcTypes.SmartError(applyErr)
+		return mcTypes.SmartError(validateErr)
 	}
 
-	// Clear any previous refusal now that the policy applied successfully.
+	// Phase 2 -- persist. The validated snapshot becomes the canonical desired
+	// policy BEFORE reconciliation runs, replacing the previous one wholesale.
+	// Storing first is what makes a reconciliation failure observable: the
+	// operator's intent survives as the desired state and GET /placement reports
+	// the desired-vs-observed gap alongside last_refusal, instead of the
+	// superseded policy silently remaining in effect as though the PUT never
+	// happened. It also means storage eligibility follows the new snapshot
+	// immediately, which is the point -- the allow-list is desired state, not a
+	// result of convergence.
+	err = ceph.StorePlacementPolicyFunc(ctx, interfaces.CephState{State: s}, policy)
+	if err != nil {
+		// The desired state could not be recorded, so do not reconcile: mutating
+		// services with no durable record of the intent behind them is exactly
+		// the gap this ordering exists to close.
+		logger.Errorf("failed to store placement policy: %v", err)
+		recordPlacementRefusal(ctx, s, err)
+		return mcTypes.InternalError(err)
+	}
+
+	// Phase 3 -- reconcile. Converge observed placement onto the stored policy.
+	reconcileErr := ceph.ReconcilePlacementFunc(ctx, interfaces.CephState{State: s}, policy)
+	if reconcileErr != nil {
+		// The policy stays stored: whether the failure is a keep-one refusal
+		// (adds applied, removals refused) or a mid-reconcile error (an add that
+		// failed partway), the desired state is a coherent intent the caller can
+		// converge by retrying the same policy, and last_refusal records what
+		// stopped it.
+		logger.Errorf("failed to reconcile placement policy: %v", reconcileErr)
+		recordPlacementRefusal(ctx, s, reconcileErr)
+		// Client-side precondition failures (keep-one) return HTTP 400 so callers
+		// can distinguish operator errors from genuine server faults. Other
+		// errors (DB failures, etc.) fall through to SmartError which maps known
+		// sentinels or returns 500.
+		if isClientSidePlacementError(reconcileErr) {
+			return mcTypes.BadRequest(reconcileErr)
+		}
+		return mcTypes.SmartError(reconcileErr)
+	}
+
+	// Clear any previous refusal now that the policy is stored and converged.
 	clearErr := ceph.SetPlacementRefusalFunc(ctx, interfaces.CephState{State: s}, "")
 	if clearErr != nil {
 		logger.Warnf("failed to clear placement refusal: %v", clearErr)
 	}
 
-	// Persist the policy only after successful application.
-	err = ceph.StorePlacementPolicyFunc(ctx, interfaces.CephState{State: s}, policy)
-	if err != nil {
-		logger.Errorf("failed to store placement policy: %v", err)
-		return mcTypes.InternalError(err)
-	}
-
 	return mcTypes.SyncResponse(true, nil)
 }
 
-// cmdPlacementDelete clears the active role-managed placement policy without
-// adding or removing services. It acquires the same cluster-wide apply lock as
-// cmdPlacementPut so an in-flight PUT cannot re-write the policy after DELETE
-// returns 200.
+// recordPlacementRefusal persists why a placement PUT did not fully succeed so
+// operators and charms polling GET /1.0/placement can inspect it. It is
+// best-effort: a failure to record is logged and swallowed, because the caller
+// is already returning the underlying error. ctx must be the detached request
+// context so the refusal is recorded even if the client has disconnected.
+func recordPlacementRefusal(ctx context.Context, s mcTypes.State, cause error) {
+	err := ceph.SetPlacementRefusalFunc(ctx, interfaces.CephState{State: s}, cause.Error())
+	if err != nil {
+		logger.Warnf("failed to persist placement refusal: %v", err)
+	}
+}
+
+// cmdPlacementDelete clears the canonical desired placement policy in full,
+// without adding or removing services. It is the stand-down path: afterwards no
+// desired placement state remains for a later PUT to inherit, and storage
+// eligibility is unmanaged again so OSD enrollment is no longer gated. To keep
+// role management active while granting nothing, PUT the waiting policy
+// {"mode":"reconcile","members":{}} instead.
+//
+// It acquires the same cluster-wide apply lock as cmdPlacementPut so an
+// in-flight PUT cannot re-write the policy after DELETE returns 200.
 func cmdPlacementDelete(s mcTypes.State, r *http.Request) mcTypes.Response {
 	ctx, ctxCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
 	defer ctxCancel()

--- a/microceph/api/placement.go
+++ b/microceph/api/placement.go
@@ -46,11 +46,10 @@ func cmdPlacementGet(s mcTypes.State, r *http.Request) mcTypes.Response {
 // operation completes and records its result even if the client disconnects.
 const placementPutTimeout = 10 * time.Minute
 
-// isClientSidePlacementError reports whether a placement engine error is a
-// client-side precondition failure (not bootstrapped, unknown member,
+// isClientSidePlacementError reports whether a placement apply error is a
+// client-side precondition failure (not bootstrapped, unknown member, or a
 // keep-one refusal) that should map to HTTP 400 rather than the SmartError 500
-// fallback. It covers both engine phases: the first two sentinels come from
-// ValidatePlacement, the keep-one refusal from ReconcilePlacement.
+// fallback.
 func isClientSidePlacementError(err error) bool {
 	return errors.Is(err, ceph.ErrCephNotBootstrapped) ||
 		errors.Is(err, ceph.ErrUnknownPlacementMember) ||
@@ -105,12 +104,12 @@ func cmdPlacementPut(s mcTypes.State, r *http.Request) mcTypes.Response {
 	ctx, ctxCancel := context.WithTimeout(context.WithoutCancel(r.Context()), placementPutTimeout)
 	defer ctxCancel()
 
-	// Serialize placement applies cluster-wide (CE142). ReconcilePlacement reads
+	// Serialize placement applies cluster-wide (CE142). Applying a policy reads
 	// observed service state and then mutates services over minutes; two
 	// overlapping PUTs (possibly served by different members) could each count
 	// the other's removal targets as keep-one retainers and together remove the
 	// last viable control service. The dqlite-backed conditional-UPDATE lock
-	// makes the whole read-modify-store cycle mutually exclusive across
+	// makes the whole apply cycle mutually exclusive across
 	// members; a lease reclaims the lock if a holder crashes mid-apply.
 	lockToken, err := ceph.LockPlacementApplyFunc(ctx, interfaces.CephState{State: s})
 	if err != nil {
@@ -136,79 +135,16 @@ func cmdPlacementPut(s mcTypes.State, r *http.Request) mcTypes.Response {
 		}
 	}()
 
-	// Phase 1 -- validate. Check the complete incoming snapshot against cluster
-	// preconditions before it displaces the stored desired state. A policy that
-	// can never apply (Ceph not bootstrapped, unknown member) is rejected here
-	// without any service operation and without disturbing the currently stored
-	// policy, so a bad request cannot revoke the grants of a good one.
-	validateErr := ceph.ValidatePlacementFunc(ctx, interfaces.CephState{State: s}, policy)
-	if validateErr != nil {
-		logger.Errorf("rejected placement policy: %v", validateErr)
-		recordPlacementRefusal(ctx, s, validateErr)
-		if isClientSidePlacementError(validateErr) {
-			return mcTypes.BadRequest(validateErr)
-		}
-		return mcTypes.SmartError(validateErr)
-	}
-
-	// Phase 2 -- persist. The validated snapshot becomes the canonical desired
-	// policy BEFORE reconciliation runs, replacing the previous one wholesale.
-	// Storing first is what makes a reconciliation failure observable: the
-	// operator's intent survives as the desired state and GET /placement reports
-	// the desired-vs-observed gap alongside last_refusal, instead of the
-	// superseded policy silently remaining in effect as though the PUT never
-	// happened. It also means storage eligibility follows the new snapshot
-	// immediately, which is the point -- the allow-list is desired state, not a
-	// result of convergence.
-	err = ceph.StorePlacementPolicyFunc(ctx, interfaces.CephState{State: s}, policy)
+	err = ceph.ApplyPlacementPolicyFunc(ctx, interfaces.CephState{State: s}, policy)
 	if err != nil {
-		// The desired state could not be recorded, so do not reconcile: mutating
-		// services with no durable record of the intent behind them is exactly
-		// the gap this ordering exists to close.
-		logger.Errorf("failed to store placement policy: %v", err)
-		recordPlacementRefusal(ctx, s, err)
-		return mcTypes.InternalError(err)
-	}
-
-	// Phase 3 -- reconcile. Converge observed placement onto the stored policy.
-	reconcileErr := ceph.ReconcilePlacementFunc(ctx, interfaces.CephState{State: s}, policy)
-	if reconcileErr != nil {
-		// The policy stays stored: whether the failure is a keep-one refusal
-		// (adds applied, removals refused) or a mid-reconcile error (an add that
-		// failed partway), the desired state is a coherent intent the caller can
-		// converge by retrying the same policy, and last_refusal records what
-		// stopped it.
-		logger.Errorf("failed to reconcile placement policy: %v", reconcileErr)
-		recordPlacementRefusal(ctx, s, reconcileErr)
-		// Client-side precondition failures (keep-one) return HTTP 400 so callers
-		// can distinguish operator errors from genuine server faults. Other
-		// errors (DB failures, etc.) fall through to SmartError which maps known
-		// sentinels or returns 500.
-		if isClientSidePlacementError(reconcileErr) {
-			return mcTypes.BadRequest(reconcileErr)
+		logger.Errorf("failed to apply placement policy: %v", err)
+		if isClientSidePlacementError(err) {
+			return mcTypes.BadRequest(err)
 		}
-		return mcTypes.SmartError(reconcileErr)
-	}
-
-	// Clear any previous refusal now that the policy is stored and converged.
-	clearErr := ceph.SetPlacementRefusalFunc(ctx, interfaces.CephState{State: s}, "")
-	if clearErr != nil {
-		logger.Warnf("failed to clear placement refusal: %v", clearErr)
+		return mcTypes.SmartError(err)
 	}
 
 	return mcTypes.SyncResponse(true, nil)
-}
-
-// recordPlacementRefusal persists why a placement PUT did not fully succeed so
-// operators and charms polling GET /1.0/placement can inspect it. It is
-// best-effort: a failure to record is logged and swallowed, because the caller
-// is already returning the underlying error. ctx must be the detached request
-// context so the refusal is recorded even if the client has disconnected.
-func recordPlacementRefusal(ctx context.Context, s mcTypes.State, cause error) {
-	err := ceph.SetPlacementRefusalFunc(ctx, interfaces.CephState{State: s}, cause.Error())
-	if err != nil {
-		logger.Warnf("failed to persist placement refusal: %v", err)
-	}
 }
 
 // cmdPlacementDelete clears the canonical desired placement policy in full,

--- a/microceph/api/placement_test.go
+++ b/microceph/api/placement_test.go
@@ -44,197 +44,204 @@ func stubPlacementApplyLock(t *testing.T) *int {
 	return &unlockCalls
 }
 
-// TestPlacementPutSuccess verifies that cmdPlacementPut decodes the policy,
-// applies it, stores it, releases the apply lock, and returns success.
+// placementRecorder captures how cmdPlacementPut drove the placement engine:
+// which phases ran and in what order, the policy handed to the store, and every
+// refusal written. Phase names recorded in order are "validate", "store",
+// "reconcile", and "refusal:<reason>".
+type placementRecorder struct {
+	order        []string
+	storedPolicy types.PlacementPolicy
+	refusals     []string
+}
+
+// ran reports whether the named phase executed.
+func (r *placementRecorder) ran(phase string) bool {
+	for _, p := range r.order {
+		if p == phase {
+			return true
+		}
+	}
+	return false
+}
+
+// placementHooks lets a test fail one phase of the handler's validate-store-
+// reconcile sequence. A nil hook makes that phase a recorded success.
+type placementHooks struct {
+	validate  func(context.Context) error
+	store     func(context.Context) error
+	reconcile func(context.Context) error
+	refusal   func(context.Context, string) error
+}
+
+// stubPlacementEngine replaces the three engine phases cmdPlacementPut drives,
+// plus the refusal writer, and restores them on cleanup. The returned recorder
+// exposes the resulting call sequence so tests can assert not just that a phase
+// ran but that it ran in the right order -- notably that the desired policy is
+// stored before reconciliation, not after it.
+func stubPlacementEngine(t *testing.T, h placementHooks) *placementRecorder {
+	t.Helper()
+	rec := &placementRecorder{}
+
+	origValidate := ceph.ValidatePlacementFunc
+	origStore := ceph.StorePlacementPolicyFunc
+	origReconcile := ceph.ReconcilePlacementFunc
+	origRefusal := ceph.SetPlacementRefusalFunc
+
+	ceph.ValidatePlacementFunc = func(ctx context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		rec.order = append(rec.order, "validate")
+		if h.validate != nil {
+			return h.validate(ctx)
+		}
+		return nil
+	}
+	ceph.StorePlacementPolicyFunc = func(ctx context.Context, _ interfaces.StateInterface, p types.PlacementPolicy) error {
+		rec.order = append(rec.order, "store")
+		rec.storedPolicy = p
+		if h.store != nil {
+			return h.store(ctx)
+		}
+		return nil
+	}
+	ceph.ReconcilePlacementFunc = func(ctx context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		rec.order = append(rec.order, "reconcile")
+		if h.reconcile != nil {
+			return h.reconcile(ctx)
+		}
+		return nil
+	}
+	ceph.SetPlacementRefusalFunc = func(ctx context.Context, _ interfaces.StateInterface, reason string) error {
+		rec.order = append(rec.order, "refusal:"+reason)
+		rec.refusals = append(rec.refusals, reason)
+		if h.refusal != nil {
+			return h.refusal(ctx, reason)
+		}
+		return nil
+	}
+
+	t.Cleanup(func() {
+		ceph.ValidatePlacementFunc = origValidate
+		ceph.StorePlacementPolicyFunc = origStore
+		ceph.ReconcilePlacementFunc = origReconcile
+		ceph.SetPlacementRefusalFunc = origRefusal
+	})
+	return rec
+}
+
+// TestPlacementPutSuccess verifies that cmdPlacementPut decodes the policy and
+// drives the three phases in order -- validate, store, reconcile -- then clears
+// any stale refusal, releases the apply lock, and returns success.
 func TestPlacementPutSuccess(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	applyCalled := false
-	storeCalled := false
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		applyCalled = true
-		return nil
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		storeCalled = true
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	rec := stubPlacementEngine(t, placementHooks{})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.True(t, applyCalled)
-	assert.True(t, storeCalled)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []string{"validate", "store", "reconcile", "refusal:"}, rec.order,
+		"the handler must validate, then persist the desired policy, then reconcile")
 	assert.Equal(t, 1, *unlockCalls, "the apply lock must be released exactly once")
 }
 
-// TestPlacementPutApplyFailureNotStored (N3) verifies that when ApplyPlacement
-// fails (e.g. unknown member), StorePlacementPolicy is NOT called and the
-// response is HTTP 400 (BadRequest) because the error is a client-side sentinel.
-func TestPlacementPutApplyFailureNotStored(t *testing.T) {
+// TestPlacementPutValidationFailureNotStored (N3) verifies that a policy
+// rejected in the validate phase (e.g. unknown member) never reaches the store:
+// the previously stored desired policy must survive a bad request untouched, so
+// an invalid PUT cannot revoke the grants of the policy already in effect.
+// Reconciliation is skipped and the response is HTTP 400 because the error is a
+// client-side sentinel.
+func TestPlacementPutValidationFailureNotStored(t *testing.T) {
 	stubPlacementApplyLock(t)
-	storeCalled := false
-	refusalCalled := false
-	var refusalReason string
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return fmt.Errorf("%w: bad-node", ceph.ErrUnknownPlacementMember)
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		storeCalled = true
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, reason string) error {
-		refusalCalled = true
-		refusalReason = reason
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	rec := stubPlacementEngine(t, placementHooks{
+		validate: func(context.Context) error {
+			return fmt.Errorf("%w: bad-node", ceph.ErrUnknownPlacementMember)
+		},
+	})
 
 	body := `{"mode":"reconcile","members":{"bad-node":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.False(t, storeCalled, "StorePlacementPolicy must not be called when Apply fails")
-	assert.True(t, refusalCalled, "SetPlacementRefusal must be called when Apply fails")
-	assert.Contains(t, refusalReason, "bad-node")
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "client-side placement error must return 400")
+	assert.False(t, rec.ran("store"), "a policy that fails validation must not replace the stored desired policy")
+	assert.False(t, rec.ran("reconcile"), "reconciliation must not run for a policy that failed validation")
+	require.Len(t, rec.refusals, 1, "the rejection reason must be recorded")
+	assert.Contains(t, rec.refusals[0], "bad-node")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "client-side placement error must return 400")
 }
 
 // TestPlacementPutPreBootstrapReturns400 verifies that the ErrCephNotBootstrapped
-// sentinel maps to HTTP 400 (not 500).
+// sentinel maps to HTTP 400 (not 500) and that the policy is not stored.
 func TestPlacementPutPreBootstrapReturns400(t *testing.T) {
 	stubPlacementApplyLock(t)
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return fmt.Errorf("%w: run bootstrap-ceph first", ceph.ErrCephNotBootstrapped)
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	rec := stubPlacementEngine(t, placementHooks{
+		validate: func(context.Context) error {
+			return fmt.Errorf("%w: run bootstrap-ceph first", ceph.ErrCephNotBootstrapped)
+		},
+	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "pre-bootstrap rejection must return 400 not 500")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "pre-bootstrap rejection must return 400 not 500")
+	assert.False(t, rec.ran("store"), "a pre-bootstrap rejection must not replace the stored desired policy")
 }
 
 // TestPlacementPutKeepOneReturns400 verifies that the ErrKeepOneInvariant
 // sentinel maps to HTTP 400 (not 500).
 func TestPlacementPutKeepOneReturns400(t *testing.T) {
 	stubPlacementApplyLock(t)
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	stubPlacementEngine(t, placementHooks{
+		reconcile: func(context.Context) error {
+			return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
+		},
+	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":false}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "keep-one refusal must return 400 not 500")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "keep-one refusal must return 400 not 500")
 }
 
 // TestPlacementPutKeepOneStoresPolicyAndRefusal verifies that a keep-one
-// refusal is treated as a partial apply: the requested adds have already taken
-// effect, so the policy is persisted as the declared intent (so GET /placement
-// can report the observed-vs-declared gap) AND the refusal reason is recorded.
-// Both StorePlacementPolicyFunc and SetPlacementRefusalFunc must be called with
-// the right arguments, and the response is HTTP 400.
+// refusal leaves the requested snapshot as the desired policy: it was persisted
+// before reconciliation ran, so GET /placement reports the desired-vs-observed
+// gap with last_refusal explaining it. The response is HTTP 400.
 func TestPlacementPutKeepOneStoresPolicyAndRefusal(t *testing.T) {
 	stubPlacementApplyLock(t)
-	storeCalled := false
-	refusalCalled := false
-	var storedPolicy types.PlacementPolicy
-	var refusalReason string
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, p types.PlacementPolicy) error {
-		storeCalled = true
-		storedPolicy = p
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, reason string) error {
-		refusalCalled = true
-		refusalReason = reason
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	rec := stubPlacementEngine(t, placementHooks{
+		reconcile: func(context.Context) error {
+			return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
+		},
+	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":false},"node-b":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "keep-one refusal must return 400 not 500")
-	assert.True(t, storeCalled, "StorePlacementPolicy must be called on keep-one refusal (partial apply)")
-	assert.True(t, refusalCalled, "SetPlacementRefusal must be called on keep-one refusal")
-	assert.Contains(t, refusalReason, "keep-one invariant")
-	// The stored policy must equal the requested declared intent.
+	assert.Equal(t, http.StatusBadRequest, w.Code, "keep-one refusal must return 400 not 500")
+	require.Len(t, rec.refusals, 1, "the refusal reason must be recorded")
+	assert.Contains(t, rec.refusals[0], "keep-one invariant")
+	assert.Equal(t, []string{"validate", "store", "reconcile", "refusal:" + rec.refusals[0]}, rec.order,
+		"the policy must be stored before reconciliation, so a refusal cannot discard it")
+
+	// The stored policy must be the submitted snapshot verbatim.
 	ctrlFalse := false
 	ctrlTrue := true
 	assert.Equal(t, types.PlacementPolicy{
@@ -243,119 +250,119 @@ func TestPlacementPutKeepOneStoresPolicyAndRefusal(t *testing.T) {
 			"node-a": {Control: &ctrlFalse},
 			"node-b": {Control: &ctrlTrue},
 		},
-	}, storedPolicy)
+	}, rec.storedPolicy)
 }
 
-// TestPlacementPutKeepOneStoreFailureStillRecordsRefusal verifies the
-// best-effort path: when StorePlacementPolicyFunc fails on a keep-one refusal,
-// the handler still records the refusal reason and returns HTTP 400 rather than
-// aborting or returning 500.
-func TestPlacementPutKeepOneStoreFailureStillRecordsRefusal(t *testing.T) {
+// TestPlacementPutReconcileFailureStoresDesiredPolicy verifies that a
+// mid-reconcile server-side failure still leaves the submitted snapshot as the
+// canonical desired policy. Persisting before reconciling is what makes the
+// failure observable: the operator's intent survives as desired state and
+// last_refusal records what stopped it, instead of the superseded policy
+// silently remaining in effect as though the PUT never happened.
+func TestPlacementPutReconcileFailureStoresDesiredPolicy(t *testing.T) {
 	stubPlacementApplyLock(t)
-	storeCalled := false
-	refusalCalled := false
-	var refusalReason string
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		storeCalled = true
-		return errors.New("database unavailable")
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, reason string) error {
-		refusalCalled = true
-		refusalReason = reason
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	rec := stubPlacementEngine(t, placementHooks{
+		reconcile: func(context.Context) error {
+			return errors.New("failed to add mon on node-b: connection refused")
+		},
+	})
 
-	body := `{"mode":"reconcile","members":{"node-a":{"control":false},"node-b":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	body := `{"mode":"reconcile","members":{"node-a":{"control":true},"node-b":{"control":true}}}`
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.True(t, storeCalled, "StorePlacementPolicy must be attempted on keep-one refusal")
-	assert.True(t, refusalCalled, "SetPlacementRefusal must still be called when the policy store fails")
-	assert.Contains(t, refusalReason, "keep-one invariant")
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "keep-one refusal must return 400 even when the policy store fails")
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "a mid-reconcile failure is a server fault")
+	assert.True(t, rec.ran("store"), "the desired policy must survive a reconciliation failure")
+	ctrlTrue := true
+	assert.Equal(t, types.PlacementPolicy{
+		Mode: types.PlacementModeReconcile,
+		Members: map[string]types.MemberPlacement{
+			"node-a": {Control: &ctrlTrue},
+			"node-b": {Control: &ctrlTrue},
+		},
+	}, rec.storedPolicy, "the whole submitted snapshot must be stored, not the part that converged")
+	require.Len(t, rec.refusals, 1, "the failure reason must be recorded alongside the desired policy")
+	assert.Contains(t, rec.refusals[0], "connection refused")
+}
+
+// TestPlacementPutStoreFailureSkipsReconcile verifies that when the desired
+// policy cannot be persisted the handler stops before reconciling: mutating
+// services with no durable record of the intent behind them is exactly the gap
+// the store-before-reconcile ordering exists to close. The failure reason is
+// still recorded and the response is HTTP 500.
+func TestPlacementPutStoreFailureSkipsReconcile(t *testing.T) {
+	unlockCalls := stubPlacementApplyLock(t)
+	rec := stubPlacementEngine(t, placementHooks{
+		store: func(context.Context) error {
+			return errors.New("database unavailable")
+		},
+	})
+
+	body := `{"mode":"reconcile","members":{"node-a":{"control":false},"node-b":{"control":true}}}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
+
+	resp := cmdPlacementPut(nil, req)
+	_ = resp.Render(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "an unpersistable policy must return 500")
+	assert.False(t, rec.ran("reconcile"), "services must not be mutated when the desired policy could not be stored")
+	require.Len(t, rec.refusals, 1, "the store failure must be recorded")
+	assert.Contains(t, rec.refusals[0], "database unavailable")
+	assert.Equal(t, 1, *unlockCalls, "the apply lock must be released when the store fails")
 }
 
 // TestPlacementPutServerErrorReturns500 verifies that a non-client-side
-// ApplyPlacement error (e.g. DB failure) does NOT map to 400 but falls through
-// to SmartError which returns 500.
+// reconcile error (e.g. DB failure) does NOT map to 400 but falls through to
+// SmartError which returns 500, and that the apply lock is still released.
 func TestPlacementPutServerErrorReturns500(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return errors.New("database connection refused")
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	stubPlacementEngine(t, placementHooks{
+		reconcile: func(context.Context) error {
+			return errors.New("database connection refused")
+		},
+	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusInternalServerError, rec.Code, "server-side error must return 500")
+	assert.Equal(t, http.StatusInternalServerError, w.Code, "server-side error must return 500")
 	assert.Equal(t, 1, *unlockCalls, "the apply lock must be released even when the apply fails")
 }
 
 // TestPlacementPutContextDetached verifies that cmdPlacementPut uses a context
 // detached from the request's cancellation: even when the request context is
-// cancelled, ApplyPlacementFunc receives a non-cancelled context. This prevents
+// cancelled, every engine phase receives a non-cancelled context. This prevents
 // the "context canceled" error during multi-minute readiness polling.
 func TestPlacementPutContextDetached(t *testing.T) {
 	stubPlacementApplyLock(t)
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	var applyCtxCancelled bool
-	ceph.ApplyPlacementFunc = func(ctx context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		select {
-		case <-ctx.Done():
-			applyCtxCancelled = true
-		default:
-			applyCtxCancelled = false
+	cancelled := map[string]bool{}
+	noteCancelled := func(phase string) func(context.Context) error {
+		return func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				cancelled[phase] = true
+			default:
+				cancelled[phase] = false
+			}
+			return nil
 		}
-		return nil
 	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	stubPlacementEngine(t, placementHooks{
+		validate:  noteCancelled("validate"),
+		store:     noteCancelled("store"),
+		reconcile: noteCancelled("reconcile"),
+	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	// Cancel the request context before the handler runs.
@@ -364,10 +371,11 @@ func TestPlacementPutContextDetached(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code, "handler must succeed despite cancelled request context")
-	assert.False(t, applyCtxCancelled, "ApplyPlacementFunc context must be detached from the request's cancellation")
+	assert.Equal(t, http.StatusOK, w.Code, "handler must succeed despite cancelled request context")
+	assert.Equal(t, map[string]bool{"validate": false, "store": false, "reconcile": false}, cancelled,
+		"every engine phase must receive a context detached from the request's cancellation")
 }
 
 // TestPlacementPutBadJSON verifies that malformed JSON returns BadRequest.
@@ -382,28 +390,22 @@ func TestPlacementPutBadJSON(t *testing.T) {
 }
 
 // TestPlacementPutUnknownModeRejected verifies that a policy with an unknown
-// mode is rejected with BadRequest before any lock, apply, or store happens,
-// so a future mode (e.g. dry-run) sent to an older snap fails loudly instead
-// of being silently applied as a reconcile.
+// mode is rejected with BadRequest before any lock, validate, store, or
+// reconcile happens, so a future mode (e.g. dry-run) sent to an older snap
+// fails loudly instead of being silently applied as a reconcile.
 func TestPlacementPutUnknownModeRejected(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	applyCalled := false
-	origApply := ceph.ApplyPlacementFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		applyCalled = true
-		return nil
-	}
-	defer func() { ceph.ApplyPlacementFunc = origApply }()
+	rec := stubPlacementEngine(t, placementHooks{})
 
 	body := `{"mode":"dry-run","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "unknown mode must be rejected with 400")
-	assert.False(t, applyCalled, "unknown mode must not be applied")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "unknown mode must be rejected with 400")
+	assert.Empty(t, rec.order, "unknown mode must not touch the placement engine or the policy store")
 	assert.Equal(t, 0, *unlockCalls, "unknown mode must be rejected before the lock is taken")
 }
 
@@ -411,71 +413,69 @@ func TestPlacementPutUnknownModeRejected(t *testing.T) {
 // mode is accepted (200).
 func TestPlacementPutReconcileModeAccepted(t *testing.T) {
 	stubPlacementApplyLock(t)
-	origApply := ceph.ApplyPlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return nil
-	}
-	ceph.StorePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
-		ceph.ApplyPlacementFunc = origApply
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	stubPlacementEngine(t, placementHooks{})
 
 	body := `{"mode":"reconcile","members":{}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code, "body %s must be accepted", body)
+	assert.Equal(t, http.StatusOK, w.Code, "body %s must be accepted", body)
+}
+
+// TestPlacementPutWaitingPolicyStored verifies that the CE142 waiting policy
+// (an empty members map) is persisted as the desired policy rather than treated
+// as a no-op request. Storing it is the point: an empty members map is an empty
+// storage allow-list, which is how the charm withholds OSD enrollment while it
+// has no valid role assignments to publish.
+func TestPlacementPutWaitingPolicyStored(t *testing.T) {
+	stubPlacementApplyLock(t)
+	rec := stubPlacementEngine(t, placementHooks{})
+
+	body := `{"mode":"reconcile","members":{}}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
+
+	resp := cmdPlacementPut(nil, req)
+	_ = resp.Render(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, rec.ran("store"), "the waiting policy must be stored as the desired policy")
+	assert.Equal(t, types.PlacementPolicy{
+		Mode:    types.PlacementModeReconcile,
+		Members: map[string]types.MemberPlacement{},
+	}, rec.storedPolicy)
 }
 
 // TestPlacementPutMissingModeRejected verifies that an omitted mode is rejected
-// with 400 (mode is required, not defaulted to reconcile) before any apply or
+// with 400 (mode is required, not defaulted to reconcile) before any engine or
 // lock interaction.
 func TestPlacementPutMissingModeRejected(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	applyCalled := false
-	origApply := ceph.ApplyPlacementFunc
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		applyCalled = true
-		return nil
-	}
-	defer func() { ceph.ApplyPlacementFunc = origApply }()
+	rec := stubPlacementEngine(t, placementHooks{})
 
 	body := `{"members":{}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, rec.Code, "a missing mode must be rejected with 400")
-	assert.False(t, applyCalled, "a missing mode must not be applied")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "a missing mode must be rejected with 400")
+	assert.Empty(t, rec.order, "a missing mode must not touch the placement engine or the policy store")
 	assert.Equal(t, 0, *unlockCalls, "a missing mode must be rejected before the lock is taken")
 }
 
 // TestPlacementPutLockHeldReturnsRetryableError verifies that when another
 // placement apply holds the cluster-wide lock, the handler returns an error
-// without applying, storing, recording a refusal, or releasing the other
-// holder's lock.
+// without validating, storing, reconciling, recording a refusal, or releasing
+// the other holder's lock.
 func TestPlacementPutLockHeldReturnsRetryableError(t *testing.T) {
-	applyCalled := false
-	refusalCalled := false
 	unlockCalled := false
 	origLock := ceph.LockPlacementApplyFunc
 	origUnlock := ceph.UnlockPlacementApplyFunc
-	origApply := ceph.ApplyPlacementFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
 	ceph.LockPlacementApplyFunc = func(_ context.Context, _ interfaces.StateInterface) (int64, error) {
 		return 0, fmt.Errorf("%w: retry after the current apply completes", ceph.ErrPlacementApplyInProgress)
 	}
@@ -483,44 +483,33 @@ func TestPlacementPutLockHeldReturnsRetryableError(t *testing.T) {
 		unlockCalled = true
 		return nil
 	}
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		applyCalled = true
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		refusalCalled = true
-		return nil
-	}
-	defer func() {
+	t.Cleanup(func() {
 		ceph.LockPlacementApplyFunc = origLock
 		ceph.UnlockPlacementApplyFunc = origUnlock
-		ceph.ApplyPlacementFunc = origApply
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	})
+	rec := stubPlacementEngine(t, placementHooks{})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
-	assert.Equal(t, http.StatusConflict, rec.Code, "a held apply lock must fail the PUT with 409 Conflict (retryable)")
-	assert.False(t, applyCalled, "ApplyPlacement must not run while another apply holds the lock")
-	assert.False(t, refusalCalled, "a lock conflict is not a policy refusal and must not overwrite last_refusal")
+	assert.Equal(t, http.StatusConflict, w.Code, "a held apply lock must fail the PUT with 409 Conflict (retryable)")
+	assert.Empty(t, rec.order, "no placement work may run while another apply holds the lock")
+	assert.Empty(t, rec.refusals, "a lock conflict is not a policy refusal and must not overwrite last_refusal")
 	assert.False(t, unlockCalled, "the handler must not release a lock it failed to acquire")
 }
 
 // TestPlacementPutLockReleasedWithAcquiredToken verifies that the handler
-// releases the apply lock with the exact token it acquired, also when the
-// apply fails.
+// releases the apply lock with the exact token it acquired, also when
+// reconciliation fails.
 func TestPlacementPutLockReleasedWithAcquiredToken(t *testing.T) {
 	const token = int64(42)
 	var releasedToken int64
 	origLock := ceph.LockPlacementApplyFunc
 	origUnlock := ceph.UnlockPlacementApplyFunc
-	origApply := ceph.ApplyPlacementFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
 	ceph.LockPlacementApplyFunc = func(_ context.Context, _ interfaces.StateInterface) (int64, error) {
 		return token, nil
 	}
@@ -528,25 +517,20 @@ func TestPlacementPutLockReleasedWithAcquiredToken(t *testing.T) {
 		releasedToken = tok
 		return nil
 	}
-	ceph.ApplyPlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		return errors.New("apply blew up")
-	}
-	ceph.SetPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
-		return nil
-	}
-	defer func() {
+	t.Cleanup(func() {
 		ceph.LockPlacementApplyFunc = origLock
 		ceph.UnlockPlacementApplyFunc = origUnlock
-		ceph.ApplyPlacementFunc = origApply
-		ceph.SetPlacementRefusalFunc = origRefusal
-	}()
+	})
+	stubPlacementEngine(t, placementHooks{
+		reconcile: func(context.Context) error { return errors.New("apply blew up") },
+	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
-	rec := httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
 
 	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(rec, req)
+	_ = resp.Render(w, req)
 
 	assert.Equal(t, token, releasedToken, "the lock must be released with the acquired token")
 }

--- a/microceph/api/placement_test.go
+++ b/microceph/api/placement_test.go
@@ -44,95 +44,44 @@ func stubPlacementApplyLock(t *testing.T) *int {
 	return &unlockCalls
 }
 
-// placementRecorder captures how cmdPlacementPut drove the placement engine:
-// which phases ran and in what order, the policy handed to the store, and every
-// refusal written. Phase names recorded in order are "validate", "store",
-// "reconcile", and "refusal:<reason>".
-type placementRecorder struct {
-	order        []string
-	storedPolicy types.PlacementPolicy
-	refusals     []string
+// placementApplyRecorder captures the policy and context handed from the HTTP
+// handler to the placement package's single orchestration entry point.
+type placementApplyRecorder struct {
+	calls            int
+	policy           types.PlacementPolicy
+	contextCancelled bool
 }
 
-// ran reports whether the named phase executed.
-func (r *placementRecorder) ran(phase string) bool {
-	for _, p := range r.order {
-		if p == phase {
-			return true
-		}
-	}
-	return false
-}
-
-// placementHooks lets a test fail one phase of the handler's validate-store-
-// reconcile sequence. A nil hook makes that phase a recorded success.
-type placementHooks struct {
-	validate  func(context.Context) error
-	store     func(context.Context) error
-	reconcile func(context.Context) error
-	refusal   func(context.Context, string) error
-}
-
-// stubPlacementEngine replaces the three engine phases cmdPlacementPut drives,
-// plus the refusal writer, and restores them on cleanup. The returned recorder
-// exposes the resulting call sequence so tests can assert not just that a phase
-// ran but that it ran in the right order -- notably that the desired policy is
-// stored before reconciliation, not after it.
-func stubPlacementEngine(t *testing.T, h placementHooks) *placementRecorder {
+// stubPlacementApply replaces ApplyPlacementPolicy for handler tests and
+// restores it on cleanup. Validate-store-reconcile ordering is tested in the
+// ceph package, where those phases are deliberately package-private.
+func stubPlacementApply(t *testing.T, apply func(context.Context, types.PlacementPolicy) error) *placementApplyRecorder {
 	t.Helper()
-	rec := &placementRecorder{}
-
-	origValidate := ceph.ValidatePlacementFunc
-	origStore := ceph.StorePlacementPolicyFunc
-	origReconcile := ceph.ReconcilePlacementFunc
-	origRefusal := ceph.SetPlacementRefusalFunc
-
-	ceph.ValidatePlacementFunc = func(ctx context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		rec.order = append(rec.order, "validate")
-		if h.validate != nil {
-			return h.validate(ctx)
+	rec := &placementApplyRecorder{}
+	origApply := ceph.ApplyPlacementPolicyFunc
+	ceph.ApplyPlacementPolicyFunc = func(ctx context.Context, _ interfaces.StateInterface, policy types.PlacementPolicy) error {
+		rec.calls++
+		rec.policy = policy
+		select {
+		case <-ctx.Done():
+			rec.contextCancelled = true
+		default:
+		}
+		if apply != nil {
+			return apply(ctx, policy)
 		}
 		return nil
 	}
-	ceph.StorePlacementPolicyFunc = func(ctx context.Context, _ interfaces.StateInterface, p types.PlacementPolicy) error {
-		rec.order = append(rec.order, "store")
-		rec.storedPolicy = p
-		if h.store != nil {
-			return h.store(ctx)
-		}
-		return nil
-	}
-	ceph.ReconcilePlacementFunc = func(ctx context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
-		rec.order = append(rec.order, "reconcile")
-		if h.reconcile != nil {
-			return h.reconcile(ctx)
-		}
-		return nil
-	}
-	ceph.SetPlacementRefusalFunc = func(ctx context.Context, _ interfaces.StateInterface, reason string) error {
-		rec.order = append(rec.order, "refusal:"+reason)
-		rec.refusals = append(rec.refusals, reason)
-		if h.refusal != nil {
-			return h.refusal(ctx, reason)
-		}
-		return nil
-	}
-
-	t.Cleanup(func() {
-		ceph.ValidatePlacementFunc = origValidate
-		ceph.StorePlacementPolicyFunc = origStore
-		ceph.ReconcilePlacementFunc = origReconcile
-		ceph.SetPlacementRefusalFunc = origRefusal
-	})
+	t.Cleanup(func() { ceph.ApplyPlacementPolicyFunc = origApply })
 	return rec
 }
 
-// TestPlacementPutSuccess verifies that cmdPlacementPut decodes the policy and
-// drives the three phases in order -- validate, store, reconcile -- then clears
-// any stale refusal, releases the apply lock, and returns success.
+// TestPlacementPutSuccess verifies that cmdPlacementPut decodes the policy,
+// passes it to the placement package's orchestration entry point, releases the
+// apply lock, and returns success.
 func TestPlacementPutSuccess(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{})
+	rec := stubPlacementApply(t, nil)
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
 	w := httptest.NewRecorder()
@@ -142,23 +91,23 @@ func TestPlacementPutSuccess(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, []string{"validate", "store", "reconcile", "refusal:"}, rec.order,
-		"the handler must validate, then persist the desired policy, then reconcile")
+	assert.Equal(t, 1, rec.calls)
+	control := true
+	assert.Equal(t, types.PlacementPolicy{
+		Mode: types.PlacementModeReconcile,
+		Members: map[string]types.MemberPlacement{
+			"node-a": {Control: &control},
+		},
+	}, rec.policy)
 	assert.Equal(t, 1, *unlockCalls, "the apply lock must be released exactly once")
 }
 
-// TestPlacementPutValidationFailureNotStored (N3) verifies that a policy
-// rejected in the validate phase (e.g. unknown member) never reaches the store:
-// the previously stored desired policy must survive a bad request untouched, so
-// an invalid PUT cannot revoke the grants of the policy already in effect.
-// Reconciliation is skipped and the response is HTTP 400 because the error is a
-// client-side sentinel.
-func TestPlacementPutValidationFailureNotStored(t *testing.T) {
+// TestPlacementPutValidationFailureReturns400 verifies that a validation
+// sentinel returned by the placement orchestration maps to HTTP 400.
+func TestPlacementPutValidationFailureReturns400(t *testing.T) {
 	stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{
-		validate: func(context.Context) error {
-			return fmt.Errorf("%w: bad-node", ceph.ErrUnknownPlacementMember)
-		},
+	rec := stubPlacementApply(t, func(context.Context, types.PlacementPolicy) error {
+		return fmt.Errorf("%w: bad-node", ceph.ErrUnknownPlacementMember)
 	})
 
 	body := `{"mode":"reconcile","members":{"bad-node":{"control":true}}}`
@@ -168,21 +117,16 @@ func TestPlacementPutValidationFailureNotStored(t *testing.T) {
 	resp := cmdPlacementPut(nil, req)
 	_ = resp.Render(w, req)
 
-	assert.False(t, rec.ran("store"), "a policy that fails validation must not replace the stored desired policy")
-	assert.False(t, rec.ran("reconcile"), "reconciliation must not run for a policy that failed validation")
-	require.Len(t, rec.refusals, 1, "the rejection reason must be recorded")
-	assert.Contains(t, rec.refusals[0], "bad-node")
+	assert.Equal(t, 1, rec.calls)
 	assert.Equal(t, http.StatusBadRequest, w.Code, "client-side placement error must return 400")
 }
 
-// TestPlacementPutPreBootstrapReturns400 verifies that the ErrCephNotBootstrapped
-// sentinel maps to HTTP 400 (not 500) and that the policy is not stored.
+// TestPlacementPutPreBootstrapReturns400 verifies that the
+// ErrCephNotBootstrapped sentinel maps to HTTP 400 rather than 500.
 func TestPlacementPutPreBootstrapReturns400(t *testing.T) {
 	stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{
-		validate: func(context.Context) error {
-			return fmt.Errorf("%w: run bootstrap-ceph first", ceph.ErrCephNotBootstrapped)
-		},
+	stubPlacementApply(t, func(context.Context, types.PlacementPolicy) error {
+		return fmt.Errorf("%w: run bootstrap-ceph first", ceph.ErrCephNotBootstrapped)
 	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
@@ -193,17 +137,14 @@ func TestPlacementPutPreBootstrapReturns400(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "pre-bootstrap rejection must return 400 not 500")
-	assert.False(t, rec.ran("store"), "a pre-bootstrap rejection must not replace the stored desired policy")
 }
 
 // TestPlacementPutKeepOneReturns400 verifies that the ErrKeepOneInvariant
 // sentinel maps to HTTP 400 (not 500).
 func TestPlacementPutKeepOneReturns400(t *testing.T) {
 	stubPlacementApplyLock(t)
-	stubPlacementEngine(t, placementHooks{
-		reconcile: func(context.Context) error {
-			return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
-		},
+	stubPlacementApply(t, func(context.Context, types.PlacementPolicy) error {
+		return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
 	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":false}}}`
@@ -216,114 +157,12 @@ func TestPlacementPutKeepOneReturns400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code, "keep-one refusal must return 400 not 500")
 }
 
-// TestPlacementPutKeepOneStoresPolicyAndRefusal verifies that a keep-one
-// refusal leaves the requested snapshot as the desired policy: it was persisted
-// before reconciliation ran, so GET /placement reports the desired-vs-observed
-// gap with last_refusal explaining it. The response is HTTP 400.
-func TestPlacementPutKeepOneStoresPolicyAndRefusal(t *testing.T) {
-	stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{
-		reconcile: func(context.Context) error {
-			return fmt.Errorf("%w: refused to remove last mon on node-a", ceph.ErrKeepOneInvariant)
-		},
-	})
-
-	body := `{"mode":"reconcile","members":{"node-a":{"control":false},"node-b":{"control":true}}}`
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
-
-	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(w, req)
-
-	assert.Equal(t, http.StatusBadRequest, w.Code, "keep-one refusal must return 400 not 500")
-	require.Len(t, rec.refusals, 1, "the refusal reason must be recorded")
-	assert.Contains(t, rec.refusals[0], "keep-one invariant")
-	assert.Equal(t, []string{"validate", "store", "reconcile", "refusal:" + rec.refusals[0]}, rec.order,
-		"the policy must be stored before reconciliation, so a refusal cannot discard it")
-
-	// The stored policy must be the submitted snapshot verbatim.
-	ctrlFalse := false
-	ctrlTrue := true
-	assert.Equal(t, types.PlacementPolicy{
-		Mode: types.PlacementModeReconcile,
-		Members: map[string]types.MemberPlacement{
-			"node-a": {Control: &ctrlFalse},
-			"node-b": {Control: &ctrlTrue},
-		},
-	}, rec.storedPolicy)
-}
-
-// TestPlacementPutReconcileFailureStoresDesiredPolicy verifies that a
-// mid-reconcile server-side failure still leaves the submitted snapshot as the
-// canonical desired policy. Persisting before reconciling is what makes the
-// failure observable: the operator's intent survives as desired state and
-// last_refusal records what stopped it, instead of the superseded policy
-// silently remaining in effect as though the PUT never happened.
-func TestPlacementPutReconcileFailureStoresDesiredPolicy(t *testing.T) {
-	stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{
-		reconcile: func(context.Context) error {
-			return errors.New("failed to add mon on node-b: connection refused")
-		},
-	})
-
-	body := `{"mode":"reconcile","members":{"node-a":{"control":true},"node-b":{"control":true}}}`
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
-
-	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(w, req)
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code, "a mid-reconcile failure is a server fault")
-	assert.True(t, rec.ran("store"), "the desired policy must survive a reconciliation failure")
-	ctrlTrue := true
-	assert.Equal(t, types.PlacementPolicy{
-		Mode: types.PlacementModeReconcile,
-		Members: map[string]types.MemberPlacement{
-			"node-a": {Control: &ctrlTrue},
-			"node-b": {Control: &ctrlTrue},
-		},
-	}, rec.storedPolicy, "the whole submitted snapshot must be stored, not the part that converged")
-	require.Len(t, rec.refusals, 1, "the failure reason must be recorded alongside the desired policy")
-	assert.Contains(t, rec.refusals[0], "connection refused")
-}
-
-// TestPlacementPutStoreFailureSkipsReconcile verifies that when the desired
-// policy cannot be persisted the handler stops before reconciling: mutating
-// services with no durable record of the intent behind them is exactly the gap
-// the store-before-reconcile ordering exists to close. The failure reason is
-// still recorded and the response is HTTP 500.
-func TestPlacementPutStoreFailureSkipsReconcile(t *testing.T) {
-	unlockCalls := stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{
-		store: func(context.Context) error {
-			return errors.New("database unavailable")
-		},
-	})
-
-	body := `{"mode":"reconcile","members":{"node-a":{"control":false},"node-b":{"control":true}}}`
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/1.0/placement", strings.NewReader(body))
-
-	resp := cmdPlacementPut(nil, req)
-	_ = resp.Render(w, req)
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code, "an unpersistable policy must return 500")
-	assert.False(t, rec.ran("reconcile"), "services must not be mutated when the desired policy could not be stored")
-	require.Len(t, rec.refusals, 1, "the store failure must be recorded")
-	assert.Contains(t, rec.refusals[0], "database unavailable")
-	assert.Equal(t, 1, *unlockCalls, "the apply lock must be released when the store fails")
-}
-
-// TestPlacementPutServerErrorReturns500 verifies that a non-client-side
-// reconcile error (e.g. DB failure) does NOT map to 400 but falls through to
-// SmartError which returns 500, and that the apply lock is still released.
+// TestPlacementPutServerErrorReturns500 verifies that a non-client-side apply
+// error falls through to SmartError as HTTP 500 and still releases the lock.
 func TestPlacementPutServerErrorReturns500(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	stubPlacementEngine(t, placementHooks{
-		reconcile: func(context.Context) error {
-			return errors.New("database connection refused")
-		},
+	stubPlacementApply(t, func(context.Context, types.PlacementPolicy) error {
+		return errors.New("database connection refused")
 	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
@@ -337,29 +176,12 @@ func TestPlacementPutServerErrorReturns500(t *testing.T) {
 	assert.Equal(t, 1, *unlockCalls, "the apply lock must be released even when the apply fails")
 }
 
-// TestPlacementPutContextDetached verifies that cmdPlacementPut uses a context
-// detached from the request's cancellation: even when the request context is
-// cancelled, every engine phase receives a non-cancelled context. This prevents
-// the "context canceled" error during multi-minute readiness polling.
+// TestPlacementPutContextDetached verifies that cmdPlacementPut passes the
+// orchestration entry point a context detached from request cancellation. This
+// prevents context-canceled failures during multi-minute readiness polling.
 func TestPlacementPutContextDetached(t *testing.T) {
 	stubPlacementApplyLock(t)
-	cancelled := map[string]bool{}
-	noteCancelled := func(phase string) func(context.Context) error {
-		return func(ctx context.Context) error {
-			select {
-			case <-ctx.Done():
-				cancelled[phase] = true
-			default:
-				cancelled[phase] = false
-			}
-			return nil
-		}
-	}
-	stubPlacementEngine(t, placementHooks{
-		validate:  noteCancelled("validate"),
-		store:     noteCancelled("store"),
-		reconcile: noteCancelled("reconcile"),
-	})
+	rec := stubPlacementApply(t, nil)
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
 	w := httptest.NewRecorder()
@@ -374,8 +196,8 @@ func TestPlacementPutContextDetached(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code, "handler must succeed despite cancelled request context")
-	assert.Equal(t, map[string]bool{"validate": false, "store": false, "reconcile": false}, cancelled,
-		"every engine phase must receive a context detached from the request's cancellation")
+	assert.False(t, rec.contextCancelled,
+		"placement apply must receive a context detached from the request's cancellation")
 }
 
 // TestPlacementPutBadJSON verifies that malformed JSON returns BadRequest.
@@ -390,12 +212,11 @@ func TestPlacementPutBadJSON(t *testing.T) {
 }
 
 // TestPlacementPutUnknownModeRejected verifies that a policy with an unknown
-// mode is rejected with BadRequest before any lock, validate, store, or
-// reconcile happens, so a future mode (e.g. dry-run) sent to an older snap
-// fails loudly instead of being silently applied as a reconcile.
+// mode is rejected with BadRequest before any lock or placement apply, so a
+// future mode sent to an older snap fails loudly.
 func TestPlacementPutUnknownModeRejected(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{})
+	rec := stubPlacementApply(t, nil)
 
 	body := `{"mode":"dry-run","members":{"node-a":{"control":true}}}`
 	w := httptest.NewRecorder()
@@ -405,7 +226,7 @@ func TestPlacementPutUnknownModeRejected(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "unknown mode must be rejected with 400")
-	assert.Empty(t, rec.order, "unknown mode must not touch the placement engine or the policy store")
+	assert.Equal(t, 0, rec.calls, "unknown mode must not apply a placement policy")
 	assert.Equal(t, 0, *unlockCalls, "unknown mode must be rejected before the lock is taken")
 }
 
@@ -413,7 +234,7 @@ func TestPlacementPutUnknownModeRejected(t *testing.T) {
 // mode is accepted (200).
 func TestPlacementPutReconcileModeAccepted(t *testing.T) {
 	stubPlacementApplyLock(t)
-	stubPlacementEngine(t, placementHooks{})
+	stubPlacementApply(t, nil)
 
 	body := `{"mode":"reconcile","members":{}}`
 	w := httptest.NewRecorder()
@@ -425,14 +246,12 @@ func TestPlacementPutReconcileModeAccepted(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "body %s must be accepted", body)
 }
 
-// TestPlacementPutWaitingPolicyStored verifies that the CE142 waiting policy
-// (an empty members map) is persisted as the desired policy rather than treated
-// as a no-op request. Storing it is the point: an empty members map is an empty
-// storage allow-list, which is how the charm withholds OSD enrollment while it
-// has no valid role assignments to publish.
-func TestPlacementPutWaitingPolicyStored(t *testing.T) {
+// TestPlacementPutWaitingPolicyApplied verifies that the CE142 waiting policy
+// (an empty members map) is passed to the placement orchestration rather than
+// treated as a no-op request.
+func TestPlacementPutWaitingPolicyApplied(t *testing.T) {
 	stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{})
+	rec := stubPlacementApply(t, nil)
 
 	body := `{"mode":"reconcile","members":{}}`
 	w := httptest.NewRecorder()
@@ -442,11 +261,11 @@ func TestPlacementPutWaitingPolicyStored(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.True(t, rec.ran("store"), "the waiting policy must be stored as the desired policy")
+	assert.Equal(t, 1, rec.calls)
 	assert.Equal(t, types.PlacementPolicy{
 		Mode:    types.PlacementModeReconcile,
 		Members: map[string]types.MemberPlacement{},
-	}, rec.storedPolicy)
+	}, rec.policy)
 }
 
 // TestPlacementPutMissingModeRejected verifies that an omitted mode is rejected
@@ -454,7 +273,7 @@ func TestPlacementPutWaitingPolicyStored(t *testing.T) {
 // lock interaction.
 func TestPlacementPutMissingModeRejected(t *testing.T) {
 	unlockCalls := stubPlacementApplyLock(t)
-	rec := stubPlacementEngine(t, placementHooks{})
+	rec := stubPlacementApply(t, nil)
 
 	body := `{"members":{}}`
 	w := httptest.NewRecorder()
@@ -464,14 +283,13 @@ func TestPlacementPutMissingModeRejected(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, "a missing mode must be rejected with 400")
-	assert.Empty(t, rec.order, "a missing mode must not touch the placement engine or the policy store")
+	assert.Equal(t, 0, rec.calls, "a missing mode must not apply a placement policy")
 	assert.Equal(t, 0, *unlockCalls, "a missing mode must be rejected before the lock is taken")
 }
 
 // TestPlacementPutLockHeldReturnsRetryableError verifies that when another
 // placement apply holds the cluster-wide lock, the handler returns an error
-// without validating, storing, reconciling, recording a refusal, or releasing
-// the other holder's lock.
+// without applying the policy or releasing the other holder's lock.
 func TestPlacementPutLockHeldReturnsRetryableError(t *testing.T) {
 	unlockCalled := false
 	origLock := ceph.LockPlacementApplyFunc
@@ -487,7 +305,7 @@ func TestPlacementPutLockHeldReturnsRetryableError(t *testing.T) {
 		ceph.LockPlacementApplyFunc = origLock
 		ceph.UnlockPlacementApplyFunc = origUnlock
 	})
-	rec := stubPlacementEngine(t, placementHooks{})
+	rec := stubPlacementApply(t, nil)
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`
 	w := httptest.NewRecorder()
@@ -497,8 +315,7 @@ func TestPlacementPutLockHeldReturnsRetryableError(t *testing.T) {
 	_ = resp.Render(w, req)
 
 	assert.Equal(t, http.StatusConflict, w.Code, "a held apply lock must fail the PUT with 409 Conflict (retryable)")
-	assert.Empty(t, rec.order, "no placement work may run while another apply holds the lock")
-	assert.Empty(t, rec.refusals, "a lock conflict is not a policy refusal and must not overwrite last_refusal")
+	assert.Equal(t, 0, rec.calls, "no placement work may run while another apply holds the lock")
 	assert.False(t, unlockCalled, "the handler must not release a lock it failed to acquire")
 }
 
@@ -521,8 +338,8 @@ func TestPlacementPutLockReleasedWithAcquiredToken(t *testing.T) {
 		ceph.LockPlacementApplyFunc = origLock
 		ceph.UnlockPlacementApplyFunc = origUnlock
 	})
-	stubPlacementEngine(t, placementHooks{
-		reconcile: func(context.Context) error { return errors.New("apply blew up") },
+	stubPlacementApply(t, func(context.Context, types.PlacementPolicy) error {
+		return errors.New("apply blew up")
 	})
 
 	body := `{"mode":"reconcile","members":{"node-a":{"control":true}}}`

--- a/microceph/api/types/placement.go
+++ b/microceph/api/types/placement.go
@@ -8,21 +8,33 @@ type NFSPlacement struct {
 }
 
 // MemberPlacement describes the desired placement for a single MicroCeph member.
-// Pointer fields distinguish "explicitly false/empty" (remove) from "omitted"
-// (leave untouched). This is the generic, non-OS106 payload consumed by the
-// snap placement engine (CE142).
+// This is the generic, non-OS106 payload consumed by the snap placement engine
+// (CE142).
+//
+// Every field is read from the submitted document alone. Because PUT
+// /1.0/placement replaces the whole policy (see PlacementPolicy), a nil field
+// is unmanaged by the new policy; it never inherits the declaration the
+// replaced policy made for that field. Pointer fields distinguish "explicitly
+// false/empty" (remove) from "omitted" (unmanaged).
 type MemberPlacement struct {
-	// Control governs MON, MGR, and MDS placement. nil means untouched.
+	// Control governs MON, MGR, and MDS placement. nil means unmanaged:
+	// reconciliation neither adds nor removes control services on this member.
 	Control *bool `json:"control,omitempty" yaml:"control,omitempty"`
-	// Rgw governs RGW placement. nil means untouched.
+	// Rgw governs RGW placement. nil means unmanaged: reconciliation does not
+	// change RGW on this member.
 	Rgw *bool `json:"rgw,omitempty" yaml:"rgw,omitempty"`
-	// Nfs governs role-driven NFS placement. nil means untouched; an empty
+	// Nfs governs role-driven NFS placement. nil means unmanaged; an empty
 	// (non-nil) slice means remove role-driven NFS on that member. The json
 	// tag intentionally omits the omitempty modifier so that an empty slice
 	// (remove intent) round-trips through json.Marshal/Unmarshal as "nfs":[]
 	// rather than being silently dropped.
 	Nfs []NFSPlacement `json:"nfs" yaml:"nfs"`
-	// StorageEligible governs OSD enrollment eligibility. nil means untouched.
+	// StorageEligible governs OSD enrollment eligibility. It is the only
+	// fail-closed dimension: while a policy is active, this member may enroll
+	// new OSDs only on an explicit storage_eligible:true. nil means unmanaged,
+	// and unmanaged storage denies enrollment rather than leaving it as it
+	// was, so a replacement policy that drops a previous grant revokes it.
+	// Existing OSDs are never removed by placement.
 	StorageEligible *bool `json:"storage_eligible,omitempty" yaml:"storage_eligible,omitempty"`
 }
 
@@ -32,9 +44,24 @@ type MemberPlacement struct {
 // snap fails loudly instead of being silently applied as a reconcile.
 const PlacementModeReconcile = "reconcile"
 
-// PlacementPolicy is the body of PUT /1.0/placement. Members maps MicroCeph
-// member names to their desired placement. Members absent from the map are not
-// touched for service placement.
+// PlacementPolicy is the body of PUT /1.0/placement and the canonical desired
+// placement policy the snap stores. PUT is a full replacement, never a delta:
+// the submitted document becomes the complete desired policy, and no member
+// entry or field value survives from the policy it replaces. A second PUT that
+// omits a declaration therefore revokes it rather than inheriting it.
+//
+// Members maps MicroCeph member names to their desired placement. A member
+// absent from the map is unmanaged: reconciliation neither adds nor removes
+// role-managed services on it. Absence is not a grant, though -- an absent
+// member is not on the storage_eligible allow-list, so while the policy is
+// active it cannot enroll new OSDs.
+//
+// An empty or absent Members map is the CE142 waiting policy: no service
+// operations on any member, and an empty storage allow-list, so no member may
+// enroll new OSDs until a policy naming it is installed. It is accepted before
+// Ceph is bootstrapped. DELETE /1.0/placement is the way to stand down
+// entirely: it clears the policy, leaves services untouched, and returns
+// storage eligibility to unmanaged (allowed).
 type PlacementPolicy struct {
 	Mode    string                     `json:"mode" yaml:"mode"`
 	Members map[string]MemberPlacement `json:"members" yaml:"members"`
@@ -51,8 +78,10 @@ type PlacementObservedMember struct {
 }
 
 // PlacementStatus is the response body of GET /1.0/placement. It returns the
-// last accepted policy, current observed placement, lifecycle state, and any
-// blocked or in-progress reasons.
+// canonical desired policy (Policy, the complete snapshot installed by the
+// last accepted PUT), the current observed placement, lifecycle state, and any
+// blocked or in-progress reasons. Policy is the whole desired state, so a
+// declaration missing from it is not in effect.
 //
 // BootstrapState is one of: "not_bootstrapped", "in_progress",
 // "bootstrapped", or "failed" (see database.CephState* constants).

--- a/microceph/ceph/lifecycle.go
+++ b/microceph/ceph/lifecycle.go
@@ -18,7 +18,7 @@ import (
 // the lifecycle state reflects reality for clusters created after the
 // cluster_lifecycle schema was introduced (CE142). Without this, a fresh
 // non-deferred cluster would be left not_bootstrapped even though Ceph is up,
-// breaking ApplyPlacement's pre-bootstrap guard and BootstrapCeph's
+// breaking ValidatePlacement's pre-bootstrap guard and BootstrapCeph's
 // idempotence.
 //
 // It no-ops when no server certificate is available, mirroring
@@ -67,7 +67,7 @@ func configIndicatesBootstrapped(ctx context.Context, tx *sql.Tx) (bool, error) 
 
 // cephBootstrappedFromConfigFunc is the standalone (own-transaction) wrapper
 // around configIndicatesBootstrapped, for callers not already inside a
-// transaction (e.g. the ApplyPlacement pre-bootstrap guard). Injectable.
+// transaction (e.g. the ValidatePlacement pre-bootstrap guard). Injectable.
 var cephBootstrappedFromConfigFunc = func(ctx context.Context, s interfaces.StateInterface) (bool, error) {
 	var bootstrapped bool
 	err := s.ClusterState().Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {

--- a/microceph/ceph/osd.go
+++ b/microceph/ceph/osd.go
@@ -826,7 +826,17 @@ func prepareValidationFailureResp(disks []types.DiskParameter, err error) types.
 	return ret
 }
 
-// Verify that the local member is allowed to enroll OSD's.
+// checkStorageEligibility verifies that the local member is allowed to enroll
+// OSDs under the active declarative placement policy (CE142).
+//
+// Storage is the one fail-closed dimension of the policy. With no active policy
+// storage is unmanaged and enrollment proceeds, but once a policy is active the
+// stored snapshot is the authoritative allow-list: enrollment requires this
+// member to be present in it with an explicit storage_eligible:true. A member
+// that is absent from the snapshot, or present with the field omitted, is
+// denied -- because PUT replaces the whole policy, a grant made by an earlier
+// policy is not inherited by the one that supersedes it. Only new enrollment is
+// gated; existing OSDs are untouched.
 func (m *OSDManager) checkStorageEligibility(ctx context.Context) error {
 	if m.state == nil {
 		return nil

--- a/microceph/ceph/osd_test.go
+++ b/microceph/ceph/osd_test.go
@@ -1521,51 +1521,7 @@ func (s *osdSuite) TestCheckStorageEligibility() {
 
 	// Helper to create a mock state with in-memory SQLite and populate the placement policy table.
 	createTestState := func(active bool, policyJSON string) (*mocks.MockState, func()) {
-		db, err := sql.Open("sqlite3", ":memory:")
-		require.NoError(s.T(), err)
-
-		_, err = db.Exec(`
-CREATE TABLE placement_policy (
-  id               INTEGER PRIMARY KEY NOT NULL CHECK (id = 1),
-  active           INTEGER NOT NULL DEFAULT 0,
-  policy_json      TEXT,
-  last_refusal     TEXT,
-  apply_lock_token INTEGER NOT NULL DEFAULT 0
-);
-INSERT INTO placement_policy (id, active, policy_json) VALUES (1, 0, '');
-`)
-		require.NoError(s.T(), err)
-
-		activeInt := 0
-		if active {
-			activeInt = 1
-		}
-		_, err = db.Exec("UPDATE placement_policy SET active = ?, policy_json = ? WHERE id = 1", activeInt, policyJSON)
-		require.NoError(s.T(), err)
-
-		txFn := func(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
-			tx, err := db.BeginTx(ctx, nil)
-			if err != nil {
-				return err
-			}
-			err = f(ctx, tx)
-			if err != nil {
-				_ = tx.Rollback()
-				return err
-			}
-			return tx.Commit()
-		}
-
-		mockDB := &mocks.MockDB{TxFn: txFn}
-		state := &mocks.MockState{
-			ClusterName: "node-a",
-			DBObj:       mockDB,
-		}
-
-		cleanup := func() {
-			db.Close()
-		}
-
+		state, _, cleanup := newPlacementPolicyTestState(s.T(), active, policyJSON)
 		return state, cleanup
 	}
 
@@ -1621,4 +1577,122 @@ INSERT INTO placement_policy (id, active, policy_json) VALUES (1, 0, '');
 		err := osdmgr.checkStorageEligibility(ctx)
 		assert.Error(s.T(), err)
 	}
+
+	// Case 7: Active is true, member is present, but storage_eligible is
+	// omitted. Reject: storage is the fail-closed dimension, so an unmanaged
+	// eligibility is not a grant. Because PUT replaces the whole policy, this
+	// is also how a snapshot that drops a previous grant revokes it -- the
+	// omitted field is never inherited from the superseded policy.
+	{
+		policyJSON := `{"members":{"node-a":{"control":true}}}`
+		state, cleanup := createTestState(true, policyJSON)
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.Error(s.T(), err)
+	}
+
+	// Case 8: Active is true with the CE142 waiting policy (an empty members
+	// map). Reject: an empty map is an empty storage allow-list, not an absent
+	// policy, so no member may enroll new OSDs.
+	{
+		policyJSON := `{"mode":"reconcile","members":{}}`
+		state, cleanup := createTestState(true, policyJSON)
+		defer cleanup()
+
+		osdmgr := NewOSDManager(state)
+		err := osdmgr.checkStorageEligibility(ctx)
+		assert.Error(s.T(), err)
+	}
+}
+
+// TestCheckStorageEligibilityPolicyReplacementRevokesGrant verifies that
+// storing a second policy replaces the first rather than merging with it: a
+// grant made by the first snapshot does not survive into a second snapshot that
+// omits it. This is the enforcement-point expression of the PUT-is-replacement
+// contract documented on types.PlacementPolicy.
+func (s *osdSuite) TestCheckStorageEligibilityPolicyReplacementRevokesGrant() {
+	ctx := context.Background()
+
+	state, db, cleanup := newPlacementPolicyTestState(s.T(), false, "")
+	defer cleanup()
+
+	osdmgr := NewOSDManager(state)
+
+	storePolicy := func(policyJSON string) {
+		tx, err := db.BeginTx(ctx, nil)
+		require.NoError(s.T(), err)
+		err = database.SetPlacementPolicy(ctx, tx, true, policyJSON)
+		require.NoError(s.T(), err)
+		require.NoError(s.T(), tx.Commit())
+	}
+
+	// First snapshot grants storage on the local member.
+	storePolicy(`{"mode":"reconcile","members":{"node-a":{"storage_eligible":true}}}`)
+	assert.NoError(s.T(), osdmgr.checkStorageEligibility(ctx))
+
+	// Second snapshot keeps node-a but declares only control. The omitted
+	// storage_eligible is unmanaged under the new policy, not inherited, so the
+	// grant is gone.
+	storePolicy(`{"mode":"reconcile","members":{"node-a":{"control":true}}}`)
+	assert.Error(s.T(), osdmgr.checkStorageEligibility(ctx))
+
+	// Third snapshot drops node-a entirely. An absent member is likewise not on
+	// the allow-list.
+	storePolicy(`{"mode":"reconcile","members":{"node-b":{"storage_eligible":true}}}`)
+	assert.Error(s.T(), osdmgr.checkStorageEligibility(ctx))
+
+	// A fresh grant re-enables enrollment, proving the denials above came from
+	// the replacement policy rather than sticky state.
+	storePolicy(`{"mode":"reconcile","members":{"node-a":{"storage_eligible":true}}}`)
+	assert.NoError(s.T(), osdmgr.checkStorageEligibility(ctx))
+}
+
+// newPlacementPolicyTestState builds a MockState backed by an in-memory SQLite
+// database carrying the placement_policy singleton row, seeded with the given
+// active flag and policy JSON. It returns the state, the underlying handle so
+// callers can rewrite the row mid-test, and a cleanup function.
+func newPlacementPolicyTestState(t require.TestingT, active bool, policyJSON string) (*mocks.MockState, *sql.DB, func()) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+CREATE TABLE placement_policy (
+  id               INTEGER PRIMARY KEY NOT NULL CHECK (id = 1),
+  active           INTEGER NOT NULL DEFAULT 0,
+  policy_json      TEXT,
+  last_refusal     TEXT,
+  apply_lock_token INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO placement_policy (id, active, policy_json) VALUES (1, 0, '');
+`)
+	require.NoError(t, err)
+
+	activeInt := 0
+	if active {
+		activeInt = 1
+	}
+	_, err = db.Exec("UPDATE placement_policy SET active = ?, policy_json = ? WHERE id = 1", activeInt, policyJSON)
+	require.NoError(t, err)
+
+	txFn := func(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		err = f(ctx, tx)
+		if err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		return tx.Commit()
+	}
+
+	state := &mocks.MockState{
+		ClusterName: "node-a",
+		DBObj:       &mocks.MockDB{TxFn: txFn},
+	}
+
+	return state, db, func() { db.Close() }
 }

--- a/microceph/ceph/placement.go
+++ b/microceph/ceph/placement.go
@@ -45,12 +45,17 @@ var ErrPlacementApplyInProgress = fmt.Errorf("placement apply already in progres
 // so a live apply can never have its lock reclaimed underneath it.
 const placementApplyLease = 15 * time.Minute
 
+// placementRefusalWriteTimeout bounds best-effort refusal bookkeeping. Writes
+// use a detached context so an apply deadline does not prevent recording the
+// failure that caused it or clearing an old refusal after convergence.
+const placementRefusalWriteTimeout = 30 * time.Second
+
 // LockPlacementApplyFunc is the injectable wrapper for LockPlacementApply,
 // used by the API handler so tests can override it.
 var LockPlacementApplyFunc = LockPlacementApply
 
 // LockPlacementApply acquires the cluster-wide placement apply lock (CE142).
-// ReconcilePlacement reads observed service state and then mutates services
+// ApplyPlacementPolicy reads observed service state and then mutates services
 // over minutes; two overlapping applies (possibly served by different members)
 // could each count the other's removal targets as keep-one retainers and
 // together remove the last viable control service. The dqlite-backed lock
@@ -105,13 +110,15 @@ func UnlockPlacementApply(ctx context.Context, s interfaces.StateInterface, toke
 	return nil
 }
 
-// ValidatePlacementFunc is the injectable wrapper for ValidatePlacement, used
-// by the API handler so tests can override it.
-var ValidatePlacementFunc = ValidatePlacement
+// ApplyPlacementPolicyFunc is the injectable wrapper for ApplyPlacementPolicy,
+// used by the API handler so tests can override it.
+var ApplyPlacementPolicyFunc = ApplyPlacementPolicy
 
-// ReconcilePlacementFunc is the injectable wrapper for ReconcilePlacement, used
-// by the API handler so tests can override it.
-var ReconcilePlacementFunc = ReconcilePlacement
+// validatePlacementFunc and reconcilePlacementFunc are the injectable phases
+// used by ApplyPlacementPolicy. Keeping them package-private prevents callers
+// from bypassing the validate-store-reconcile orchestration.
+var validatePlacementFunc = ValidatePlacement
+var reconcilePlacementFunc = reconcilePlacement
 
 // getClusterLifecycleFunc reads the Ceph lifecycle state for the pre-bootstrap
 // guard. It is injectable for testing.
@@ -128,7 +135,7 @@ var getClusterLifecycleFunc = func(ctx context.Context, s interfaces.StateInterf
 // ValidatePlacement checks a desired placement snapshot against cluster
 // preconditions without touching any service or the stored policy (CE142).
 //
-// It is the first of the three phases the API handler drives -- validate,
+// It is the first of the three phases ApplyPlacementPolicy drives -- validate,
 // store, reconcile -- and exists as a separate phase so that a policy which can
 // never apply is rejected before it replaces the stored desired state, while a
 // policy that merely fails to converge is still persisted and observable.
@@ -190,7 +197,61 @@ func ValidatePlacement(ctx context.Context, s interfaces.StateInterface, policy 
 	return nil
 }
 
-// ReconcilePlacement converges observed service placement onto a desired
+// ApplyPlacementPolicy validates, stores, and reconciles a complete desired
+// placement snapshot (CE142). The caller must hold the cluster-wide placement
+// apply lock for the duration of this call.
+//
+// Validation runs before persistence so a policy that can never apply does not
+// replace the current desired state. Persistence runs before reconciliation so
+// a convergence failure leaves the new intent observable through placement
+// status. Every failure is recorded as the latest refusal on a best-effort
+// basis; a successful apply clears any previous refusal.
+func ApplyPlacementPolicy(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
+	err := validatePlacementFunc(ctx, s, policy)
+	if err != nil {
+		recordPlacementRefusal(ctx, s, err)
+		return err
+	}
+
+	err = storePlacementPolicyFunc(ctx, s, policy)
+	if err != nil {
+		recordPlacementRefusal(ctx, s, err)
+		return err
+	}
+
+	err = reconcilePlacementFunc(ctx, s, policy)
+	if err != nil {
+		recordPlacementRefusal(ctx, s, err)
+		return err
+	}
+
+	err = writePlacementRefusal(ctx, s, "")
+	if err != nil {
+		logger.Warnf("failed to clear placement refusal: %v", err)
+	}
+
+	return nil
+}
+
+// recordPlacementRefusal persists why a placement policy did not fully apply.
+// It is best-effort because the original apply error is more useful to callers.
+func recordPlacementRefusal(ctx context.Context, s interfaces.StateInterface, cause error) {
+	err := writePlacementRefusal(ctx, s, cause.Error())
+	if err != nil {
+		logger.Warnf("failed to persist placement refusal: %v", err)
+	}
+}
+
+// writePlacementRefusal uses a fresh bounded context detached from apply
+// cancellation. In particular, a deadline-exceeded apply must still be able to
+// persist that failure for placement status consumers.
+func writePlacementRefusal(ctx context.Context, s interfaces.StateInterface, reason string) error {
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), placementRefusalWriteTimeout)
+	defer cancel()
+	return setPlacementRefusalFunc(writeCtx, s, reason)
+}
+
+// reconcilePlacement converges observed service placement onto a desired
 // placement snapshot (CE142). It is the core of the placement engine: it
 // computes the diff between the desired snapshot and observed placement, then
 // applies control-service adds before removals, refusing to remove the last
@@ -212,18 +273,18 @@ func ValidatePlacement(ctx context.Context, s interfaces.StateInterface, policy 
 //   - The engine never removes the last viable MON, MGR, or MDS.
 //
 // Reconciliation is deliberately a no-op for unmanaged fields, but that does
-// not make the stored policy a delta: StorePlacementPolicy replaces the whole
+// not make the stored policy a delta: storePlacementPolicy replaces the whole
 // desired snapshot regardless of which fields caused work here.
 //
-// The caller must have run ValidatePlacement on the same policy first;
-// ReconcilePlacement does not re-check bootstrap state or member membership.
+// ApplyPlacementPolicy is the only production entry point: it validates and
+// stores the same policy before calling this package-private phase.
 //
 // If a removal is refused for keep-one safety the adds remain in effect (a
 // partial convergence) and the function returns ErrKeepOneInvariant so the
 // caller can surface a clear blocked reason. The desired policy has already
 // been stored by then, so GET /placement reports the observed-vs-desired gap
 // with last_refusal explaining it.
-func ReconcilePlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
+func reconcilePlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
 	if s.ClusterState().ServerCert() == nil {
 		return fmt.Errorf("no server certificate")
 	}
@@ -500,17 +561,17 @@ func GetPlacementStatus(ctx context.Context, s interfaces.StateInterface) (*type
 	return status, nil
 }
 
-// StorePlacementPolicyFunc is the injectable wrapper for StorePlacementPolicy,
-// used by the API handler so tests can override it.
-var StorePlacementPolicyFunc = StorePlacementPolicy
+// storePlacementPolicyFunc is the injectable persistence phase used by
+// ApplyPlacementPolicy.
+var storePlacementPolicyFunc = storePlacementPolicy
 
-// StorePlacementPolicy replaces the stored canonical desired placement policy
+// storePlacementPolicy replaces the stored canonical desired placement policy
 // with the given snapshot and marks a policy active. The write is a full
 // replacement: the previously stored policy is discarded rather than merged, so
 // a member or field the caller omitted is not carried forward. Consumers read
 // this record as the authoritative statement of desired placement --
 // OSDManager.checkStorageEligibility gates OSD enrollment on it.
-func StorePlacementPolicy(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
+func storePlacementPolicy(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
 	data, err := json.Marshal(policy)
 	if err != nil {
 		return fmt.Errorf("failed to marshal placement policy: %w", err)
@@ -524,13 +585,13 @@ func StorePlacementPolicy(ctx context.Context, s interfaces.StateInterface, poli
 // ClearPlacementPolicyFunc clears the active placement policy.
 var ClearPlacementPolicyFunc = ClearPlacementPolicy
 
-// SetPlacementRefusalFunc persists (or clears) the last placement refusal
-// reason. Injectable for testing.
-var SetPlacementRefusalFunc = SetPlacementRefusal
+// setPlacementRefusalFunc is the injectable refusal writer used by
+// ApplyPlacementPolicy.
+var setPlacementRefusalFunc = setPlacementRefusal
 
-// SetPlacementRefusal persists (or clears, if reason is empty) the last
+// setPlacementRefusal persists (or clears, if reason is empty) the last
 // placement refusal reason in the placement_policy table.
-func SetPlacementRefusal(ctx context.Context, s interfaces.StateInterface, reason string) error {
+func setPlacementRefusal(ctx context.Context, s interfaces.StateInterface, reason string) error {
 	return s.ClusterState().Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		return database.SetPlacementRefusal(ctx, tx, reason)
 	})

--- a/microceph/ceph/placement.go
+++ b/microceph/ceph/placement.go
@@ -50,8 +50,8 @@ const placementApplyLease = 15 * time.Minute
 var LockPlacementApplyFunc = LockPlacementApply
 
 // LockPlacementApply acquires the cluster-wide placement apply lock (CE142).
-// ApplyPlacement reads observed service state and then mutates services over
-// minutes; two overlapping applies (possibly served by different members)
+// ReconcilePlacement reads observed service state and then mutates services
+// over minutes; two overlapping applies (possibly served by different members)
 // could each count the other's removal targets as keep-one retainers and
 // together remove the last viable control service. The dqlite-backed lock
 // makes the read-modify cycle mutually exclusive across all cluster members.
@@ -105,9 +105,13 @@ func UnlockPlacementApply(ctx context.Context, s interfaces.StateInterface, toke
 	return nil
 }
 
-// ApplyPlacementFunc is the injectable wrapper for ApplyPlacement, used by the
-// API handler so tests can override it.
-var ApplyPlacementFunc = ApplyPlacement
+// ValidatePlacementFunc is the injectable wrapper for ValidatePlacement, used
+// by the API handler so tests can override it.
+var ValidatePlacementFunc = ValidatePlacement
+
+// ReconcilePlacementFunc is the injectable wrapper for ReconcilePlacement, used
+// by the API handler so tests can override it.
+var ReconcilePlacementFunc = ReconcilePlacement
 
 // getClusterLifecycleFunc reads the Ceph lifecycle state for the pre-bootstrap
 // guard. It is injectable for testing.
@@ -121,32 +125,35 @@ var getClusterLifecycleFunc = func(ctx context.Context, s interfaces.StateInterf
 	return lc, err
 }
 
-// ApplyPlacement applies a declarative placement policy (CE142). It is the core
-// of the placement engine: it computes the diff between desired and observed
-// placement, then applies control-service adds before removals, refusing to
-// remove the last viable MON, MGR, or MDS.
+// ValidatePlacement checks a desired placement snapshot against cluster
+// preconditions without touching any service or the stored policy (CE142).
 //
-// Rules:
-//   - An empty members map performs no service operations.
-//   - Members absent from the map are not touched for service placement.
-//   - Omitted service fields on present members are not touched.
-//   - control:true adds MON/MGR/MDS; control:false removes them (after safety).
-//   - The engine never removes the last viable MON, MGR, or MDS.
-//   - Unknown members in the map are rejected.
+// It is the first of the three phases the API handler drives -- validate,
+// store, reconcile -- and exists as a separate phase so that a policy which can
+// never apply is rejected before it replaces the stored desired state, while a
+// policy that merely fails to converge is still persisted and observable.
 //
-// If a removal is refused for keep-one safety the adds remain in effect (a
-// partial apply) and the function returns ErrKeepOneInvariant so the caller can
-// surface a clear blocked reason; the API handler is responsible for persisting
-// the policy as the declared intent in that case so GET /placement can report
-// the observed-vs-declared gap.
-func ApplyPlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
+// Rejections:
+//   - Ceph is not bootstrapped and the policy is non-empty
+//     (ErrCephNotBootstrapped).
+//   - The policy names a member that is not a known cluster member
+//     (ErrUnknownPlacementMember).
+//
+// Both are client-side sentinels so the API handler maps them to HTTP 400
+// rather than the SmartError 500 fallback. An empty members map (the CE142
+// waiting policy) always validates, including before Ceph is bootstrapped.
+func ValidatePlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
 	if s.ClusterState().ServerCert() == nil {
 		return fmt.Errorf("no server certificate")
 	}
 
-	// Empty members map: no service operations.
+	// Empty members map: the CE142 waiting policy. It is accepted before the
+	// pre-bootstrap guard below so the charm can install it while Ceph is still
+	// unbootstrapped (relation missing, no assignments published, or only
+	// pending/error entries). Storing it is not inert: an empty members map is
+	// an empty storage allow-list, so once active it denies new OSD enrollment
+	// on every member (see OSDManager.checkStorageEligibility).
 	if len(policy.Members) == 0 {
-		logger.Debug("Placement policy has empty members map: no service operations")
 		return nil
 	}
 
@@ -157,9 +164,6 @@ func ApplyPlacement(ctx context.Context, s interfaces.StateInterface, policy typ
 	// placement. Without this, EnableService -> UpdateConfig fails with an
 	// obscure 'failed to locate IP on public network' error because no Ceph
 	// config exists yet.
-	//
-	// ErrCephNotBootstrapped is a client-side sentinel so the API handler maps
-	// it to HTTP 400 (BadRequest) rather than the SmartError 500 fallback.
 	bootstrapped, err := cephIsBootstrappedFunc(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to determine Ceph bootstrap state: %w", err)
@@ -181,6 +185,55 @@ func ApplyPlacement(ctx context.Context, s interfaces.StateInterface, policy typ
 		if !memberSet[memberName] {
 			return fmt.Errorf("%w: %s", ErrUnknownPlacementMember, memberName)
 		}
+	}
+
+	return nil
+}
+
+// ReconcilePlacement converges observed service placement onto a desired
+// placement snapshot (CE142). It is the core of the placement engine: it
+// computes the diff between the desired snapshot and observed placement, then
+// applies control-service adds before removals, refusing to remove the last
+// viable MON, MGR, or MDS.
+//
+// The policy is a complete desired-state snapshot, not a delta (see
+// types.PlacementPolicy): every decision below is taken from this policy alone,
+// and the previously stored policy is never consulted or merged.
+//
+// Rules:
+//   - An empty members map performs no service operations (the waiting policy).
+//   - A member absent from the map is unmanaged: no service is added to or
+//     removed from it. Absence is not a grant -- it also leaves that member off
+//     the storage_eligible allow-list once the policy is stored.
+//   - A nil service field on a present member is unmanaged for that service
+//     class: no operation is performed, and the field is not inherited from the
+//     policy this one replaces.
+//   - control:true adds MON/MGR/MDS; control:false removes them (after safety).
+//   - The engine never removes the last viable MON, MGR, or MDS.
+//
+// Reconciliation is deliberately a no-op for unmanaged fields, but that does
+// not make the stored policy a delta: StorePlacementPolicy replaces the whole
+// desired snapshot regardless of which fields caused work here.
+//
+// The caller must have run ValidatePlacement on the same policy first;
+// ReconcilePlacement does not re-check bootstrap state or member membership.
+//
+// If a removal is refused for keep-one safety the adds remain in effect (a
+// partial convergence) and the function returns ErrKeepOneInvariant so the
+// caller can surface a clear blocked reason. The desired policy has already
+// been stored by then, so GET /placement reports the observed-vs-desired gap
+// with last_refusal explaining it.
+func ReconcilePlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
+	if s.ClusterState().ServerCert() == nil {
+		return fmt.Errorf("no server certificate")
+	}
+
+	// Empty members map (the waiting policy): no service operations. The policy
+	// still governs storage eligibility once stored; it is only reconciliation
+	// that has nothing to do.
+	if len(policy.Members) == 0 {
+		logger.Debug("Placement policy has empty members map: no service operations")
+		return nil
 	}
 
 	// Get current observed control services.
@@ -358,8 +411,11 @@ func redactSecrets(s string) string {
 	return secretPattern.ReplaceAllString(s, "AQ****REDACTED****==")
 }
 
-// GetPlacementStatus reads the placement policy and lifecycle state from the
-// database and returns a PlacementStatus response.
+// GetPlacementStatus reads the canonical desired placement policy and the
+// lifecycle state from the database and returns a PlacementStatus response.
+// The returned Policy is the complete desired snapshot as stored, so callers
+// can compare it against Observed without reconstructing it from earlier
+// requests.
 func GetPlacementStatus(ctx context.Context, s interfaces.StateInterface) (*types.PlacementStatus, error) {
 	if s.ClusterState().ServerCert() == nil {
 		return nil, fmt.Errorf("no server certificate")
@@ -448,7 +504,12 @@ func GetPlacementStatus(ctx context.Context, s interfaces.StateInterface) (*type
 // used by the API handler so tests can override it.
 var StorePlacementPolicyFunc = StorePlacementPolicy
 
-// StorePlacementPolicy stores the given policy as the active placement policy.
+// StorePlacementPolicy replaces the stored canonical desired placement policy
+// with the given snapshot and marks a policy active. The write is a full
+// replacement: the previously stored policy is discarded rather than merged, so
+// a member or field the caller omitted is not carried forward. Consumers read
+// this record as the authoritative statement of desired placement --
+// OSDManager.checkStorageEligibility gates OSD enrollment on it.
 func StorePlacementPolicy(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
 	data, err := json.Marshal(policy)
 	if err != nil {
@@ -475,8 +536,10 @@ func SetPlacementRefusal(ctx context.Context, s interfaces.StateInterface, reaso
 	})
 }
 
-// ClearPlacementPolicy clears the active role-managed placement policy without
-// adding or removing services.
+// ClearPlacementPolicy clears the canonical desired placement policy and marks
+// role-managed placement inactive, without adding or removing services. It is
+// the stand-down path: with no active policy, storage eligibility is unmanaged
+// again and OSD enrollment is no longer gated.
 func ClearPlacementPolicy(ctx context.Context, s interfaces.StateInterface) error {
 	return s.ClusterState().Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		return database.ClearPlacementPolicy(ctx, tx)

--- a/microceph/ceph/placement_test.go
+++ b/microceph/ceph/placement_test.go
@@ -28,6 +28,18 @@ func TestPlacement(t *testing.T) {
 	suite.Run(t, new(placementSuite))
 }
 
+// applyPlacement runs the validate-then-reconcile sequence that cmdPlacementPut
+// drives, minus the persistence phase between them. Engine tests use it so they
+// exercise the two phases in the order the handler does; the handler's own
+// ordering (including where the policy is stored) is covered by the API tests.
+func applyPlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
+	err := ValidatePlacement(ctx, s, policy)
+	if err != nil {
+		return err
+	}
+	return ReconcilePlacement(ctx, s, policy)
+}
+
 func (s *placementSuite) SetupTest() {
 	s.BaseSuite.SetupTest()
 	s.CopyCephConfigs()
@@ -163,7 +175,7 @@ func (s *placementSuite) TestPlacementEmptyMapNoOps() {
 	defer restore()
 
 	policy := types.PlacementPolicy{Mode: "reconcile", Members: map[string]types.MemberPlacement{}}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), rec.adds())
 	assert.Empty(s.T(), rec.removes())
@@ -183,7 +195,7 @@ func (s *placementSuite) TestPlacementAddControl() {
 			"node-a": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.ElementsMatch(s.T(), []string{"mon:node-a", "mgr:node-a", "mds:node-a"}, rec.adds())
 	assert.Empty(s.T(), rec.removes())
@@ -207,7 +219,7 @@ func (s *placementSuite) TestPlacementRemoveControl() {
 			"node-b": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.ElementsMatch(s.T(), []string{"mon:node-a", "mgr:node-a", "mds:node-a"}, rec.removes())
 }
@@ -229,7 +241,7 @@ func (s *placementSuite) TestPlacementKeepOneInvariant() {
 			"node-a": {Control: boolPtr(false)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.Error(s.T(), err, "keep-one refusal must be surfaced as an error")
 	assert.ErrorIs(s.T(), err, ErrKeepOneInvariant)
 	assert.Empty(s.T(), rec.removes(), "must not remove last control service")
@@ -253,7 +265,7 @@ func (s *placementSuite) TestPlacementMigrateControl() {
 			"node-b": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 
 	// All adds must precede all removes in the ordered event log.
@@ -277,9 +289,12 @@ func (s *placementSuite) TestPlacementMigrateControl() {
 	assert.True(s.T(), removeSet["mds:node-a"])
 }
 
-// TestPlacementOmittedFieldsUntouched verifies that omitted service fields and
-// omitted members are not touched (UAT-S1.5 / precedence rule 8).
-func (s *placementSuite) TestPlacementOmittedFieldsUntouched() {
+// TestPlacementAbsentMemberUnmanaged verifies that a member absent from the
+// desired snapshot is unmanaged: reconciliation neither adds services to it nor
+// removes services from it (UAT-S1.5 / precedence rule 8). Absence is not an
+// instruction to strip the member, and it is not an inherited declaration from
+// whatever policy this one replaced.
+func (s *placementSuite) TestPlacementAbsentMemberUnmanaged() {
 	defer withObservedControl(map[string]map[string]bool{
 		"mon": {"node-c": true},
 		"mgr": {"node-c": true},
@@ -295,7 +310,7 @@ func (s *placementSuite) TestPlacementOmittedFieldsUntouched() {
 			"node-a": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 
 	// node-c should not be touched (no adds or removes for node-c).
@@ -319,7 +334,7 @@ func (s *placementSuite) TestPlacementUnknownMemberRejected() {
 			"unknown-node": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.Error(s.T(), err)
 	assert.ErrorIs(s.T(), err, ErrUnknownPlacementMember)
 	assert.Empty(s.T(), rec.adds())
@@ -342,7 +357,7 @@ func (s *placementSuite) TestPlacementIdempotent() {
 			"node-a": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), rec.adds())
 	assert.Empty(s.T(), rec.removes())
@@ -366,7 +381,7 @@ func (s *placementSuite) TestPlacementControlFalseOnMemberWithNoService() {
 			"node-b": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.Empty(s.T(), rec.removes(), "no removals for a member without services")
 }
@@ -392,7 +407,7 @@ func (s *placementSuite) TestPlacementMultiRemovalConvergence() {
 			"node-c": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 
 	// node-c should get mon/mgr/mds added.
@@ -435,7 +450,7 @@ func (s *placementSuite) TestPlacementOmittedControlOnPresentMember() {
 			"node-b": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 
 	// node-a must not be touched (no adds or removes for node-a).
@@ -466,7 +481,7 @@ func (s *placementSuite) TestPlacementPreBootstrapRejectsNonEmptyPolicy() {
 			"node-a": {Control: boolPtr(true)},
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.Error(s.T(), err)
 	assert.ErrorIs(s.T(), err, ErrCephNotBootstrapped)
 	assert.Empty(s.T(), rec.adds(), "no service operations must run pre-bootstrap")
@@ -486,7 +501,7 @@ func (s *placementSuite) TestPlacementPreBootstrapAllowsEmptyPolicy() {
 	defer restore()
 
 	policy := types.PlacementPolicy{Mode: "reconcile", Members: map[string]types.MemberPlacement{}}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err, "empty policy must be accepted pre-bootstrap")
 	assert.Empty(s.T(), rec.adds())
 	assert.Empty(s.T(), rec.removes())
@@ -523,7 +538,7 @@ func (s *placementSuite) TestPlacementKeepOneReadinessGuard() {
 			"node-b": {Control: boolPtr(true)},  // add new (not ready)
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	// The add succeeds; the removal is refused because node-b is not viable.
 	assert.Error(s.T(), err, "must refuse to remove old control when replacement not viable")
 	assert.ErrorIs(s.T(), err, ErrKeepOneInvariant)
@@ -558,7 +573,7 @@ func (s *placementSuite) TestPlacementRemovalAllowedWhenReplacementReady() {
 			"node-b": {Control: boolPtr(true)},  // add new (ready)
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.NotEmpty(s.T(), rec.adds(), "replacement must be added")
 	assert.NotEmpty(s.T(), rec.removes(), "old service must be removed when replacement is viable")
@@ -590,7 +605,7 @@ func (s *placementSuite) TestPlacementRemovesExistingNonViableTargetWhenRetainer
 			"node-b": {},                        // omitted control retains viable services
 		},
 	}
-	err := ApplyPlacement(context.Background(), s.TestStateInterface, policy)
+	err := applyPlacement(context.Background(), s.TestStateInterface, policy)
 	assert.NoError(s.T(), err)
 	assert.ElementsMatch(s.T(), []string{"mon:node-a", "mgr:node-a", "mds:node-a"}, rec.removes())
 }

--- a/microceph/ceph/placement_test.go
+++ b/microceph/ceph/placement_test.go
@@ -28,16 +28,210 @@ func TestPlacement(t *testing.T) {
 	suite.Run(t, new(placementSuite))
 }
 
-// applyPlacement runs the validate-then-reconcile sequence that cmdPlacementPut
-// drives, minus the persistence phase between them. Engine tests use it so they
-// exercise the two phases in the order the handler does; the handler's own
-// ordering (including where the policy is stored) is covered by the API tests.
+// applyPlacement runs validation before the package-private reconciliation
+// phase. Reconciliation tests use it without exercising policy persistence;
+// ApplyPlacementPolicy's full validate-store-reconcile ordering is covered by
+// dedicated orchestration tests below.
 func applyPlacement(ctx context.Context, s interfaces.StateInterface, policy types.PlacementPolicy) error {
 	err := ValidatePlacement(ctx, s, policy)
 	if err != nil {
 		return err
 	}
-	return ReconcilePlacement(ctx, s, policy)
+	return reconcilePlacement(ctx, s, policy)
+}
+
+// TestApplyPlacementPolicyOrdering verifies that the exported placement entry
+// point enforces validate-store-reconcile ordering, stops at the failing phase,
+// records failures, and clears an old refusal only after successful convergence.
+func TestApplyPlacementPolicyOrdering(t *testing.T) {
+	validationErr := fmt.Errorf("%w: node-z", ErrUnknownPlacementMember)
+	storeErr := fmt.Errorf("database unavailable")
+	reconcileErr := fmt.Errorf("%w: mon on node-a", ErrKeepOneInvariant)
+
+	tests := []struct {
+		name          string
+		validationErr error
+		storeErr      error
+		reconcileErr  error
+		wantOrder     []string
+	}{
+		{
+			name:      "success",
+			wantOrder: []string{"validate", "store", "reconcile", "refusal:"},
+		},
+		{
+			name:          "validation failure",
+			validationErr: validationErr,
+			wantOrder:     []string{"validate", "refusal:" + validationErr.Error()},
+		},
+		{
+			name:      "store failure",
+			storeErr:  storeErr,
+			wantOrder: []string{"validate", "store", "refusal:" + storeErr.Error()},
+		},
+		{
+			name:         "reconcile failure",
+			reconcileErr: reconcileErr,
+			wantOrder:    []string{"validate", "store", "reconcile", "refusal:" + reconcileErr.Error()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var order []string
+			var storedPolicy types.PlacementPolicy
+			origValidate := validatePlacementFunc
+			origStore := storePlacementPolicyFunc
+			origReconcile := reconcilePlacementFunc
+			origRefusal := setPlacementRefusalFunc
+			validatePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+				order = append(order, "validate")
+				return tt.validationErr
+			}
+			storePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, policy types.PlacementPolicy) error {
+				order = append(order, "store")
+				storedPolicy = policy
+				return tt.storeErr
+			}
+			reconcilePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+				order = append(order, "reconcile")
+				return tt.reconcileErr
+			}
+			setPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, reason string) error {
+				order = append(order, "refusal:"+reason)
+				return nil
+			}
+			t.Cleanup(func() {
+				validatePlacementFunc = origValidate
+				storePlacementPolicyFunc = origStore
+				reconcilePlacementFunc = origReconcile
+				setPlacementRefusalFunc = origRefusal
+			})
+
+			control := true
+			policy := types.PlacementPolicy{
+				Mode: types.PlacementModeReconcile,
+				Members: map[string]types.MemberPlacement{
+					"node-a": {Control: &control},
+				},
+			}
+			err := ApplyPlacementPolicy(context.Background(), nil, policy)
+
+			wantErr := tt.validationErr
+			if wantErr == nil {
+				wantErr = tt.storeErr
+			}
+			if wantErr == nil {
+				wantErr = tt.reconcileErr
+			}
+			if wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, wantErr)
+			}
+			assert.Equal(t, tt.wantOrder, order)
+			if tt.validationErr == nil {
+				assert.Equal(t, policy, storedPolicy)
+			} else {
+				assert.Equal(t, types.PlacementPolicy{}, storedPolicy,
+					"a policy rejected by validation must not displace desired state")
+			}
+		})
+	}
+}
+
+// TestApplyPlacementPolicyRefusalPersistenceBestEffort verifies that refusal
+// bookkeeping cannot hide either the original apply error or a successful
+// convergence result.
+func TestApplyPlacementPolicyRefusalPersistenceBestEffort(t *testing.T) {
+	origValidate := validatePlacementFunc
+	origStore := storePlacementPolicyFunc
+	origReconcile := reconcilePlacementFunc
+	origRefusal := setPlacementRefusalFunc
+	t.Cleanup(func() {
+		validatePlacementFunc = origValidate
+		storePlacementPolicyFunc = origStore
+		reconcilePlacementFunc = origReconcile
+		setPlacementRefusalFunc = origRefusal
+	})
+
+	applyErr := fmt.Errorf("apply failed")
+	refusalErr := fmt.Errorf("refusal write failed")
+	validatePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return applyErr
+	}
+	setPlacementRefusalFunc = func(_ context.Context, _ interfaces.StateInterface, _ string) error {
+		return refusalErr
+	}
+
+	err := ApplyPlacementPolicy(context.Background(), nil, types.PlacementPolicy{})
+	assert.ErrorIs(t, err, applyErr)
+
+	validatePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return nil
+	}
+	storePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return nil
+	}
+	reconcilePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return nil
+	}
+
+	err = ApplyPlacementPolicy(context.Background(), nil, types.PlacementPolicy{})
+	assert.NoError(t, err)
+}
+
+// TestApplyPlacementPolicyRefusalContextDetached verifies that an expired apply
+// context cannot prevent recording a failure or clearing a stale refusal.
+func TestApplyPlacementPolicyRefusalContextDetached(t *testing.T) {
+	origValidate := validatePlacementFunc
+	origStore := storePlacementPolicyFunc
+	origReconcile := reconcilePlacementFunc
+	origRefusal := setPlacementRefusalFunc
+	t.Cleanup(func() {
+		validatePlacementFunc = origValidate
+		storePlacementPolicyFunc = origStore
+		reconcilePlacementFunc = origReconcile
+		setPlacementRefusalFunc = origRefusal
+	})
+
+	applyErr := fmt.Errorf("apply failed after deadline")
+	validatePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return applyErr
+	}
+	storePlacementPolicyFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return nil
+	}
+	reconcilePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return nil
+	}
+
+	var reasons []string
+	var contextErrors []error
+	var contextsHaveDeadline []bool
+	setPlacementRefusalFunc = func(ctx context.Context, _ interfaces.StateInterface, reason string) error {
+		reasons = append(reasons, reason)
+		contextErrors = append(contextErrors, ctx.Err())
+		_, hasDeadline := ctx.Deadline()
+		contextsHaveDeadline = append(contextsHaveDeadline, hasDeadline)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := ApplyPlacementPolicy(ctx, nil, types.PlacementPolicy{})
+	assert.ErrorIs(t, err, applyErr)
+
+	validatePlacementFunc = func(_ context.Context, _ interfaces.StateInterface, _ types.PlacementPolicy) error {
+		return nil
+	}
+	err = ApplyPlacementPolicy(ctx, nil, types.PlacementPolicy{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{applyErr.Error(), ""}, reasons)
+	assert.Equal(t, []error{nil, nil}, contextErrors)
+	assert.Equal(t, []bool{true, true}, contextsHaveDeadline)
 }
 
 func (s *placementSuite) SetupTest() {

--- a/microceph/cmd/microcephd/simple_bootstrapper.go
+++ b/microceph/cmd/microcephd/simple_bootstrapper.go
@@ -139,7 +139,7 @@ func (sb *SimpleBootstrapper) Bootstrap(ctx context.Context, state interfaces.St
 
 	// Mark the Ceph lifecycle as bootstrapped (CE142). Non-fatal: if this
 	// write fails the cluster is still up, and the defensive config-based
-	// check in ApplyPlacement/BootstrapCeph covers a stale lifecycle row.
+	// check in ValidatePlacement/BootstrapCeph covers a stale lifecycle row.
 	err = ceph.MarkCephBootstrappedFunc(ctx, state)
 	if err != nil {
 		logger.Warnf("failed to mark ceph lifecycle as bootstrapped: %v", err)

--- a/microceph/cmd/microcephd/simple_bootstrapper_test.go
+++ b/microceph/cmd/microcephd/simple_bootstrapper_test.go
@@ -157,7 +157,7 @@ func (s *simpleBootstrapSuite) TestSimpleBootstrap() {
 // TestSimpleBootstrapMarksLifecycle verifies that a successful non-deferred
 // (Simple) bootstrap marks the Ceph lifecycle as bootstrapped (CE142 blocker
 // fix: a fresh legacy cluster must not be left not_bootstrapped, otherwise
-// ApplyPlacement rejects it and bootstrap-ceph is not idempotent).
+// ValidatePlacement rejects it and bootstrap-ceph is not idempotent).
 func (s *simpleBootstrapSuite) TestSimpleBootstrapMarksLifecycle() {
 	r := mocks.NewRunner(s.T())
 	nw := mocks.NewNetworkIntf(s.T())

--- a/microceph/database/placement_policy.go
+++ b/microceph/database/placement_policy.go
@@ -1,7 +1,12 @@
 package database
 
-// placement_policy is a singleton table (CHECK(id=1)) that stores the last
-// accepted role-managed declarative placement policy as a JSON blob (CE142).
+// placement_policy is a singleton table (CHECK(id=1)) that stores the canonical
+// desired role-managed declarative placement policy as a JSON blob (CE142).
+//
+// The blob is a complete desired-state snapshot, not an accumulation of
+// requests: each accepted PUT /1.0/placement overwrites it wholesale, so the
+// row always reads as the full current intent rather than the most recent
+// partial edit.
 //
 // This table uses intentional hand-rolled SQL helpers (see
 // placement_policy_extras.go) rather than lxd-generate mapper codegen, because

--- a/microceph/database/placement_policy_extras.go
+++ b/microceph/database/placement_policy_extras.go
@@ -9,11 +9,13 @@ import (
 )
 
 // PlacementPolicyRecord is the single-row record tracking the active role-managed
-// declarative placement policy (CE142). PolicyJSON holds the last accepted
-// placement policy as a JSON blob; Active records whether a role-managed
-// placement policy is currently in effect. LastRefusal holds the most recent
-// placement refusal reason (e.g. keep-one invariant) so operators and charms
-// polling GET /1.0/placement can inspect why the last PUT was rejected.
+// declarative placement policy (CE142). PolicyJSON holds the canonical desired
+// placement policy as a JSON blob -- the complete snapshot installed by the
+// last accepted PUT, never a merge of successive requests; Active records
+// whether a role-managed placement policy is currently in effect. LastRefusal
+// holds the most recent placement refusal reason (e.g. keep-one invariant) so
+// operators and charms polling GET /1.0/placement can inspect why the last PUT
+// was rejected.
 type PlacementPolicyRecord struct {
 	Active      bool
 	PolicyJSON  string
@@ -34,8 +36,11 @@ SELECT active, coalesce(policy_json, ''), last_refusal FROM placement_policy WHE
 	return &PlacementPolicyRecord{Active: active != 0, PolicyJSON: policyJSON, LastRefusal: lastRefusal.String}, nil
 }
 
-// SetPlacementPolicy updates the single-row placement policy record (the row
-// is created by the schema migration; a missing row is an error).
+// SetPlacementPolicy replaces the policy stored in the single-row placement
+// policy record (the row is created by the schema migration; a missing row is
+// an error). policyJSON overwrites any previously stored policy in full; this
+// layer performs no merge, so the caller must pass the complete desired
+// snapshot.
 func SetPlacementPolicy(ctx context.Context, tx *sql.Tx, active bool, policyJSON string) error {
 	a := 0
 	if active {
@@ -56,9 +61,10 @@ UPDATE placement_policy SET active = ?, policy_json = ? WHERE id = 1`, a, policy
 	return nil
 }
 
-// ClearPlacementPolicy clears the active role-managed placement policy without
-// touching services. It sets Active to false and clears the stored policy JSON
-// and the last refusal reason.
+// ClearPlacementPolicy clears the canonical desired role-managed placement
+// policy without touching services. It sets Active to false and clears the
+// stored policy JSON and the last refusal reason, leaving no desired placement
+// state behind for a later PUT to inherit.
 func ClearPlacementPolicy(ctx context.Context, tx *sql.Tx) error {
 	result, err := tx.ExecContext(ctx, `UPDATE placement_policy SET active = 0, policy_json = NULL, last_refusal = NULL WHERE id = 1`)
 	if err != nil {

--- a/microceph/database/schema.go
+++ b/microceph/database/schema.go
@@ -268,8 +268,9 @@ UPDATE cluster_lifecycle
 }
 
 // schemaUpdate9 adds the placement_policy table (CE142). It is a single-row
-// table storing the last accepted role-managed declarative placement policy as
-// a JSON blob, plus:
+// table storing the canonical desired role-managed declarative placement policy
+// as a JSON blob -- each accepted PUT replaces it in full rather than amending
+// it -- plus:
 //   - active: whether a role-managed policy is active.
 //   - last_refusal: the most recent placement refusal reason (e.g. keep-one
 //     invariant) so operators and charms polling GET /1.0/placement can inspect

--- a/tests/robot/deferred-ceph-single-tests/deferred_ceph_single_tests.robot
+++ b/tests/robot/deferred-ceph-single-tests/deferred_ceph_single_tests.robot
@@ -3,7 +3,8 @@ Documentation    deferred-ceph-single-tests
 ...    Single-node deferred-Ceph coverage:
 ...      deferred bootstrap leaves MicroCluster up but Ceph not bootstrapped,
 ...      capability markers are advertised, lifecycle state is not_bootstrapped, and
-...      an empty-members placement policy is accepted as a no-op.
+...      an empty-members placement policy is accepted and stored as active,
+...      performing no service operations.
 ...    Legacy (non-deferred) bootstrap compatibility is covered by the existing
 ...    single-system-tests and cluster-tests suites running against the same snap.
 Resource        ../resources/microceph_harness.resource
@@ -61,7 +62,8 @@ Test Capability Markers Advertised
 Test Placement Policy Empty Members Is No Op
     [Documentation]    Precondition: PUT /1.0/placement with an empty members map performs
     ...    no service operations, is accepted, and is stored as the active policy. Ceph must
-    ...    remain unbootstrapped.
+    ...    remain unbootstrapped. Storing it is not inert: this is the CE142 waiting policy,
+    ...    an empty storage allow-list that denies new OSD enrollment on every member.
     [Tags]    api    placement
     ${resp}=    MicroCeph API Put    placement    {"mode":"reconcile","members":{}}    timeout=30
     ${code}=    Response Status Code    ${resp}


### PR DESCRIPTION
# Description

1. Split ApplyPlacement into validate / store / reconcile

Orchestration used to live in the HTTP handler, which decided when to persist and special-cased ErrKeepOneInvariant. It's now ceph.ApplyPlacementPolicy driving three phases: ValidatePlacement (preconditions only — cert, pre-bootstrap guard, unknown members), storePlacementPolicy, reconcilePlacement (diff, adds before removals, keep-one safety).

Ordering: validate before persist, so an unappliable policy doesn't replace stored state; persist before reconcile, so a policy that fails to converge stays observable via GET /1.0/placement with last_refusal. This generalises the old keep-one special case to any mid-reconcile failure. Refusal writes moved into ceph with a detached 30s context, so a deadline-exceeded apply can still record why. StorePlacementPolicyFunc and SetPlacementRefusalFunc are unexported — the API layer can't bypass the sequence. The handler is now decode → lock → apply → map to 400/500.

2. Document the policy as a full-replacement snapshot

PUT overwrites wholesale; it never merges. Doc comments across types, api, ceph, and database now say so consistently, including that the empty-members waiting policy is an empty allow-list (not inert) and that DELETE returns eligibility to unmanaged. 


## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

unit tests

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change