### PR TITLE
fix: Deferred placement mon removal flake

### DIFF
--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -221,7 +221,9 @@ var (
 // invokes them through those injectable vars so teardown ordering and failure
 // boundaries stay unit-testable.
 
-// DeleteService deletes a service from the node.
+// DeleteService deletes a service from the node. For mon, mgr and mds it first
+// renders ceph.conf from the shared database, so the teardown's ceph commands
+// can reach a current monitor.
 func DeleteService(ctx context.Context, s interfaces.StateInterface, service string) error {
 	// Serialize teardown with bootstrap, join, service enablement, and startup
 	// re-enablement. In particular, reEnableServices must not observe the service
@@ -231,6 +233,23 @@ func DeleteService(ctx context.Context, s interfaces.StateInterface, service str
 	defer serviceStartMu.Unlock()
 
 	hostname := s.ClusterState().Name()
+
+	// Render ceph.conf from the shared database before touching Ceph. The
+	// ensure*Absent phases below run `ceph` commands on this node, and this
+	// node's `mon host` line is otherwise refreshed only by the once-a-minute
+	// loop in Start. A MON added elsewhere within that minute is missing from
+	// it, so once this node's own MON leaves the monmap the local client has no
+	// reachable monitor and hangs until its deadline. Reconciliation adds
+	// services before removing any, so the database already holds every current
+	// MON address at this point. Other services are torn down without ceph
+	// commands, so they skip the render and its public network requirement.
+	switch service {
+	case "mon", "mgr", "mds":
+		err := updateConfigFunc(ctx, s)
+		if err != nil {
+			return fmt.Errorf("failed to render ceph config before %s removal: %w", service, err)
+		}
+	}
 
 	if service == "mon" {
 		// Commit membership removal while the source MON is still running. With

--- a/microceph/ceph/services_test.go
+++ b/microceph/ceph/services_test.go
@@ -108,9 +108,11 @@ func (s *servicesSuite) TestCleanService() {
 	assert.NoDirExists(s.T(), svcPath)
 }
 
-// installDeleteServiceRecorder replaces the external deletion phases and
-// records their exact order. The originals are restored after each test.
+// installDeleteServiceRecorder replaces the config render and the external
+// deletion phases and records their exact order. The originals are restored
+// after each test.
 func installDeleteServiceRecorder(t *testing.T, stopErr error) *[]string {
+	origUpdateConfig := updateConfigFunc
 	origEnsureMonAbsent := ensureMonAbsentFunc
 	origEnsureMgrAbsent := ensureMgrAbsentFunc
 	origEnsureMdsAbsent := ensureMdsAbsentFunc
@@ -118,6 +120,7 @@ func installDeleteServiceRecorder(t *testing.T, stopErr error) *[]string {
 	origCleanService := cleanServiceFunc
 	origRemoveServiceDatabase := removeServiceDatabaseFunc
 	t.Cleanup(func() {
+		updateConfigFunc = origUpdateConfig
 		ensureMonAbsentFunc = origEnsureMonAbsent
 		ensureMgrAbsentFunc = origEnsureMgrAbsent
 		ensureMdsAbsentFunc = origEnsureMdsAbsent
@@ -127,6 +130,10 @@ func installDeleteServiceRecorder(t *testing.T, stopErr error) *[]string {
 	})
 
 	events := []string{}
+	updateConfigFunc = func(_ context.Context, _ interfaces.StateInterface) error {
+		events = append(events, "config")
+		return nil
+	}
 	ensureMonAbsentFunc = func(_ context.Context, hostname string) error {
 		events = append(events, "monmap:"+hostname)
 		return nil
@@ -160,6 +167,7 @@ func (s *servicesSuite) TestDeleteMonRemovesMembershipBeforeStoppingDaemon() {
 	err := DeleteService(context.Background(), s.TestStateInterface, "mon")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), []string{
+		"config",
 		"monmap:foohost",
 		"stop:mon:true",
 		"clean:mon:foohost",
@@ -177,7 +185,7 @@ func (s *servicesSuite) TestDeleteMonMembershipFailureLeavesDaemonRunning() {
 
 	err := DeleteService(context.Background(), s.TestStateInterface, "mon")
 	assert.ErrorIs(s.T(), err, membershipErr)
-	assert.Equal(s.T(), []string{"monmap:foohost"}, *events)
+	assert.Equal(s.T(), []string{"config", "monmap:foohost"}, *events)
 }
 
 func (s *servicesSuite) TestDeleteMonResumesAfterStopFailure() {
@@ -201,8 +209,10 @@ func (s *servicesSuite) TestDeleteMonResumesAfterStopFailure() {
 	err = DeleteService(context.Background(), s.TestStateInterface, "mon")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), []string{
+		"config",
 		"monmap:foohost",
 		"stop:mon:true",
+		"config",
 		"monmap:foohost",
 		"stop:mon:true",
 		"clean:mon:foohost",
@@ -216,6 +226,7 @@ func (s *servicesSuite) TestDeleteMgrEvictsMapAfterStoppingDaemon() {
 	err := DeleteService(context.Background(), s.TestStateInterface, "mgr")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), []string{
+		"config",
 		"stop:mgr:true",
 		"mgrmap:foohost",
 		"clean:mgr:foohost",
@@ -229,6 +240,7 @@ func (s *servicesSuite) TestDeleteMdsEvictsMapAfterStoppingDaemon() {
 	err := DeleteService(context.Background(), s.TestStateInterface, "mds")
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), []string{
+		"config",
 		"stop:mds:true",
 		"mdsmap:foohost",
 		"clean:mds:foohost",
@@ -249,7 +261,41 @@ func (s *servicesSuite) TestDeleteMgrMapFailureLeavesCleanupPending() {
 	// The daemon is stopped and eviction attempted, but on-disk and DB cleanup
 	// must not run so a retry resumes teardown.
 	assert.Equal(s.T(), []string{
+		"config",
 		"stop:mgr:true",
 		"mgrmap:foohost",
+	}, *events)
+}
+
+func (s *servicesSuite) TestDeleteConfigRenderFailureAbortsBeforeTouchingCeph() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+	renderErr := errors.New("failed to locate IP on public network")
+	updateConfigFunc = func(_ context.Context, _ interfaces.StateInterface) error {
+		*events = append(*events, "config")
+		return renderErr
+	}
+
+	for _, service := range []string{"mon", "mgr", "mds"} {
+		*events = nil
+		err := DeleteService(context.Background(), s.TestStateInterface, service)
+		assert.ErrorIs(s.T(), err, renderErr)
+		// With a stale ceph.conf the ensure*Absent phases would hang on an
+		// unreachable monitor, so nothing may run before a successful render.
+		assert.Equal(s.T(), []string{"config"}, *events)
+	}
+}
+
+func (s *servicesSuite) TestDeleteClientServiceSkipsConfigRender() {
+	events := installDeleteServiceRecorder(s.T(), nil)
+
+	// Services without a Ceph map eviction never run ceph commands during
+	// teardown. They must not gain the render's public network requirement,
+	// which would block `cluster remove` on a node that lost its Ceph NIC.
+	err := DeleteService(context.Background(), s.TestStateInterface, "rbd-mirror")
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), []string{
+		"stop:rbd-mirror:true",
+		"clean:rbd-mirror:foohost",
+		"db:rbd-mirror",
 	}, *events)
 }

--- a/tests/robot/deferred-ceph-multinode-tests/deferred_ceph_multinode_tests.robot
+++ b/tests/robot/deferred-ceph-multinode-tests/deferred_ceph_multinode_tests.robot
@@ -32,6 +32,34 @@ Ceph Only Bootstrap Target And Verify
     Run In Container    node-wrk0    microceph.ceph -s    30
     Assert Member Has Control Services    ${target}    yes
 
+Get Public Network IP
+    [Documentation]    The container's address on the LXD public network, which is the
+    ...    address ceph.conf's mon host carries. `hostname -I` lists the management
+    ...    address first, so the public one is selected by subnet.
+    [Arguments]    ${container}
+    ${cidr}=    Get Public Network CIDR
+    ${res}=    Run In Container    ${container}    hostname -I    30
+    ${ip}=    Evaluate    next((a for a in """${res.stdout}""".split() if ipaddress.ip_address(a) in ipaddress.ip_network("""${cidr}""", strict=False)), "")    modules=ipaddress
+    Should Not Be Empty    ${ip}    msg=No address of ${container} on public network ${cidr}: ${res.stdout}
+    RETURN    ${ip}
+
+Pin Mon Host To Self
+    [Documentation]    Overwrite the container's ceph.conf `mon host` line with only its own
+    ...    address, reproducing a render from before a peer MON was added. The daemon's
+    ...    refresh loop only re-renders when the MON list changes, so once it has rendered
+    ...    the current list the pin holds until service teardown renders the file itself.
+    [Arguments]    ${container}
+    ${ip}=    Get Public Network IP    ${container}
+    Run In Container    ${container}    sed -i 's/^mon host = .*/mon host = ${ip}/' /var/snap/microceph/current/conf/ceph.conf    30
+    ${pinned}=    Get Ceph Conf Value    ${container}    mon host
+    Should Be Equal As Strings    ${pinned}    ${ip}    msg=Failed to pin mon host on ${container}: ${pinned}
+
+Assert Mon Host Includes
+    [Documentation]    The container's rendered ceph.conf `mon host` line names the given address.
+    [Arguments]    ${container}    ${peer_ip}
+    ${hosts}=    Get Ceph Conf Value    ${container}    mon host
+    Should Contain    ${hosts}    ${peer_ip}    msg=mon host on ${container} does not list ${peer_ip}: ${hosts}
+
 *** Test Cases ***
 Test Deferred Join Forms MicroCluster Without Ceph
     [Documentation]    `microceph cluster join --defer-ceph` joins MicroCluster but does
@@ -72,11 +100,26 @@ Test Declarative Control Placement Migration Preserves Quorum
     [Documentation]    Moving the only desired control placement from the bootstrap member
     ...    to its replacement must commit MON membership removal before stopping the source.
     ...    The destination remains a one-MON quorum and repeating the policy is idempotent.
+    ...    Once the source's refresh loop has rendered the destination MON, the source's
+    ...    ceph.conf is pinned to list only its own MON, as a render from before the add
+    ...    would. Nothing rewrites that pin before teardown, so the removal verify on the
+    ...    source only succeeds if service teardown re-renders mon host before `ceph mon rm`;
+    ...    otherwise it hangs on the exited local MON until its deadline kills it.
     [Tags]    placement    migration
     ${policy}=    Set Variable    {"mode":"reconcile","members":{"node-wrk0":{"control":true},"node-wrk1":{"control":false}}}
+    ${dst_ip}=    Get Public Network IP    node-wrk0
+    # The refresh loop renders the destination MON into the source's conf within a
+    # minute of the add and then stays idle until the MON list changes again.
+    Wait Until Keyword Succeeds    90s    5s    Assert Mon Host Includes    node-wrk1    ${dst_ip}
+    Pin Mon Host To Self    node-wrk1
+    ${start}=    Get Time    epoch
     ${resp}=    MicroCeph API Put In Container    node-wrk0    placement    ${policy}
     ${code}=    Response Status Code    ${resp}
     Should Be Equal As Integers    ${code}    200    msg=Control migration failed: ${resp}
+    ${end}=    Get Time    epoch
+    ${elapsed}=    Evaluate    ${end} - ${start}
+    Should Be True    ${elapsed} < 25    msg=Migration took ${elapsed}s: the MON removal verify ran against a stale mon host and timed out
+    Assert Mon Host Includes    node-wrk1    ${dst_ip}
     ${mons}=    Get Mon Count
     Should Be Equal As Integers    ${mons}    1    msg=Expected destination-only monmap after migration
     Assert Mon Quorum Members    node-wrk0


### PR DESCRIPTION
# Description

The source's ceph.conf is rewritten to list only its own MON, as the once-a-minute refresh leaves it after a recent MON add. The migration must then finish quickly and re-render mon host, which fails on every run until service teardown renders ceph.conf itself.

Fixes #828 

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Regression & unit test

## Contributor checklist

Please check that you have:

- [x] self-reviewed the code in this PR
- [x] added code comments, particularly in less straightforward areas
- [x] checked and added or updated relevant documentation
- [x] added or updated HTML meta descriptions for any new or modified documentation pages (see [#643](https://github.com/canonical/microceph/pull/643))
- [x] verified that page title and headings accurately represent page content for new or modified documentation pages
- [x] checked and added or updated relevant release notes
- [x] added tests to verify effectiveness of this change