### PR TITLE
test: harden cephadm adoption fixture

### DIFF
--- a/tests/robot/unit-tests/unit_tests.robot
+++ b/tests/robot/unit-tests/unit_tests.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation    unit-tests
-...    Runs Go unit tests on the host runner. Go and libdqlite are installed by the
+...    Runs host-only Go, Python, and shell unit tests. Go and libdqlite are installed by the
 ...    CI YAML before Robot runs; no VM or snap needed.
 Resource        ../resources/microceph_harness.resource
 Suite Setup     Check Host Dependencies
@@ -19,6 +19,14 @@ Run Go Unit Tests
     Log    ${result.stdout}
     Log    STDERR: ${result.stderr}
     Should Be Equal As Integers    ${result.rc}    0    msg=make check-unit failed:\n${result.stderr}
+
+Run Adoptutils Shell Unit Tests
+    [Documentation]    Exercises cephadm bootstrap readiness and image selection with mocked host commands.
+    [Tags]    unit    fast    smoke    shell
+    ${result}=    Run Process    bash    ${REPO_ROOT}/tests/scripts/test_adoptutils.sh    timeout=60
+    Log    ${result.stdout}
+    Log    STDERR: ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0    msg=adoptutils shell tests failed:\n${result.stderr}
 
 Run Python Helper Unit Tests
     [Documentation]    Runs pytest over the pure Python harness helpers (parsers + _poll_until).

