### PR TITLE
fix: build against an existing tentacle PPA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ confinement: strict
 
 package-repositories:
   - type: apt
-    ppa: lmlogiudice/ceph-tentacle-rc
+    ppa: johnramsden/noble-caracal-ceph-tentacle
 
 plugs:
   load-rbd:


### PR DESCRIPTION
The lmlogiudice/ceph-tentacle-rc PPA no longer exists on Launchpad, so every snap build fails at apt source setup. Switch to a PPA publishing ceph 20.2.1 for noble.

https://github.com/canonical/microceph/actions/runs/33696938187/job/100467737368?pr=821