--- a/tests/scripts/adoptutils.sh
+++ b/tests/scripts/adoptutils.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# The bundled MicroCeph Ceph client is 20.2.1, which predates the
-# AES256KRB5 CephX key format emitted by Squid 19.2.6. Keep this fixture on
-# the compatible Squid point release until the bundled client is upgraded.
+# Ceph 19.2.6 defaults CephX to AES256KRB5 as part of CVE-2025-30156.
+# The bundled MicroCeph Ceph 20.2.1 client cannot read that key format, so
+# keep this fixture on the compatible Squid 19.2.5 image. Remove this pin
+# once MicroCeph bundles Ceph 20.2.4 or later; tracked in #826.
 readonly CEPHADM_TEST_IMAGE="quay.io/ceph/ceph:v19.2.5"
 
 function create_cephadm_vm() {
@@ -84,7 +85,7 @@ function dump_osd_diagnostics() {
   lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph osd tree" || true
   lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph orch ps --daemon_type osd --format json-pretty" || true
   lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph orch device ls --wide" || true
-  lxc exec "$name" -- sh -c "cephadm ls" || true
+  lxc exec "$name" -- sh -c "timeout 30s cephadm ls" || true
 
   echo "--- local service and container state ---"
   lxc exec "$name" -- sh -c "systemctl --no-pager --failed" || true

--- a/tests/scripts/adoptutils.sh
+++ b/tests/scripts/adoptutils.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# The bundled MicroCeph Ceph client is 20.2.1, which predates the
+# AES256KRB5 CephX key format emitted by Squid 19.2.6. Keep this fixture on
+# the compatible Squid point release until the bundled client is upgraded.
+readonly CEPHADM_TEST_IMAGE="quay.io/ceph/ceph:v19.2.5"
+
 function create_cephadm_vm() {
   set -eu
   input=$1
@@ -54,6 +59,72 @@ function exec_ls_on_vm() {
   lxc exec $name -- sh -c "ls"
 }
 
+function dump_osd_diagnostics() {
+  local name=$1
+
+  echo "=== Cephadm OSD diagnostics for ${name} ==="
+
+  echo "--- host block-device identity and mappings ---"
+  lxc exec "$name" -- sh -c "lsblk --all --paths --output NAME,KNAME,TYPE,SIZE,MODEL,SERIAL,WWN,FSTYPE,MOUNTPOINTS" || true
+  lxc exec "$name" -- sh -c "ls -l /dev/disk/by-id /dev/mapper 2>&1 || true" || true
+  lxc exec "$name" -- sh -c "command -v dmsetup >/dev/null && dmsetup ls --tree || true" || true
+  lxc exec "$name" -- sh -c "command -v multipath >/dev/null && multipath -ll || true" || true
+  lxc exec "$name" -- sh -c "systemctl is-active multipathd.service multipathd.socket || true" || true
+  lxc exec "$name" -- sh -c "command -v pvs >/dev/null && pvs --all -o pv_name,pv_uuid,vg_name,vg_uuid,devices || true" || true
+  lxc exec "$name" -- sh -c "command -v vgs >/dev/null && vgs --all -o vg_name,vg_uuid,vg_attr,vg_size,vg_free,pv_count || true" || true
+  lxc exec "$name" -- sh -c "command -v lvs >/dev/null && lvs --all -o vg_name,lv_name,lv_attr,lv_size,lv_path,devices || true" || true
+  # Do not use ceph-volume inventory here. In this fixture it can report an
+  # escaped /dev/mapper alias as missing after an OSD is active; the direct
+  # LVM reports above distinguish that false diagnostic from a real failure.
+
+  echo "--- Ceph cluster and orchestrator state ---"
+  lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph -s" || true
+  lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph health detail" || true
+  lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph osd stat --format json-pretty" || true
+  lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph osd tree" || true
+  lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph orch ps --daemon_type osd --format json-pretty" || true
+  lxc exec "$name" -- sh -c "timeout 30s cephadm shell -- ceph orch device ls --wide" || true
+  lxc exec "$name" -- sh -c "cephadm ls" || true
+
+  echo "--- local service and container state ---"
+  lxc exec "$name" -- sh -c "systemctl --no-pager --failed" || true
+  lxc exec "$name" -- sh -c "if command -v podman >/dev/null; then podman ps --all --no-trunc; elif command -v docker >/dev/null; then docker ps --all --no-trunc; else echo 'No container engine found'; fi" || true
+
+  echo "--- OSD and kernel journal ---"
+  lxc exec "$name" -- sh -c "journalctl --no-pager -b -u 'ceph-*@osd.*' -n 500" || true
+  lxc exec "$name" -- sh -c "journalctl --no-pager -k -b -n 200" || true
+
+  echo "=== End Cephadm OSD diagnostics for ${name} ==="
+}
+
+function wait_for_up_osds() {
+  local name=$1
+  local expected_osds=${2:-3}
+  local attempts=${3:-30}
+  local up_osds
+
+  for i in $(seq 1 "$attempts"); do
+    up_osds=$(lxc exec "$name" -- sh -c "cephadm shell -- ceph osd stat --format json 2>/dev/null" | jq -r '.num_up_osds // 0' 2>/dev/null || printf '0')
+    if [[ ! "$up_osds" =~ ^[0-9]+$ ]]; then
+      up_osds=0
+    fi
+
+    if [[ "$up_osds" -ge "$expected_osds" ]]; then
+      echo "All ${expected_osds} OSDs are up on ${name}"
+      return 0
+    fi
+
+    if [[ "$i" -lt "$attempts" ]]; then
+      echo "Waiting for ${expected_osds} OSDs on ${name}; found ${up_osds} (attempt ${i}/${attempts})"
+      sleep 10s
+    fi
+  done
+
+  echo "Expected ${expected_osds} up OSDs on ${name}, found ${up_osds}; failing bootstrap"
+  dump_osd_diagnostics "$name"
+  return 1
+}
+
 function bootstrap_cephadm() {
   set -eux
   name=$1
@@ -65,8 +136,17 @@ function bootstrap_cephadm() {
 
   ip=$(echo "$ip_info" | jq -r '.[] | select(.dst | contains("default")) | .prefsrc' | tr -d '[:space:]')
 
-  lxc exec $name -- sh -c "cephadm bootstrap --mon-ip $ip --single-host-defaults --skip-dashboard --skip-monitoring-stack"
-  lxc exec $name -- sh -c "cephadm shell -- ceph orch apply osd --all-available-devices"
+  if ! lxc exec "$name" -- sh -c "cephadm --image ${CEPHADM_TEST_IMAGE} bootstrap --mon-ip ${ip} --single-host-defaults --skip-dashboard --skip-monitoring-stack"; then
+    echo "cephadm bootstrap failed on ${name}; collecting diagnostics"
+    dump_osd_diagnostics "$name"
+    return 1
+  fi
+
+  if ! lxc exec "$name" -- sh -c "cephadm shell -- ceph orch apply osd --all-available-devices"; then
+    echo "OSD provisioning request failed on ${name}; collecting diagnostics"
+    dump_osd_diagnostics "$name"
+    return 1
+  fi
 
   # Wait for the cluster to settle before adopt can connect
   echo "Waiting for ceph cluster to become healthy..."
@@ -85,19 +165,17 @@ function bootstrap_cephadm() {
     echo "Waiting for cluster health... attempt $i/30"
     sleep 10s
   done
-  lxc exec $name -- sh -c "cephadm shell -- ceph -s"
+  lxc exec "$name" -- sh -c "cephadm shell -- ceph -s" || true
   if [[ $healthy -ne 1 ]]; then
-    echo "Cluster on $name did not reach HEALTH_OK; failing bootstrap"
+    echo "Cluster on $name did not reach HEALTH_OK; collecting diagnostics"
+    dump_osd_diagnostics "$name"
     return 1
   fi
 
-  # HEALTH_OK with zero OSDs is impossible, but be explicit: every later
-  # stage (fs volume create, MDS activation, mirroring) silently wedges if
-  # the OSDs were never created, so verify all 3 are up before moving on.
-  up_osds=$(lxc exec $name -- sh -c "cephadm shell -- ceph osd stat --format json 2>/dev/null" | jq -r '.num_up_osds // 0')
-  if [[ "${up_osds}" -lt 3 ]]; then
-    echo "Expected 3 up OSDs on $name, found ${up_osds}; failing bootstrap"
-    lxc exec $name -- sh -c "cephadm shell -- ceph-volume inventory" || true
+  # HEALTH_OK does not require OSDs when the cluster has no pools. OSD
+  # provisioning is asynchronous, so wait for all attached block volumes to
+  # become usable before later CephFS and replication stages depend on them.
+  if ! wait_for_up_osds "$name" 3; then
     return 1
   fi
 }
@@ -117,8 +195,10 @@ function adopt_cephadm() {
   ip_info=$(lxc exec $name -- sh -c "ip -4 -j route")
   mon_ip=$(echo "$ip_info" | jq -r '.[] | select(.dst | contains("default")) | .prefsrc' | tr -d '[:space:]')
 
-  # Admin Key
-  key=$(lxc exec $name -- sh -c "cat /etc/ceph/ceph.client.admin.keyring" | grep key | cut -d " " -f 3)
+  # Keep the admin key out of xtrace and host command arguments.
+  set +x
+  key=$(lxc exec "$name" -- sh -c "cat /etc/ceph/ceph.client.admin.keyring" | grep key | cut -d " " -f 3)
+  set -x
 
   lxc --quiet file push $snap_glob $name/root/
 
@@ -129,7 +209,10 @@ function adopt_cephadm() {
   done
 
   # Adopt cephadm cluster using microceph --public-network=10.230.118.167/24 --cluster-network=10.230.118.167/247/24
-  lxc exec $name -- bash -c "echo $key | sudo microceph cluster adopt --fsid=$fsid --mon-hosts=$mon_ip -"
+  set +x
+  printf '%s\n' "$key" | lxc exec "$name" -- bash -c "sudo microceph cluster adopt --fsid=${fsid} --mon-hosts=${mon_ip} -"
+  unset key
+  set -x
 }
 
 function exchange_adopt_remote_tokens() {

--- a/tests/scripts/test_adoptutils.sh
+++ b/tests/scripts/test_adoptutils.sh
@@ -167,7 +167,7 @@ test_osd_timeout_dumps_diagnostics() (
     'ceph osd tree' \
     'ceph orch ps --daemon_type osd --format json-pretty' \
     'ceph orch device ls --wide' \
-    'cephadm ls' \
+    'timeout 30s cephadm ls' \
     'lsblk --all --paths --output' \
     'dmsetup ls --tree' \
     'multipath -ll' \

--- a/tests/scripts/test_adoptutils.sh
+++ b/tests/scripts/test_adoptutils.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Unit tests for the host-side cephadm adoption helpers.
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly repo_root
+adoptutils="$repo_root/tests/scripts/adoptutils.sh"
+readonly adoptutils
+
+test_dir=""
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$test_dir" ]]; then
+    rm -rf "$test_dir"
+  fi
+}
+
+setup_test_environment() {
+  local osd_sequence=$1
+  local health=${2:-HEALTH_OK}
+  local fail_match=${3:-}
+
+  test_dir=$(mktemp -d)
+
+  mkdir -p "$test_dir/bin"
+  export ADOPTUTILS_TEST_LXC_LOG="$test_dir/lxc.log"
+  export ADOPTUTILS_TEST_OSD_INDEX="$test_dir/osd-index"
+  export ADOPTUTILS_TEST_OSD_SEQUENCE="$osd_sequence"
+  export ADOPTUTILS_TEST_SLEEP_LOG="$test_dir/sleep.log"
+  export ADOPTUTILS_TEST_HEALTH="$health"
+  export ADOPTUTILS_TEST_FAIL_MATCH="$fail_match"
+  export ADOPTUTILS_TEST_CEPHX_KEY='test-admin-key-do-not-log'
+  printf '0\n' > "$ADOPTUTILS_TEST_OSD_INDEX"
+
+  cat > "$test_dir/bin/lxc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$ADOPTUTILS_TEST_LXC_LOG"
+
+if [[ -n "${ADOPTUTILS_TEST_FAIL_MATCH:-}" && "$*" == *"${ADOPTUTILS_TEST_FAIL_MATCH}"* ]]; then
+  printf 'simulated lxc failure: %s\n' "$ADOPTUTILS_TEST_FAIL_MATCH" >&2
+  exit 1
+fi
+
+case "$*" in
+  *"ceph.client.admin.keyring"*)
+    printf 'key = %s\n' "$ADOPTUTILS_TEST_CEPHX_KEY"
+    ;;
+  *"ip -4 -j route"*)
+    printf '%s\n' 'routes'
+    ;;
+  *"ceph health"*)
+    printf '%s\n' "$ADOPTUTILS_TEST_HEALTH"
+    ;;
+  *"ceph osd stat --format json"*)
+    IFS=, read -r -a osd_counts <<< "$ADOPTUTILS_TEST_OSD_SEQUENCE"
+    index=$(< "$ADOPTUTILS_TEST_OSD_INDEX")
+    last_index=$((${#osd_counts[@]} - 1))
+    if [[ "$index" -gt "$last_index" ]]; then
+      index=$last_index
+    fi
+    printf '%s\n' "$((index + 1))" > "$ADOPTUTILS_TEST_OSD_INDEX"
+    printf '{"num_up_osds": %s}\n' "${osd_counts[$index]}"
+    ;;
+esac
+EOF
+
+  cat > "$test_dir/bin/jq" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *'.[] | select(.dst | contains("default")) | .prefsrc'* ]]; then
+  printf '%s\n' '10.0.0.1'
+  exit 0
+fi
+
+if [[ "$*" == *'.num_up_osds // 0'* ]]; then
+  input=$(< /dev/stdin)
+  if [[ "$input" =~ \"num_up_osds\"[[:space:]]*:[[:space:]]*([0-9]+) ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  else
+    printf '%s\n' '0'
+  fi
+  exit 0
+fi
+
+cat
+EOF
+
+  cat > "$test_dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$ADOPTUTILS_TEST_SLEEP_LOG"
+EOF
+
+  chmod +x "$test_dir/bin/lxc" "$test_dir/bin/jq" "$test_dir/bin/sleep"
+}
+
+run_bootstrap() {
+  local output
+
+  if ! output=$(PATH="$test_dir/bin:$PATH" bash "$adoptutils" bootstrap_cephadm test 2>&1); then
+    printf '%s\n' "$output" >&2
+    fail 'bootstrap_cephadm returned a failure'
+  fi
+}
+
+run_bootstrap_expect_failure() {
+  local output
+
+  if output=$(PATH="$test_dir/bin:$PATH" bash "$adoptutils" bootstrap_cephadm test 2>&1); then
+    fail 'bootstrap_cephadm unexpectedly succeeded'
+  fi
+  printf '%s\n' "$output"
+}
+
+assert_osd_diagnostics() {
+  local output=$1
+  local reason=$2
+
+  if [[ "$output" != *"$reason"* ]]; then
+    fail "bootstrap failure did not report: $reason"
+  fi
+
+  if [[ "$output" != *'=== Cephadm OSD diagnostics for test ==='* ]]; then
+    fail 'bootstrap failure did not collect OSD diagnostics'
+  fi
+}
+
+test_bootstrap_waits_for_all_osds() (
+  trap cleanup EXIT
+  setup_test_environment '0,3'
+  run_bootstrap
+
+  stat_calls=$(grep -c -- 'ceph osd stat --format json' "$ADOPTUTILS_TEST_LXC_LOG" || true)
+  if [[ "$stat_calls" -ne 2 ]]; then
+    fail "expected two OSD status checks, got $stat_calls"
+  fi
+
+  sleep_calls=$(wc -l < "$ADOPTUTILS_TEST_SLEEP_LOG")
+  if [[ "$sleep_calls" -ne 1 ]]; then
+    fail "expected one OSD readiness wait, got $sleep_calls"
+  fi
+)
+
+test_osd_timeout_dumps_diagnostics() (
+  trap cleanup EXIT
+  setup_test_environment '0'
+
+  if output=$(PATH="$test_dir/bin:$PATH" bash "$adoptutils" wait_for_up_osds test 3 1 2>&1); then
+    fail 'wait_for_up_osds unexpectedly succeeded without OSDs'
+  fi
+
+  if [[ "$output" != *'=== Cephadm OSD diagnostics for test ==='* ]]; then
+    fail 'OSD timeout did not label its diagnostic dump'
+  fi
+
+  for expected in \
+    'ceph health detail' \
+    'ceph osd tree' \
+    'ceph orch ps --daemon_type osd --format json-pretty' \
+    'ceph orch device ls --wide' \
+    'cephadm ls' \
+    'lsblk --all --paths --output' \
+    'dmsetup ls --tree' \
+    'multipath -ll' \
+    'systemctl is-active multipathd.service multipathd.socket' \
+    'systemctl --no-pager --failed' \
+    'podman ps --all --no-trunc' \
+    'docker ps --all --no-trunc' \
+    "journalctl --no-pager -b -u 'ceph-*@osd.*' -n 500"; do
+    if ! grep -Fq -- "$expected" "$ADOPTUTILS_TEST_LXC_LOG"; then
+      fail "OSD timeout omitted diagnostic command: $expected"
+    fi
+  done
+
+  if grep -Fq -- 'ceph-volume inventory' "$ADOPTUTILS_TEST_LXC_LOG"; then
+    fail 'OSD diagnostics used ceph-volume inventory instead of direct LVM state'
+  fi
+)
+
+test_bootstrap_failure_dumps_diagnostics() (
+  trap cleanup EXIT
+  setup_test_environment '3' 'HEALTH_OK' 'cephadm --image'
+  output=$(run_bootstrap_expect_failure)
+  assert_osd_diagnostics "$output" 'cephadm bootstrap failed on test; collecting diagnostics'
+)
+
+test_osd_provisioning_failure_dumps_diagnostics() (
+  trap cleanup EXIT
+  setup_test_environment '3' 'HEALTH_OK' 'ceph orch apply osd'
+  output=$(run_bootstrap_expect_failure)
+  assert_osd_diagnostics "$output" 'OSD provisioning request failed on test; collecting diagnostics'
+)
+
+test_health_timeout_dumps_diagnostics() (
+  trap cleanup EXIT
+  setup_test_environment '3' 'HEALTH_WARN'
+  output=$(run_bootstrap_expect_failure)
+  assert_osd_diagnostics "$output" 'Cluster on test did not reach HEALTH_OK; collecting diagnostics'
+)
+
+test_adoption_does_not_log_admin_key() (
+  trap cleanup EXIT
+  setup_test_environment '3'
+
+  if ! output=$(PATH="$test_dir/bin:$PATH" bash "$adoptutils" adopt_cephadm test /tmp/microceph.snap 2>&1); then
+    fail 'adopt_cephadm returned a failure'
+  fi
+
+  if [[ "$output" == *"$ADOPTUTILS_TEST_CEPHX_KEY"* ]]; then
+    fail 'adoption xtrace exposed the admin key'
+  fi
+
+  if grep -Fq -- "$ADOPTUTILS_TEST_CEPHX_KEY" "$ADOPTUTILS_TEST_LXC_LOG"; then
+    fail 'adoption passed the admin key as an lxc command argument'
+  fi
+)
+
+test_adoption_traces_non_secret_steps() (
+  trap cleanup EXIT
+  setup_test_environment '3'
+
+  if ! output=$(PATH="$test_dir/bin:$PATH" bash "$adoptutils" adopt_cephadm test /tmp/microceph.snap 2>&1); then
+    fail 'adopt_cephadm returned a failure'
+  fi
+
+  if [[ "$output" != *'snap connect microceph:block-devices'* ]]; then
+    fail 'adoption stopped tracing non-secret setup steps'
+  fi
+)
+
+test_bootstrap_pins_compatible_ceph_image() (
+  trap cleanup EXIT
+  setup_test_environment '3'
+  run_bootstrap
+
+  if ! grep -Fq -- 'cephadm --image quay.io/ceph/ceph:v19.2.5 bootstrap' "$ADOPTUTILS_TEST_LXC_LOG"; then
+    fail 'bootstrap did not select the compatible Ceph image'
+  fi
+)
+
+case "${1:-all}" in
+  all)
+    test_bootstrap_waits_for_all_osds
+    test_osd_timeout_dumps_diagnostics
+    test_bootstrap_failure_dumps_diagnostics
+    test_osd_provisioning_failure_dumps_diagnostics
+    test_health_timeout_dumps_diagnostics
+    test_adoption_does_not_log_admin_key
+    test_adoption_traces_non_secret_steps
+    test_bootstrap_pins_compatible_ceph_image
+    ;;
+  waits-for-osds)
+    test_bootstrap_waits_for_all_osds
+    ;;
+  dumps-osd-diagnostics)
+    test_osd_timeout_dumps_diagnostics
+    ;;
+  bootstrap-failure-diagnostics)
+    test_bootstrap_failure_dumps_diagnostics
+    ;;
+  osd-provisioning-failure-diagnostics)
+    test_osd_provisioning_failure_dumps_diagnostics
+    ;;
+  health-timeout-diagnostics)
+    test_health_timeout_dumps_diagnostics
+    ;;
+  hides-admin-key)
+    test_adoption_does_not_log_admin_key
+    ;;
+  traces-non-secret-steps)
+    test_adoption_traces_non_secret_steps
+    ;;
+  pins-ceph-image)
+    test_bootstrap_pins_compatible_ceph_image
+    ;;
+  *)
+    fail "unknown test: $1"
+    ;;
+esac
+
+printf '%s\n' 'PASS: adoptutils shell tests'


### PR DESCRIPTION
# Description

Harden the cephadm adoption CI fixture against two independent failures:

- Pin the cephadm bootstrap image to Squid 19.2.5 until the bundled MicroCeph 20.2.1 client supports the AES256KRB5 CephX key format emitted by 19.2.6.
- Wait for all three OSDs after `HEALTH_OK`, rather than treating a single instantaneous count as readiness.
- Collect bounded, failure-only diagnostics for block identity, LVM/device-mapper, multipath, orchestration, container, OSD-journal, and kernel state.
- Avoid `ceph-volume inventory` in that dump because it reports a missing escaped mapper alias even on a healthy active OSD.
- Pass the adoption admin key on standard input with xtrace disabled around key handling.

No related issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Added mocked shell regressions for OSD readiness, all diagnostic failure paths, the image pin, and admin-key log protection.
- `tox -e robot -- --test-suite unit-tests`
- `tox -e robot -- --test-suite static-checks`
- `tox -e robot -- --test-suite cephadm-adopt-test --snap-path /tmp/microceph-ci-snap/microceph_20.2.1+test_amd64.snap` (10 tests passed)
- Forced an OSD-readiness timeout against a healthy three-OSD cluster to verify the complete diagnostic dump and absence of CephX-like values.

## Contributor checklist

- [ ] self-reviewed the code in this PR
- [ ] added code comments, particularly in less straightforward areas
- [ ] checked and added or updated relevant documentation
- [ ] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change